### PR TITLE
Fixed #254 - Keep the audio track selection on each playlist video metadata

### DIFF
--- a/src/api/video.ts
+++ b/src/api/video.ts
@@ -333,7 +333,7 @@ function getVideoUrl(video: any): string {
 
 function playVideo() {
     if (canPlay) {
-        var promise = player.play();
+        const promise = player.play();
         if (promise !== undefined) {
             promise
                 .then(function () {

--- a/src/worker/brsTypes/components/RoVideoPlayer.ts
+++ b/src/worker/brsTypes/components/RoVideoPlayer.ts
@@ -61,7 +61,7 @@ export class RoVideoPlayer extends BrsComponent implements BrsValue {
     getContent() {
         const contents: Object[] = [];
         this.contentList.forEach((aa, index, array) => {
-            const item = { url: "", streamFormat: "" };
+            const item = { url: "", streamFormat: "", audioTrack: -1 };
             let url = aa.get(new BrsString("url"));
             if (url instanceof BrsString) {
                 item.url = url.value;


### PR DESCRIPTION
Also added handler to the promise returned to `play()`  method and used mute to prevent browser blocking the video playback.