### PR TITLE
Updated CLI app to load the engine as an external library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BrightScript Simulation Engine
 
-An intepreter for the BrightScript language that runs Roku apps on modern browser platforms.
+An intepreter for the BrightScript language that runs Roku apps on browser platforms and Node.js.
 
 ![GitHub](https://img.shields.io/github/license/lvcabral/brs-engine)
 [![NPM Version](https://badge.fury.io/js/brs-engine.svg?style=flat)](https://npmjs.org/package/brs-engine)
@@ -11,9 +11,11 @@ An intepreter for the BrightScript language that runs Roku apps on modern browse
 
 ## The Project
 
-This respository was created as a fork from [**brs**](https://github.com/rokucommunity/brs), a _command line interpreter_ for **BrightScript** language, with the objective of implementing a Roku simulator, an important tool that was missing for the **Roku** development community.
+The **BrightScript Simulation Engine** implements an interpreter for the **BrightScript** language, that can be embedded in Web, Electron and Node.js applications, allowing [Roku apps](https://developer.roku.com/overview) to be executed in several different non-Roku platforms.
 
 Initially the focus was on the **Draw 2D API** components (`roScreen`, `roCompositor`, `roRegion`, etc.) along with the core elements of the **BrightScript** language, allowing a full Roku app execution over an **HTML5 Canvas**, but it was extended to include simulation of the **Roku** file system, registry, remote control and the Micro Debugger.
+
+This repository was originally a fork from [**brs**](https://github.com/rokucommunity/brs), a **BrightScript** _command line interpreter_.
 
 **Important Notes:**
 
@@ -28,9 +30,10 @@ The **brs-engine** is developed in [TypeScript](https://www.typescriptlang.org/)
 
 | Library File | Description |
 | --- | --- |
-| `app/lib/brs.api.js` | Provides the **[Engine API](docs/engine-api.md)** to be imported and used by the client applications hosting the Simulator.|
+| `app/lib/brs.api.js` | Provides the **[Engine API](docs/engine-api.md)** to be imported and used by the Web applications hosting the Simulator.|
 | `app/lib/brs.worker.js` | A **[Web Worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers)** library that runs the language parser and interpreter in a background thread on the browser platform.|
 |`bin/brs.cli.js`| Executable **[CLI](docs/run-as-cli.md)** application that can be used from the terminal: <br/>- As a language shell - [REPL (read-eval-print loop)](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop)<br/>- Executing `brs`, `zip` or `bpk` files<br/>- Packaging `zip` files into encrypted `bpk` packages.|
+|`bin/brs.node.js`| A NodeJS library, similar to `brs.worker.js` that exposes the language parser and interpreter to be used by Node.js applications, the engine CLI and automated tests.|
 |`bin/brs.ecp.js`| A **[NodeJS Worker](https://nodejs.org/api/worker_threads.html)** library, used by the CLI to launch the ECP and SSDP services.|
 
 The Web Worker library require features like [SharedArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) and [OffScreenCanvas](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas), that are _relatively recent_ in the browser engines, because of that, it can only be executed on recent versions of:

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -24,16 +24,10 @@ import {
     getSerialNumber,
 } from "../api/package";
 import { isNumber } from "../api/util";
-import {
-    registerCallback,
-    getInterpreter,
-    getFonts,
-    executeLine,
-    executeFile,
-    createPayload,
-} from "../worker";
 import { debugPrompt, dataBufferIndex, dataBufferSize } from "../worker/common";
 import packageInfo from "../../package.json";
+// @ts-ignore
+import * as brs from './brs.node.js';
 
 // Constants
 const program = new Command();
@@ -93,14 +87,14 @@ program
             deviceData.deviceModel = "4400X";
             deviceData.customFeatures.push("ascii_rendering");
             deviceData.fontPath = "../app/fonts";
-            deviceData.fonts = getFonts(deviceData.fontPath, deviceData.defaultFont);
+            deviceData.fonts = brs.getFonts(deviceData.fontPath, deviceData.defaultFont);
             deviceData.localIps = getLocalIps();
             if (program.registry) {
                 deviceData.registry = getRegistry();
             }
         }
         subscribePackage("cli", packageCallback);
-        registerCallback(messageCallback, sharedBuffer);
+        brs.registerCallback(messageCallback, sharedBuffer);
         if (brsFiles.length > 0) {
             try {
                 // Run App Zip file
@@ -119,7 +113,7 @@ program
                     return;
                 }
                 // Run BrightScript files
-                const payload = createPayload(brsFiles);
+                const payload = brs.createPayload(brsFiles);
                 runApp(payload);
             } catch (err: any) {
                 if (err.messages?.length) {
@@ -177,7 +171,7 @@ function runApp(payload: any) {
         brsWorker.postMessage(sharedBuffer);
         return;
     }
-    const pkg = executeFile(payload);
+    const pkg = brs.executeFile(payload);
     if (program.ecp) {
         brsWorker?.terminate();
     }
@@ -265,7 +259,7 @@ function getRegistry(): Map<string, string> {
  * **NOTE:** Currently limited to single-line inputs :(
  */
 function repl() {
-    const replInterpreter = getInterpreter({ device: deviceData });
+    const replInterpreter = brs.getInterpreter({ device: deviceData });
     const rl = readline.createInterface({
         input: process.stdin,
         output: process.stdout,
@@ -285,7 +279,7 @@ function repl() {
             );
             process.stdout.write("\n");
         } else {
-            executeLine(line, replInterpreter);
+            brs.executeLine(line, replInterpreter);
         }
         rl.prompt();
     });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -27,7 +27,7 @@ import { isNumber } from "../api/util";
 import { debugPrompt, dataBufferIndex, dataBufferSize } from "../worker/common";
 import packageInfo from "../../package.json";
 // @ts-ignore
-import * as brs from './brs.node.js';
+import * as brs from "./brs.node.js";
 
 // Constants
 const program = new Command();

--- a/webpack.cli.config.js
+++ b/webpack.cli.config.js
@@ -57,7 +57,8 @@ module.exports = (env) => {
                 new ShebangPlugin(),
             ],
             externals: {
-                canvas: "commonjs canvas" // Important (2)
+                "./brs.node.js": "commonjs ./brs.node.js",
+                canvas: "commonjs canvas"
             },
             output: {
                 filename: libName + ".cli.js",


### PR DESCRIPTION
In order to the unit tests to be executed, was necessary to create a NodeJS library with the interpreter.
This PR reuses this library in the CLI, avoiding to build the whole engine inside the CLI js file.