### PR TITLE
Fixed #229 - Clear buffer on terminate

### DIFF
--- a/src/api/display.ts
+++ b/src/api/display.ts
@@ -278,7 +278,7 @@ export function clearDisplay() {
     }
 }
 
-function clearBuffer() {
+export function clearBuffer() {
     if (bufferCtx) {
         bufferCtx.fillStyle = "black";
         bufferCtx.fillRect(0, 0, bufferCanvas.width, bufferCanvas.height);

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -31,6 +31,7 @@ import {
     redrawDisplay,
     clearDisplay,
     statsUpdate,
+    clearBuffer,
 } from "./display";
 import {
     initSoundModule,
@@ -245,6 +246,7 @@ export function terminate(reason: string) {
         deviceDebug(`print,------ Finished '${currentApp.title}' execution [${reason}] ------\r\n`);
     }
     if (currentApp.clearDisplay) {
+        clearBuffer();
         clearDisplay();
     }
     resetWorker();


### PR DESCRIPTION
The display canvas was not being always cleared when app terminates, a final buffer draw was happening after the event, solution was to clear the buffer too.