### PR TITLE
Control queue modes: Single Key Events and Multi Key Events

### DIFF
--- a/src/worker/brsTypes/components/RoMessagePort.ts
+++ b/src/worker/brsTypes/components/RoMessagePort.ts
@@ -1,6 +1,6 @@
 import { BrsValue, ValueKind, BrsInvalid, BrsBoolean } from "../BrsType";
 import { BrsComponent } from "./BrsComponent";
-import { RoUniversalControlEvent } from "./RoUniversalControlEvent";
+import { RoUniversalControlEvent, KeyEvent } from "./RoUniversalControlEvent";
 import { RoAudioPlayerEvent } from "./RoAudioPlayerEvent";
 import { BrsType } from "..";
 import { Callable, StdlibArgument } from "../Callable";
@@ -12,6 +12,7 @@ export class RoMessagePort extends BrsComponent implements BrsValue {
     readonly kind = ValueKind.Object;
     private messageQueue: BrsType[];
     private callbackQueue: Function[]; // TODO: consider having the id of the connected objects
+    private keysQueue: KeyEvent[];
     private lastKey: number;
     private screen: boolean;
     private lastFlags: number;
@@ -23,6 +24,7 @@ export class RoMessagePort extends BrsComponent implements BrsValue {
         });
         this.messageQueue = [];
         this.callbackQueue = [];
+        this.keysQueue = [];
         this.lastKey = -1;
         this.screen = false;
         this.lastFlags = -1;
@@ -58,64 +60,31 @@ export class RoMessagePort extends BrsComponent implements BrsValue {
     }
 
     wait(interpreter: Interpreter, ms: number) {
+        const loop = ms === 0;
+        ms += performance.now();
         if (this.screen) {
-            if (ms === 0) {
-                while (true) {
-                    const key = Atomics.load(interpreter.sharedArray, DataType.KEY);
-                    if (key !== this.lastKey) {
-                        const ctrlEvent =  this.newControlEvent(interpreter, key);
-                        if  (ctrlEvent instanceof RoUniversalControlEvent) {
-                            return ctrlEvent;
-                        }
-                    } else if (interpreter.checkBreakCommand()) {
-                        return BrsInvalid.Instance;
-                    }
-                }
-            } else {
-                ms += performance.now();
-                while (performance.now() < ms) {
-                    const key = Atomics.load(interpreter.sharedArray, DataType.KEY);
-                    if (key !== this.lastKey) {
-                        const ctrlEvent =  this.newControlEvent(interpreter, key);
-                        if  (ctrlEvent instanceof RoUniversalControlEvent) {
-                            return ctrlEvent;
-                        }
-                    } else if (interpreter.checkBreakCommand()) {
-                        return BrsInvalid.Instance;
-                    }
+            while (loop || performance.now() < ms) {
+                this.updateKeysQueue(interpreter);
+                const ctrlEvent = this.newControlEvent(interpreter);
+                if (ctrlEvent instanceof RoUniversalControlEvent) {
+                    return ctrlEvent;
+                } else if (interpreter.checkBreakCommand()) {
+                    return BrsInvalid.Instance;
                 }
             }
         } else if (this.audio) {
-            if (ms === 0) {
-                while (true) {
-                    const flags = Atomics.load(interpreter.sharedArray, DataType.SND);
-                    if (flags !== this.lastFlags) {
-                        this.lastFlags = flags;
-                        if (this.lastFlags >= 0) {
-                            return new RoAudioPlayerEvent(
-                                this.lastFlags,
-                                Atomics.load(interpreter.sharedArray, DataType.IDX)
-                            );
-                        }
-                    } else if (interpreter.checkBreakCommand()) {
-                        return BrsInvalid.Instance;
+            while (loop || performance.now() < ms) {
+                const flags = Atomics.load(interpreter.sharedArray, DataType.SND);
+                if (flags !== this.lastFlags) {
+                    this.lastFlags = flags;
+                    if (this.lastFlags >= 0) {
+                        return new RoAudioPlayerEvent(
+                            this.lastFlags,
+                            Atomics.load(interpreter.sharedArray, DataType.IDX)
+                        );
                     }
-                }
-            } else {
-                ms += performance.now();
-                while (performance.now() < ms) {
-                    const flags = Atomics.load(interpreter.sharedArray, DataType.SND);
-                    if (flags !== this.lastFlags) {
-                        this.lastFlags = flags;
-                        if (this.lastFlags >= 0) {
-                            return new RoAudioPlayerEvent(
-                                this.lastFlags,
-                                Atomics.load(interpreter.sharedArray, DataType.IDX)
-                            );
-                        }
-                    } else if (interpreter.checkBreakCommand()) {
-                        return BrsInvalid.Instance;
-                    }
+                } else if (interpreter.checkBreakCommand()) {
+                    return BrsInvalid.Instance;
                 }
             }
         } else {
@@ -154,19 +123,34 @@ export class RoMessagePort extends BrsComponent implements BrsValue {
         return BrsInvalid.Instance;
     }
 
-    newControlEvent(interpreter: Interpreter, key: number): RoUniversalControlEvent | BrsInvalid {
-        let mod = Atomics.load(interpreter.sharedArray, DataType.MOD);
-        if (mod === 0) {
-            if (this.lastKey < 100) {
-                key = this.lastKey + 100
-            }
-        } else if (key !== this.lastKey + 100) {
-            return BrsInvalid.Instance;
+    updateKeysQueue(interpreter: Interpreter) {
+        const key = Atomics.load(interpreter.sharedArray, DataType.KEY);
+        if (this.keysQueue.length === 0 || key !== this.keysQueue.at(-1)?.key) {
+            let mod = Atomics.load(interpreter.sharedArray, DataType.MOD);
+            this.keysQueue.push({ key: key, mod: mod });
         }
-        interpreter.lastKeyTime = interpreter.currKeyTime;
-        interpreter.currKeyTime = performance.now();
-        this.lastKey = key;
-        return new RoUniversalControlEvent("WD:0", key, mod);
+    }
+
+    newControlEvent(interpreter: Interpreter): RoUniversalControlEvent | BrsInvalid {
+        const nextKey = this.keysQueue.shift();
+        if (nextKey && nextKey.key !== this.lastKey) {
+            if (interpreter.singleKeyEvents) {
+                if (nextKey.mod === 0) {
+                    if (this.lastKey >= 0 && this.lastKey < 100) {
+                        this.keysQueue.unshift({ key: nextKey.key, mod: nextKey.mod });
+                        nextKey.key = this.lastKey + 100;
+                        nextKey.mod = 100;
+                    }
+                } else if (nextKey.key !== this.lastKey + 100) {
+                    return BrsInvalid.Instance;
+                }
+            }
+            interpreter.lastKeyTime = interpreter.currKeyTime;
+            interpreter.currKeyTime = performance.now();
+            this.lastKey = nextKey.key;
+            return new RoUniversalControlEvent("WD:0", nextKey);
+        }
+        return BrsInvalid.Instance;
     }
 
     /** Waits until an event object is available or timeout milliseconds have passed. */
@@ -188,10 +172,8 @@ export class RoMessagePort extends BrsComponent implements BrsValue {
         },
         impl: (interpreter: Interpreter) => {
             if (this.screen) {
-                const key = Atomics.load(interpreter.sharedArray, DataType.KEY);
-                if (key !== this.lastKey) {
-                    return this.newControlEvent(interpreter, key);
-                }
+                this.updateKeysQueue(interpreter);
+                return this.newControlEvent(interpreter);
             } else if (this.audio) {
                 const flags = Atomics.load(interpreter.sharedArray, DataType.SND);
                 if (flags !== this.lastFlags) {
@@ -226,10 +208,10 @@ export class RoMessagePort extends BrsComponent implements BrsValue {
         },
         impl: (interpreter: Interpreter) => {
             if (this.screen) {
-                const key = Atomics.load(interpreter.sharedArray, DataType.KEY);
-                if (key !== this.lastKey) {
-                    const mod = Atomics.load(interpreter.sharedArray, DataType.MOD);
-                    return new RoUniversalControlEvent("WD:0", key, mod);
+                this.updateKeysQueue(interpreter);
+                const nextKey = this.keysQueue[0];
+                if (nextKey) {
+                    return new RoUniversalControlEvent("WD:0", nextKey);
                 }
             } else if (this.audio) {
                 const flags = Atomics.load(interpreter.sharedArray, DataType.SND);

--- a/src/worker/brsTypes/components/RoUniversalControlEvent.ts
+++ b/src/worker/brsTypes/components/RoUniversalControlEvent.ts
@@ -5,17 +5,22 @@ import { Callable } from "../Callable";
 import { Interpreter } from "../../interpreter";
 import { Int32 } from "../Int32";
 
+export interface KeyEvent {
+    key: number; // Key Code
+    mod: number; // Modifier (0 = press, 100 = release)
+}
+
 export class RoUniversalControlEvent extends BrsComponent implements BrsValue {
     readonly kind = ValueKind.Object;
     private key: number;
     private remote: string;
     private mod: number;
 
-    constructor(remote: string, key: number, mod: number) {
+    constructor(remote: string, keyEvent: KeyEvent) {
         super("roUniversalControlEvent");
-        this.key = key;
         this.remote = remote;
-        this.mod = mod;
+        this.key = keyEvent.key;
+        this.mod = keyEvent.mod;
 
         this.registerMethods({
             ifUniversalControlEvent: [

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -144,8 +144,8 @@ export function executeFile(payload: any): RunResult {
     // Input Parameters / Deep Link
     const inputArray = setupInputArray(payload.input);
     // Process Payload Content
-    setupManifest(payload.manifest, interpreter);
-    setupRegistry(payload.device.registry, interpreter);
+    interpreter.setManifest(payload.manifest);
+    interpreter.setRegistry(payload.device.registry);
     setupDeviceData(payload.device, interpreter);
     setupDeviceFonts(payload.device, interpreter);
     setupPackageFiles(payload.paths, payload.binaries, payload.texts, payload.brs, interpreter);
@@ -193,36 +193,6 @@ function setupInputArray(input: any): AAMember[] {
         inputArray.push({ name: new BrsString(key), value: new BrsString(value) });
     });
     return inputArray;
-}
-
-/**
- * Updates the interpreter manifest with the provided data
- *
- * @param manifest Map with manifest content.
- * @param interpreter the Interpreter instance to update.
- *
- */
-function setupManifest(manifest: any, interpreter: Interpreter) {
-    if (manifest instanceof Map) {
-        manifest.forEach(function (value: string, key: string) {
-            interpreter.manifest.set(key, value);
-        });
-    }
-}
-
-/**
- * Updates the interpreter registry with the provided data
- *
- * @param registry Map with registry content.
- * @param interpreter the Interpreter instance to update.
- *
- */
-function setupRegistry(registry: any, interpreter: Interpreter) {
-    if (registry instanceof Map) {
-        registry.forEach(function (value: string, key: string) {
-            interpreter.registry.set(key, value);
-        });
-    }
 }
 
 /**

--- a/src/worker/interpreter/index.ts
+++ b/src/worker/interpreter/index.ts
@@ -68,6 +68,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
         end: { line: 0, column: 0 },
     };
     private _dotLevel = 0;
+    private _singleKeyEvents = true; // Default Roku behavior is `true`
     readonly options: ExecutionOptions = defaultExecutionOptions;
     readonly fileSystem: Map<string, FileSystem> = new Map<string, FileSystem>();
     readonly manifest: Map<string, any> = new Map<string, any>();
@@ -90,10 +91,42 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
         return this._startTime;
     }
 
+    get singleKeyEvents() {
+        return this._singleKeyEvents;
+    }
+
     public audioId: number = 0;
     public lastKeyTime: number = Date.now();
     public currKeyTime: number = Date.now();
     public debugMode: boolean = false;
+
+    /**
+     * Updates the interpreter manifest with the provided data
+     *
+     * @param manifest Map with manifest content.
+     *
+     */
+    public setManifest(manifest: Map<string, string>) {
+        manifest.forEach((value: string, key: string) => {
+            this.manifest.set(key, value);
+            // Custom Manifest Entries
+            if (key.toLowerCase() === "multi_key_events") {
+                this._singleKeyEvents = value.trim() !== "1";
+            }
+        });
+    }
+
+    /**
+     * Updates the interpreter registry with the provided data
+     *
+     * @param registry Map with registry content.
+     *
+     */
+    public setRegistry(registry: Map<string, string>) {
+        registry.forEach((value: string, key: string) => {
+            this.registry.set(key, value);
+        });
+    }
 
     /**
      * Convenience function to subscribe to the `err` events emitted by `interpreter.events`.


### PR DESCRIPTION
Added a queue to control the keys sent to the engine, and changed the default behavior to match Roku, making sure all key events are complete (key press, key release). If the app needs to enable the support for multiple key events, needs to add the custom entry `multi_key_events=1` to the `manifest` file.