### PR TITLE
Fixed loading fonts on CLI when running `.brs` files

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -113,7 +113,7 @@ program
                     return;
                 }
                 // Run BrightScript files
-                const payload = brs.createPayload(brsFiles);
+                const payload = brs.createPayload(brsFiles, deviceData);
                 runApp(payload);
             } catch (err: any) {
                 if (err.messages?.length) {


### PR DESCRIPTION
The deviceData is not shared with the library code anymore, as it is a separate file, so we have to pass on createPayload