### PR TITLE
Implemented interface filter for components

### DIFF
--- a/src/worker/brsTypes/BrsInterface.ts
+++ b/src/worker/brsTypes/BrsInterface.ts
@@ -11,7 +11,13 @@ export class BrsInterface implements BrsValue {
     readonly methodNames: Set<string>;
 
     constructor(readonly name: string, methods: Callable[]) {
-        this.methodNames = new Set(methods.filter((m) => m.name).map((m) => m.name!));
+        this.methodNames = new Set(
+            methods.filter((m) => m.name?.toLowerCase()).map((m) => m.name?.toLowerCase()!)
+        );
+    }
+
+    hasMethod(method: string): boolean {
+        return this.methodNames.has(method.toLowerCase());
     }
 
     toString(): string {

--- a/src/worker/brsTypes/components/BrsComponent.ts
+++ b/src/worker/brsTypes/components/BrsComponent.ts
@@ -6,6 +6,7 @@ import { BrsInterface } from "../BrsInterface";
 export class BrsComponent {
     private methods: Map<string, Callable> = new Map();
     private readonly componentName: string;
+    private filter: string = "";
 
     readonly interfaces = new Map<string, BrsInterface>();
 
@@ -21,6 +22,14 @@ export class BrsComponent {
         return this.componentName;
     }
 
+    hasInterface(interfaceName: string) {
+        return this.interfaces.has(interfaceName.toLowerCase());
+    }
+
+    setFilter(interfaceName: string) {
+        this.filter = interfaceName.toLowerCase();
+    }
+
     protected registerMethods(interfaces: Record<string, Callable[]>) {
         this.methods = new Map<string, Callable>();
         Object.entries(interfaces).forEach(([interfaceName, methods]) => {
@@ -34,7 +43,13 @@ export class BrsComponent {
     }
 
     getMethod(index: string): Callable | undefined {
-        return this.methods.get(index.toLowerCase());
+        const method = index.toLowerCase();
+        if (this.filter !== "") {
+            const iface = this.interfaces.get(this.filter);
+            this.filter = "";
+            return iface?.hasMethod(method) ? this.methods.get(method) : undefined;
+        }
+        return this.methods.get(method);
     }
 }
 

--- a/test/emulator/dot-interface.brs
+++ b/test/emulator/dot-interface.brs
@@ -1,10 +1,24 @@
 sub main()
-    text = "abcd1234"
+    ' a = {}
+    ' a.AddReplace("ifEnum", "text")
+    ' print a.ifEnum.isEmpty()
+    ' print a.ifEnum
+    text = CreateObject("roString")
+    text.SetString("abcd1234")
     print text.len(), text.mid(4,4)
     print text.ifStringOps.len(), text.ifStringOps.mid(4,4)
+    text.ifString.setString("mlc7070")
+    print text.getString()
+    ar = [3, 4, 5]
+    print type(ar)
+    print ar
+    print ar.getEntry(2)
+    print ar.ifArrayGet.getEntry(1)
+    ar.reverse()
+    print ar
     strText = GetInterface(text, "ifStringOps")
     print type(strText)
-    print strText.len()
+    print strText
     objBool = GetInterface(true, "ifBoolean")
     print type(objBool)
     print objBool


### PR DESCRIPTION
Changes on this PR (finishing implementation of #164):
- When using explicit interface, only methods from that interface are accessible.
- If trying to access interface directly (no method) a Syntax Error is raised