### PR TITLE
Fixed API to handle `mute` in sync for both Audio and Video

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -227,7 +227,7 @@ export function execute(filePath: string, fileData: any, options: any = {}) {
         console.info(`Loading ${filePath}...`);
     }
     initSoundModule(sharedArray, deviceData.maxSimulStreams, options.muteSound);
-    muteVideo(options.muteSound)
+    muteVideo(options.muteSound);
 
     if (fileExt === "zip" || fileExt === "bpk") {
         loadAppZip(fileName, fileData, runApp);

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -49,7 +49,7 @@ import {
     resetSounds,
     addSoundPlaylist,
     muteSound,
-    isMuted,
+    isSoundMuted,
     subscribeSound,
     switchSoundState,
     handleSoundEvent,
@@ -58,6 +58,8 @@ import {
     addVideoPlaylist,
     handleVideoEvent,
     initVideoModule,
+    isVideoMuted,
+    muteVideo,
     resetVideo,
     subscribeVideo,
     switchVideoState,
@@ -225,6 +227,7 @@ export function execute(filePath: string, fileData: any, options: any = {}) {
         console.info(`Loading ${filePath}...`);
     }
     initSoundModule(sharedArray, deviceData.maxSimulStreams, options.muteSound);
+    muteVideo(options.muteSound)
 
     if (fileExt === "zip" || fileExt === "bpk") {
         loadAppZip(fileName, fileData, runApp);
@@ -288,11 +291,12 @@ export function enableStats(state: boolean) {
 
 // Audio API
 export function getAudioMute() {
-    return isMuted();
+    return isSoundMuted() && isVideoMuted();
 }
 export function setAudioMute(mute: boolean) {
     if (currentApp.running) {
         muteSound(mute);
+        muteVideo(mute);
     }
 }
 

--- a/src/api/sound.ts
+++ b/src/api/sound.ts
@@ -88,12 +88,12 @@ export function handleSoundEvent(eventData: string) {
     }
 }
 
-export function muteSound(mute: boolean) {
+export function muteSound(mute: boolean = false) {
     muted = mute;
     Howler.mute(mute);
 }
 
-export function isMuted() {
+export function isSoundMuted() {
     return muted;
 }
 

--- a/src/api/video.ts
+++ b/src/api/video.ts
@@ -52,7 +52,7 @@ export function initVideoModule(array: Int32Array, mute: boolean = false) {
         player.addEventListener("durationchange", setDuration);
         player.addEventListener("loadedmetadata", startProgress);
         player.addEventListener("loadeddata", startProgress);
-        player.muted = mute;
+        player.defaultMuted = mute;
     }
     sharedArray = array;
     resetVideo();
@@ -112,7 +112,7 @@ export function handleVideoEvent(eventData: string) {
         resumeVideo();
     } else if (data[1] === "mute") {
         if (data[2]) {
-            muteVideo(data[2] === "true");
+            player.muted = player?.defaultMuted || data[2] === "true";
         }
     } else if (data[1] === "loop") {
         if (data[2]) {
@@ -135,8 +135,11 @@ export function handleVideoEvent(eventData: string) {
     }
 }
 
-export function muteVideo(mute: boolean) {
-    player.muted = mute;
+export function muteVideo(mute: boolean = false) {
+    if (player) {
+        player.defaultMuted = mute;
+        player.muted = mute;
+    }
 }
 
 export function isVideoMuted() {


### PR DESCRIPTION
The API methods `setAudioMute()` and `getAudioMute()` were not considering the new video player.