### PR TITLE
Add support to videos inside the package or downloaded - closes #239

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -50,6 +50,7 @@ import {
     handleSoundEvent,
 } from "./sound";
 import {
+    addVideo,
     addVideoPlaylist,
     handleVideoEvent,
     initVideoModule,
@@ -446,6 +447,8 @@ function workerCallback(event: MessageEvent) {
         if (event.data.videoPlaylist instanceof Array) {
             addVideoPlaylist(event.data.videoPlaylist);
         }
+    } else if (event.data.videoPath && context.inBrowser) {
+        addVideo(event.data.videoPath, new Blob([event.data.videoData], { type: "video/mp4" }));
     } else if (typeof event.data !== "string") {
         // All messages beyond this point must be csv string
         apiException("warning", `[api] Invalid worker message: ${event.data}`);

--- a/src/api/package.ts
+++ b/src/api/package.ts
@@ -9,7 +9,8 @@ import { drawSplashScreen, clearDisplay, drawIconAsSplash } from "./display";
 import { bufferToBase64, parseCSV, SubscribeCallback, context } from "./util";
 import { unzipSync, zipSync, strFromU8, strToU8, Zippable, Unzipped } from "fflate";
 import { addSound, audioCodecs } from "./sound";
-import { videoFormats } from "./video";
+import { addVideo, videoFormats } from "./video";
+import { audioExt, videoExt } from "../worker/enums";
 import models from "../worker/common/models.csv";
 
 // Default Device Data
@@ -127,14 +128,17 @@ function processFile(relativePath: string, fileData: Uint8Array) {
         paths.push({ url: relativePath, id: txtId, type: "text" });
         txts.push(strFromU8(fileData));
         txtId++;
-    } else if (
-        ["wav", "mp2", "mp3", "mp4", "m4a", "aac", "ogg", "oga", "ac3", "wma", "flac"].includes(ext)
-    ) {
+    } else if (audioExt.has(ext)) {
         paths.push({ url: relativePath, id: audId, type: "audio", format: ext });
         if (context.inBrowser) {
             addSound(`pkg:/${relativePath}`, ext, new Blob([fileData]));
         }
         audId++;
+    } else if (videoExt.has(ext)) {
+        paths.push({ url: relativePath, id: 0, type: "video", format: ext });
+        if (context.inBrowser) {
+            addVideo(`pkg:/${relativePath}`, new Blob([fileData], { type: "video/mp4" }));
+        }
     } else {
         const binType = lcasePath === "source/data" ? "pcode" : "binary";
         paths.push({ url: relativePath, id: binId, type: binType });

--- a/src/api/sound.ts
+++ b/src/api/sound.ts
@@ -131,7 +131,6 @@ export function audioCodecs() {
         "caf",
         "m4a",
         "m4b",
-        "mp4",
         "weba",
         "webm",
         "dolby",

--- a/src/worker/enums.ts
+++ b/src/worker/enums.ts
@@ -76,3 +76,18 @@ export enum MediaEvent {
     LOADING,
     POSITION,
 }
+
+export const audioExt = new Set<string>([
+    "wav",
+    "mp2",
+    "mp3",
+    "m4a",
+    "aac",
+    "ogg",
+    "oga",
+    "ac3",
+    "wma",
+    "flac",
+]);
+
+export const videoExt = new Set<string>(["mp4", "m4v", "mkv", "mov"]);

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -297,11 +297,13 @@ function setupPackageFiles(
                     volume.writeFileSync(`/${filePath.url}`, binaries[filePath.id]);
                 } else if (filePath.type === "pcode" && Array.isArray(binaries)) {
                     pcode = Buffer.from(binaries[filePath.id]);
-                } else if (filePath.type === "audio") {
-                    // As the audio files are played on the renderer process we need to
+                } else if (["audio", "video"].includes(filePath.type)) {
+                    // As the media files are played on the renderer process we need to
                     // save a mock file to allow file exist checking and save the index
                     volume.writeFileSync(`/${filePath.url}`, filePath.id.toString());
-                    interpreter.audioId = filePath.id;
+                    if (filePath.type === "audio") {
+                        interpreter.audioId = filePath.id;
+                    }
                 } else if (filePath.type === "text" && Array.isArray(texts)) {
                     if (filePath.url === "source/var") {
                         iv = texts[filePath.id];


### PR DESCRIPTION
Video files with extensions "mp4", "m4v",  "mov" or "mkv" can now be included on the app package or downloaded using `roUrlTransfer` to be played.