### PR TITLE
Implemented `ifDraw2d` method `drawTransformedObject()` #272

### DIFF
--- a/src/worker/brsTypes/components/RoBitmap.ts
+++ b/src/worker/brsTypes/components/RoBitmap.ts
@@ -7,7 +7,7 @@ import { Int32 } from "../Int32";
 import { Float } from "../Float";
 import { RoFont } from "./RoFont";
 import { RoAssociativeArray } from "./RoAssociativeArray";
-import { drawImageToContext, drawObjectToComponent } from "../draw2d";
+import { drawImageToContext, drawObjectToComponent, drawRotatedObject } from "../draw2d";
 import URL from "url-parse";
 import { RoByteArray } from "./RoByteArray";
 import { GifReader } from "omggif";
@@ -325,14 +325,15 @@ export class RoBitmap extends BrsComponent implements BrsValue {
             rgba: Int32 | BrsInvalid
         ) => {
             let ctx = this.context;
-            const positionX = x.getValue();
-            const positionY = y.getValue();
-            const angleInRad = (-theta.getValue() * Math.PI) / 180;
-            ctx.save();
-            ctx.translate(positionX, positionY);
-            ctx.rotate(angleInRad);
-            const didDraw = this.drawImage(object, rgba, 0, 0);
-            ctx.restore();
+            const didDraw = drawRotatedObject(
+                this,
+                ctx,
+                object,
+                rgba,
+                x.getValue(),
+                y.getValue(),
+                theta.getValue()
+            );
             this.rgbaRedraw = true;
             return BrsBoolean.from(didDraw);
         },

--- a/src/worker/brsTypes/components/RoBitmap.ts
+++ b/src/worker/brsTypes/components/RoBitmap.ts
@@ -155,6 +155,7 @@ export class RoBitmap extends BrsComponent implements BrsValue {
                 this.drawObject,
                 this.drawRotatedObject,
                 this.drawScaledObject,
+                this.drawTransformedObject,
                 this.drawLine,
                 this.drawPoint,
                 this.drawRect,
@@ -369,6 +370,52 @@ export class RoBitmap extends BrsComponent implements BrsValue {
                 scaleY.getValue()
             );
             ctx.globalAlpha = 1.0;
+            this.rgbaRedraw = true;
+            return BrsBoolean.from(didDraw);
+        },
+    });
+
+    /** Draw the source object, at position x,y, rotated by theta and scaled horizontally by scaleX and vertically by scaleY. */
+    private drawTransformedObject = new Callable("drawTransformedObject", {
+        signature: {
+            args: [
+                new StdlibArgument("x", ValueKind.Int32),
+                new StdlibArgument("y", ValueKind.Int32),
+                new StdlibArgument("theta", ValueKind.Float),
+                new StdlibArgument("scaleX", ValueKind.Float),
+                new StdlibArgument("scaleY", ValueKind.Float),
+                new StdlibArgument("object", ValueKind.Object),
+                new StdlibArgument("rgba", ValueKind.Object, BrsInvalid.Instance),
+            ],
+            returns: ValueKind.Boolean,
+        },
+        impl: (
+            _: Interpreter,
+            x: Int32,
+            y: Int32,
+            theta: Float,
+            scaleX: Float,
+            scaleY: Float,
+            object: BrsComponent,
+            rgba: Int32 | BrsInvalid
+        ) => {
+            const ctx = this.context;
+            const positionX = x.getValue();
+            const positionY = y.getValue();
+            const angleInRad = (-theta.getValue() * Math.PI) / 180;
+            ctx.save();
+            ctx.translate(positionX, positionY);
+            ctx.rotate(angleInRad);
+            const didDraw = this.drawImage(
+                object,
+                rgba,
+                0,
+                0,
+                scaleX.getValue(),
+                scaleY.getValue()
+            );
+            ctx.globalAlpha = 1.0;
+            ctx.restore();
             this.rgbaRedraw = true;
             return BrsBoolean.from(didDraw);
         },

--- a/src/worker/brsTypes/components/RoRegion.ts
+++ b/src/worker/brsTypes/components/RoRegion.ts
@@ -8,7 +8,7 @@ import { RoBitmap, rgbaIntToHex } from "./RoBitmap";
 import { RoScreen } from "./RoScreen";
 import { Rect, Circle } from "./RoCompositor";
 import { RoByteArray } from "./RoByteArray";
-import { drawImageToContext, drawObjectToComponent } from "../draw2d";
+import { drawImageToContext, drawObjectToComponent, drawRotatedObject } from "../draw2d";
 import UPNG from "upng-js";
 
 export class RoRegion extends BrsComponent implements BrsValue {
@@ -620,14 +620,15 @@ export class RoRegion extends BrsComponent implements BrsValue {
             rgba: Int32 | BrsInvalid
         ) => {
             const ctx = this.bitmap.getContext();
-            const positionX = x.getValue();
-            const positionY = y.getValue();
-            const angleInRad = (-theta.getValue() * Math.PI) / 180;
-            ctx.save();
-            ctx.translate(positionX, positionY);
-            ctx.rotate(angleInRad);
-            const didDraw = this.drawImage(object, rgba, 0, 0);
-            ctx.restore();
+            const didDraw = drawRotatedObject(
+                this,
+                ctx,
+                object,
+                rgba,
+                x.getValue(),
+                y.getValue(),
+                theta.getValue()
+            );
             return BrsBoolean.from(didDraw);
         },
     });

--- a/src/worker/brsTypes/components/RoRegion.ts
+++ b/src/worker/brsTypes/components/RoRegion.ts
@@ -94,6 +94,7 @@ export class RoRegion extends BrsComponent implements BrsValue {
                 this.drawObject,
                 this.drawRotatedObject,
                 this.drawScaledObject,
+                this.drawTransformedObject,
                 this.drawLine,
                 this.drawPoint,
                 this.drawRect,
@@ -640,7 +641,7 @@ export class RoRegion extends BrsComponent implements BrsValue {
                 new StdlibArgument("scaleX", ValueKind.Float),
                 new StdlibArgument("scaleY", ValueKind.Float),
                 new StdlibArgument("object", ValueKind.Object),
-                new StdlibArgument("rgba", ValueKind.Object, BrsInvalid.Instance), // TODO: add support to rgba
+                new StdlibArgument("rgba", ValueKind.Object, BrsInvalid.Instance),
             ],
             returns: ValueKind.Boolean,
         },
@@ -663,6 +664,51 @@ export class RoRegion extends BrsComponent implements BrsValue {
                 scaleY.getValue()
             );
             ctx.globalAlpha = 1.0;
+            return BrsBoolean.from(didDraw);
+        },
+    });
+
+    /** Draw the source object, at position x,y, rotated by theta and scaled horizontally by scaleX and vertically by scaleY. */
+    private drawTransformedObject = new Callable("drawTransformedObject", {
+        signature: {
+            args: [
+                new StdlibArgument("x", ValueKind.Int32),
+                new StdlibArgument("y", ValueKind.Int32),
+                new StdlibArgument("theta", ValueKind.Float),
+                new StdlibArgument("scaleX", ValueKind.Float),
+                new StdlibArgument("scaleY", ValueKind.Float),
+                new StdlibArgument("object", ValueKind.Object),
+                new StdlibArgument("rgba", ValueKind.Object, BrsInvalid.Instance),
+            ],
+            returns: ValueKind.Boolean,
+        },
+        impl: (
+            _: Interpreter,
+            x: Int32,
+            y: Int32,
+            theta: Float,
+            scaleX: Float,
+            scaleY: Float,
+            object: BrsComponent,
+            rgba: Int32 | BrsInvalid
+        ) => {
+            const ctx = this.bitmap.getContext();
+            const positionX = x.getValue();
+            const positionY = y.getValue();
+            const angleInRad = (-theta.getValue() * Math.PI) / 180;
+            ctx.save();
+            ctx.translate(positionX, positionY);
+            ctx.rotate(angleInRad);
+            const didDraw = this.drawImage(
+                object,
+                rgba,
+                0,
+                0,
+                scaleX.getValue(),
+                scaleY.getValue()
+            );
+            ctx.globalAlpha = 1.0;
+            ctx.restore();
             return BrsBoolean.from(didDraw);
         },
     });

--- a/src/worker/brsTypes/components/RoScreen.ts
+++ b/src/worker/brsTypes/components/RoScreen.ts
@@ -83,6 +83,7 @@ export class RoScreen extends BrsComponent implements BrsValue {
                 this.drawObject,
                 this.drawRotatedObject,
                 this.drawScaledObject,
+                this.drawTransformedObject,
                 this.drawLine,
                 this.drawPoint,
                 this.drawRect,
@@ -297,6 +298,51 @@ export class RoScreen extends BrsComponent implements BrsValue {
                 scaleY.getValue()
             );
             ctx.globalAlpha = 1.0;
+            return BrsBoolean.from(this.isDirty);
+        },
+    });
+
+    /** Draw the source object, at position x,y, rotated by theta and scaled horizontally by scaleX and vertically by scaleY. */
+    private drawTransformedObject = new Callable("drawTransformedObject", {
+        signature: {
+            args: [
+                new StdlibArgument("x", ValueKind.Int32),
+                new StdlibArgument("y", ValueKind.Int32),
+                new StdlibArgument("theta", ValueKind.Float),
+                new StdlibArgument("scaleX", ValueKind.Float),
+                new StdlibArgument("scaleY", ValueKind.Float),
+                new StdlibArgument("object", ValueKind.Object),
+                new StdlibArgument("rgba", ValueKind.Object, BrsInvalid.Instance),
+            ],
+            returns: ValueKind.Boolean,
+        },
+        impl: (
+            _: Interpreter,
+            x: Int32,
+            y: Int32,
+            theta: Float,
+            scaleX: Float,
+            scaleY: Float,
+            object: BrsComponent,
+            rgba: Int32 | BrsInvalid
+        ) => {
+            const ctx = this.context[this.currentBuffer];
+            const positionX = x.getValue();
+            const positionY = y.getValue();
+            const angleInRad = (-theta.getValue() * Math.PI) / 180;
+            ctx.save();
+            ctx.translate(positionX, positionY);
+            ctx.rotate(angleInRad);
+            this.drawImage(
+                object,
+                rgba,
+                0,
+                0,
+                scaleX.getValue(),
+                scaleY.getValue()
+            );
+            ctx.globalAlpha = 1.0;
+            ctx.restore();
             return BrsBoolean.from(this.isDirty);
         },
     });

--- a/src/worker/brsTypes/components/RoScreen.ts
+++ b/src/worker/brsTypes/components/RoScreen.ts
@@ -9,7 +9,7 @@ import { rgbaIntToHex } from "./RoBitmap";
 import { RoMessagePort } from "./RoMessagePort";
 import { RoFont } from "./RoFont";
 import { RoByteArray } from "./RoByteArray";
-import { drawImageToContext, drawObjectToComponent } from "../draw2d";
+import { drawImageToContext, drawObjectToComponent, drawRotatedObject } from "../draw2d";
 import UPNG from "upng-js";
 
 export class RoScreen extends BrsComponent implements BrsValue {
@@ -254,14 +254,15 @@ export class RoScreen extends BrsComponent implements BrsValue {
             rgba: Int32 | BrsInvalid
         ) => {
             const ctx = this.context[this.currentBuffer];
-            const positionX = x.getValue();
-            const positionY = y.getValue();
-            const angleInRad = (-theta.getValue() * Math.PI) / 180;
-            ctx.save();
-            ctx.translate(positionX, positionY);
-            ctx.rotate(angleInRad);
-            this.drawImage(object, rgba, 0, 0);
-            ctx.restore();
+            drawRotatedObject(
+                this,
+                ctx,
+                object,
+                rgba,
+                x.getValue(),
+                y.getValue(),
+                theta.getValue()
+            );
             return BrsBoolean.from(this.isDirty);
         },
     });
@@ -333,14 +334,7 @@ export class RoScreen extends BrsComponent implements BrsValue {
             ctx.save();
             ctx.translate(positionX, positionY);
             ctx.rotate(angleInRad);
-            this.drawImage(
-                object,
-                rgba,
-                0,
-                0,
-                scaleX.getValue(),
-                scaleY.getValue()
-            );
+            this.drawImage(object, rgba, 0, 0, scaleX.getValue(), scaleY.getValue());
             ctx.globalAlpha = 1.0;
             ctx.restore();
             return BrsBoolean.from(this.isDirty);

--- a/src/worker/brsTypes/draw2d.ts
+++ b/src/worker/brsTypes/draw2d.ts
@@ -262,3 +262,21 @@ export function drawImageToContext(
     }
     return true;
 }
+
+export function drawRotatedObject(
+    component: BrsDraw2D,
+    ctx: OffscreenCanvasRenderingContext2D,
+    object: BrsComponent,
+    rgba: Int32 | BrsInvalid,
+    x: number,
+    y: number,
+    angle: number
+): boolean {
+    const angleInRad = (-angle * Math.PI) / 180;
+    ctx.save();
+    ctx.translate(x, y);
+    ctx.rotate(angleInRad);
+    const didDraw = component.drawImage(object, rgba, 0, 0);
+    ctx.restore();
+    return didDraw;
+}

--- a/test/simulator/ballboing.brs
+++ b/test/simulator/ballboing.brs
@@ -1,171 +1,172 @@
 Library "v30/bslDefender.brs"
 
 sub main()
-    screen=CreateObject("roScreen", true, 854, 480)
+	m.files = CreateObject("roFileSystem")
+    screen = CreateObject("roScreen", true, 854, 480)
     screen.SetAlphaEnable(true)
     screen.Clear(&HFF)
     port = CreateObject("roMessagePort")
     screen.SetMessagePort(port)
-    compositor=CreateObject("roCompositor")
+    compositor = CreateObject("roCompositor")
     compositor.SetDrawTo(screen, 0)
     scaleblit(screen, port, 0, 0, 854, 480, 1)
 end sub
 
 sub scaleblit(screenFull as object, msgport as object, topx, topy, w, h, par)
 
-        print "Scale Boing"
-        screen = screenFull
-        
-        red = 255*256*256*256+255
-        green = 255*256*256+255
-        blue = 255*256+255
-        
-        clr = int(255*.55)
-        background = &h8c8c8cff
-        sidebarcolor = green
+    print "Scale Boing"
+    screen = screenFull
 
-        screen.Clear(background)
+    red = 255 * 256 * 256 * 256 + 255
+    green = 255 * 256 * 256 + 255
+    blue = 255 * 256 + 255
+
+    clr = int(255 * .55)
+    background = &h8c8c8cff
+    sidebarcolor = green
+
+    screen.Clear(background)
+    screenFull.SwapBuffers()
+
+    ' create a red sprite
+
+    ballsize = h / 4
+    ballsizey = int(ballsize)
+    ballsizex = int(ballsize * par)
+
+    filePath = CacheFile("https://brsfiddle.net/images/AmigaBoingBall.png", "AmigaBoingBall.png")
+
+    tmpballbitmap = createobject("robitmap", filePath)
+
+    scaley = ballsizey / tmpballbitmap.getheight()
+    scalex = scaley * par
+
+    ballbitmap = createobject("robitmap", {width: ballsizex, height: ballsizey, alphaenable: true})
+    ballbitmap.drawscaledobject(0, 0, scalex, scaley, tmpballbitmap)
+
+    ballregion = createobject("roregion", ballbitmap, 0, 0, ballsizex, ballsizey)
+    ballcenterX = int(ballsizex / 2)
+    ballcenterY = int(ballsizey / 2)
+    ballregion.setpretranslation(-ballcenterX, -ballcenterY)
+    ballregion.setscalemode(0)
+
+    ' construct ball shadow
+	filePath = CacheFile("https://brsfiddle.net/images/BallShadow.png", "BallShadow.png")
+
+    tmpballbitmap = createobject("robitmap", filePath)
+    ballshadow = createobject("robitmap", {width: ballsizex, height: ballsizey, alphaenable: true})
+    ballshadow.drawscaledobject(0, 0, ballsizex / tmpballbitmap.getwidth(), ballsizey / tmpballbitmap.getheight(), tmpballbitmap)
+
+    shadowregion = createobject("roregion", ballshadow, 0, 0, ballsizex, ballsizey)
+    shadowregion.setpretranslation(-ballcenterX, -ballcenterY)
+    shadowregion.setscalemode(0)
+
+    ' calculate starting position and motion dynamics
+    x = w / 10 + ballcenterX
+    y = h / 10 + ballcenterY
+
+    dx = 2
+    dy = 1
+    ay = 1
+    angle = 0
+    framecount = 0
+    timestamp = createobject("rotimespan")
+    swapbuff_timestamp = createobject("rotimespan")
+    start = timestamp.totalmilliseconds()
+    swapbuff_time = 0
+    shadow_dx = int(ballsizex / 4)
+    shadow_dy = int(ballsizey / 10)
+    w_over_10 = w / 10
+    rightedge = int(ballcenterx + (w * 9) / 10)
+    bottomedge = int(ballcentery + (h * 9) / 10)
+    running = true
+    codes = bslUniversalControlEventCodes()
+    print codes
+    grid = createobject("robitmap", {width: screen.getWidth(), height: screen.getheight(), alphaenable: false})
+    regiondrawgrid(grid, background)
+    grid.finish()
+    while true
+        screen.drawobject(0, 0, grid)
+        screen.SetAlphaEnable(true)
+        scalex = x / rightedge
+        scaley = y / bottomedge
+        screen.drawscaledobject((x + shadow_dx), (y + shadow_dy), scalex, scaley, shadowregion)
+
+        screen.drawtransformedobject(x, y, angle, scalex, scaley, ballregion)
+        angle += 15
+        if angle >= 360
+            angle = 0
+        end if
+        screen.SetAlphaEnable(false)
+        screen.drawrect((x - 2), (y - 2), 5, 5, green) ' show where the (x,y) is
+
+        swapbuff_timestamp.mark()
         screenFull.SwapBuffers()
+        swapbuff_time = swapbuff_time + swapbuff_timestamp.totalmilliseconds()
 
-        ' create a red sprite
-
-        ballsize = h/4
-        ballsizey = int(ballsize)
-        ballsizex = int(ballsize*par)
-
-        tmpballbitmap = createobject("robitmap","pkg:/images/AmigaBoingBall.png")
-
-        scaley = ballsizey/tmpballbitmap.getheight()
-        scalex = scaley*par
-
-        ballbitmap = createobject("robitmap",{width:ballsizex,height:ballsizey,alphaenable:true})
-        ballbitmap.drawscaledobject(0,0,scalex,scaley,tmpballbitmap)
-
-        ballregion = createobject("roregion",ballbitmap,0,0,ballsizex,ballsizey)
-        ballcenterX = int(ballsizex/2)
-        ballcenterY = int(ballsizey/2)
-        ballregion.setpretranslation(-ballcenterX, -ballcenterY)
-        ballregion.setscalemode(0)
-        
-        ' construct ball shadow
-        tmpballbitmap = createobject("robitmap","pkg:/images/BallShadow.png")
-        ballshadow = createobject("robitmap",{width:ballsizex,height:ballsizey,alphaenable:true})
-        ballshadow.drawscaledobject(0,0,ballsizex/tmpballbitmap.getwidth(),ballsizey/tmpballbitmap.getheight(),tmpballbitmap)
-        
-        shadowregion = createobject("roregion",ballshadow,0,0,ballsizex,ballsizey)
-        shadowregion.setpretranslation(-ballcenterX, -ballcenterY)
-        shadowregion.setscalemode(0)
-
-        ' calculate starting position and motion dynamics
-        x = w/10 + ballcenterX
-        y = h/10 + ballcenterY
-        
-        dx = 2
-        dy = 1
-        ay = 1
-        framecount = 0
-        timestamp = createobject("rotimespan")
-        swapbuff_timestamp = createobject("rotimespan")
-        start = timestamp.totalmilliseconds()
-        swapbuff_time = 0
-        shadow_dx = int(ballsizex/4)
-        shadow_dy = int(ballsizey/10)
-        w_over_10 = w/10
-        rightedge = int(ballcenterx + (w*9)/10)
-        bottomedge = int(ballcentery + (h*9)/10)
-        running = true
-        codes = bslUniversalControlEventCodes()
-        print codes
-        grid = createobject("robitmap", {width:screen.getWidth(),height:screen.getheight(),alphaenable:false})
-        regiondrawgrid(grid, background)
-        grid.finish()
-        while true
-                screen.drawobject(0, 0, grid)
-                screen.SetAlphaEnable(true)
-                scalex = x/rightedge
-                scaley = y/bottomedge
-                screen.drawscaledobject((x+shadow_dx),(y+shadow_dy),scalex,scaley,shadowregion)
-
-                screen.drawscaledobject(x,y,scalex,scaley,ballregion)
-                screen.SetAlphaEnable(false)
-                screen.drawrect((x-2),(y-2),5,5,green)        ' show where the (x,y) is
-                
-                swapbuff_timestamp.mark()
-                screenFull.SwapBuffers()
-                swapbuff_time = swapbuff_time + swapbuff_timestamp.totalmilliseconds()
-                
-                pullingmsgs = true
-                while pullingmsgs
-                    deltatime = timestamp.totalmilliseconds() - start
-                    msg = msgport.getmessage()
-                    if msg = invalid and deltatime > 16 'aprox 60fps	
-                        timestamp.mark()
-                        start = timestamp.totalmilliseconds()
-                        pullingmsgs = false
-                    else
-                        if type(msg) = "roUniversalControlEvent"
-                            button = msg.getint()
-                            print "button=";button
-                            if button=codes.BUTTON_BACK_PRESSED   
-                                return
-                            endif
-                        endif
-                    endif
-                end while
-                x = x + dx
-                y = y + dy
-                dy = dy + ay
-                if x<w_over_10
-                        x = w_over_10+(w_over_10-x)
-                        dx = -dx
-                endif
-                if y<0
-                        y = -y
-                        dy = -dy
-                endif
-                if x+ballsizex > rightedge
-                        x = 2*rightedge - x - 2*ballsizex
-                        dx = -dx
-                endif
-                if y+ballsizey > bottomedge
-                        y = 2*y - y
-                        dy = -dy + ay
-                endif
-                ' framecount = framecount + 1
-                ' if framecount >= 100
-                '       deltatime = timestamp.totalmilliseconds() - start
-                '       print "frames per second = "; (framecount*1000)/deltatime;
-                '       print " average swapbuff time = "; swapbuff_time/framecount; " milliseconds"
-                '       swapbuff_time = 0
-                '       framecount = 0
-                '       timestamp.mark()
-                ' endif
+        pullingmsgs = true
+        while pullingmsgs
+            deltatime = timestamp.totalmilliseconds() - start
+            msg = msgport.getmessage()
+            if msg = invalid and deltatime > 16 'aprox 60fps
+                timestamp.mark()
+                start = timestamp.totalmilliseconds()
+                pullingmsgs = false
+            else
+                if type(msg) = "roUniversalControlEvent"
+                    button = msg.getint()
+                    print "button=";button
+                    if button = codes.BUTTON_BACK_PRESSED
+                        return
+                    end if
+                end if
+            end if
         end while
-        print "Exiting APP"
-End Sub
+        x = x + dx
+        y = y + dy
+        dy = dy + ay
+        if x < w_over_10
+            x = w_over_10 + (w_over_10 - x)
+            dx = -dx
+        end if
+        if y < 0
+            y = -y
+            dy = -dy
+        end if
+        if x + ballsizex > rightedge
+            x = 2 * rightedge - x - 2 * ballsizex
+            dx = -dx
+        end if
+        if y + ballsizey > bottomedge
+            y = 2 * y - y
+            dy = -dy + ay
+        end if
+    end while
+    print "Exiting APP"
+end sub
 
-sub drawline(screen, x0,y0,x1,y1,width,color)
+sub drawline(screen, x0, y0, x1, y1, width, color)
 
     if (width = 1) and (y0 <> y1) and (x0 <> x1)
         screen.drawline(x0, y0, x1, y1, color)
         return
     end if
 
-    if (x0=x1)
+    if (x0 = x1)
         ' vertical line
-        h = y1-y0
-        if h<0 ' upside down?
-            y0=y1
+        h = y1 - y0
+        if h < 0 ' upside down?
+            y0 = y1
             h = -h
-        endif            
-        screen.drawrect(x0,y0,width,h+1,color)
-    else if (y0=y1)
-        w = x1-x0
-        if w<0
-            x0=x1
+        end if
+        screen.drawrect(x0, y0, width, h + 1, color)
+    else if (y0 = y1)
+        w = x1 - x0
+        if w < 0
+            x0 = x1
             w = -w
-        endif
-        screen.drawrect(x0,y0,w+1,width,color)
+        end if
+        screen.drawrect(x0, y0, w + 1, width, color)
     end if
 end sub
 
@@ -174,37 +175,54 @@ sub regiondrawgrid(screen, background)
     screen.clear(background)
     w = screen.getWidth()
     h = screen.getHeight()
-    left = int(w/10)
-    right = w-left
-    top= int(h/10)
-    bottom = h-top
+    left = int(w / 10)
+    right = w - left
+    top = int(h / 10)
+    bottom = h - top
 
     color = &hff00ffff
     ' draw vertical lines
     i = 0
     x = left
-    deltax = int(left/2)
+    deltax = int(left / 2)
     deltay = deltax
     lineheight = bottom - top
-    bottom = top + deltay*int(lineheight/deltay)
-    bottomXdelta = (deltax/3)
+    bottom = top + deltay * int(lineheight / deltay)
+    bottomXdelta = (deltax / 3)
     bottomXdeltainit = bottomXdelta
-    deltax_over_20 = int(deltax/20)
-    deltay_over_2 = int(deltay/2)
-    while x<=right
-        drawline(screen,x,top,x,bottom,1,color)
-        drawline(screen,x,bottom,x-bottomXdelta,bottom+deltay_over_2,1,color)
+    deltax_over_20 = int(deltax / 20)
+    deltay_over_2 = int(deltay / 2)
+    while x <= right
+        drawline(screen, x, top, x, bottom, 1, color)
+        drawline(screen, x, bottom, x - bottomXdelta, bottom + deltay_over_2, 1, color)
         x = x + deltax
-        bottomXdelta =bottomXdelta - deltax_over_20
+        bottomXdelta = bottomXdelta - deltax_over_20
     end while
     ' correct for actual right edge
     right = x - deltax
     y = top
     'draw horizontal lines
-    while y<=bottom
-        drawline(screen,left,y,right,y,1,color)
+    while y <= bottom
+        drawline(screen, left, y, right, y, 1, color)
         y = y + deltay
     end while
     ' draw floor
-    drawline(screen, left-bottomXdeltainit, bottom+deltay_over_2,right-bottomXdelta-deltax_over_20 , bottom+deltay_over_2, 1, color)
+    drawline(screen, left - bottomXdeltainit, bottom + deltay_over_2, right - bottomXdelta - deltax_over_20, bottom + deltay_over_2, 1, color)
 end sub
+
+Function CacheFile(url as string, file as string, overwrite = false as boolean) as string
+    tmpFile = "tmp:/" + file
+    if overwrite or not m.files.Exists(tmpFile)
+        http = CreateObject("roUrlTransfer")
+        http.SetCertificatesFile("common:/certs/ca-bundle.crt")
+        http.SetUrl(url)
+        ret = http.GetToFile(tmpFile)
+        if ret = 200
+            print "CacheFile: "; url; " to "; tmpFile
+        else
+            print "File not cached! http return code: "; ret
+            tmpFile = ""
+        end if
+    end if
+    return tmpFile
+End Function

--- a/test/simulator/main.brs
+++ b/test/simulator/main.brs
@@ -1,37 +1,40 @@
-sub main()            
+sub main()
+    m.files = CreateObject("roFileSystem")
     for t = 1 to 5
         print t;
     next
-    date=CreateObject("roDateTime")
+    date = CreateObject("roDateTime")
     date.toLocalTime()
     print date.AsDateStringNoParam();
-    screen=CreateObject("roScreen", true, 854, 480)
+    screen = CreateObject("roScreen", true, 854, 480)
     screen.SetAlphaEnable(true)
     port = CreateObject("roMessagePort")
     screen.SetMessagePort(port)
     print screen.getWidth() "x" screen.getHeight()
     print &HFF0000
     screen.Clear(&H303030FF)
-    screen.DrawLine(0,0,200,300,&HFFD800FF)
-    screen.DrawRect(210,0,200,300,&HFF0000FF)
-    screen.DrawPoint(310,150,7.0,&HFFFFFFFF)
+    screen.DrawLine(0, 0, 200, 300, &HFFD800FF)
+    screen.DrawRect(210, 0, 200, 300, &HFF0000FF)
+    screen.DrawPoint(310, 150, 7.0, &HFFFFFFFF)
     fontRegistry = CreateObject("roFontRegistry")
-    font = fontRegistry.GetFont("Arial", 40, false, false)
+    font = fontRegistry.GetDefaultFont(40, false, false)
     screen.DrawText("brsLib", 230, 30, &HFFFFFFFF, font)
-    bmp = CreateObject("roBitmap", "pkg:/images/roku-logo.png")
+    filePath = CacheFile("https://brsfiddle.net/images/roku-logo.png", "roku-logo.png")
+    bmp = CreateObject("roBitmap", filePath)
     rgn = CreateObject("roRegion", bmp, 100.99, 100, 100.99, 100)
-    bmp.DrawLine(0,0,200,300,&HFFFFFFFF)
+    bmp.DrawLine(0, 0, 200, 300, &HFFFFFFFF)
     screen.DrawObject(450, 50, bmp)
-    screen.DrawScaledObject(0,300,0.3,0.3,bmp)
-    brt = CreateObject("roBitmap", {width:30, height:30, AlphaEnable: true })
+    screen.DrawScaledObject(0, 300, 0.3, 0.3, bmp)
+    brt = CreateObject("roBitmap", {width: 30, height: 30, AlphaEnable: true})
     brt.Clear(&H00FF00FF)
     screen.DrawObject(0, 0, brt)
-    screen.DrawObject(40,40, rgn)
-    screen.DrawScaledObject(40,40,2,2, rgn)
+    screen.DrawObject(40, 40, rgn)
+    screen.DrawScaledObject(40, 40, 2, 2, rgn)
     DrawBall(screen)
     screen.SwapBuffers()
     bitmap_set = CreateObject("roXMLElement")
-    xmlString = ReadAsciiFile("pkg:/assets/bitmapset.xml")
+    filePath = CacheFile("https://brsfiddle.net/bitmapset.xml", "bitmapset.xml")
+    xmlString = ReadAsciiFile(filePath)
     if not bitmap_set.Parse(xmlString)
         print "dfNewBitmapSet: Error parsing XML"
     end if
@@ -44,7 +47,7 @@ sub main()
     print bitmap_set.getChildElements()
     print bitmap_set.getNamedElements("extrainfo")
     print bitmap_set.genXML(true)
-    a =  [1, "2", 3]
+    a = [1, "2", 3]
     print a
     print a[1]
     b = "4"
@@ -58,6 +61,24 @@ sub main()
 end sub
 
 sub DrawBall(screen as object)
-    ball = CreateObject("roBitmap", "pkg:/images/AmigaBoingBall.png")
-    screen.DrawRotatedObject(200,300,30.0,ball)
+    filePath = CacheFile("https://brsfiddle.net/images/AmigaBoingBall.png", "AmigaBoingBall.png")
+    ball = CreateObject("roBitmap", filePath)
+    screen.DrawTransformedObject(200, 300, 30.0, 0.5, 0.5, ball)
 end sub
+
+function CacheFile(url as string, file as string, overwrite = false as boolean) as string
+    tmpFile = "tmp:/" + file
+    if overwrite or not m.files.Exists(tmpFile)
+        http = CreateObject("roUrlTransfer")
+        http.SetCertificatesFile("common:/certs/ca-bundle.crt")
+        http.SetUrl(url)
+        ret = http.GetToFile(tmpFile)
+        if ret = 200
+            print "CacheFile: "; url; " to "; tmpFile
+        else
+            print "File not cached! http return code: "; ret
+            tmpFile = ""
+        end if
+    end if
+    return tmpFile
+end function


### PR DESCRIPTION
The behavior, when `scaleX` and `scaleY` are not the same value is different from Roku.
- In Roku the object is rotated first, then scaled.
- In brs-engine the object is scaled then rotated.

This will be fixed in a future ticket.