### PR TITLE
Fixed #219 - Video playback is not always pausing when the app get `PAUSE` or `BREAK` commands

### DIFF
--- a/src/api/video.ts
+++ b/src/api/video.ts
@@ -83,7 +83,9 @@ export function unsubscribeVideo(observerId: string) {
     observers.delete(observerId);
 }
 function notifyAll(eventName: string, eventData?: any) {
-    playerState = eventName;
+    if (["play", "pause", "stop"].includes(eventName)) {
+        playerState = eventName;
+    }
     observers.forEach((callback, id) => {
         callback(eventName, eventData);
     });


### PR DESCRIPTION
The state variable was being changed by the `rect` event causing the issue.