### PR TITLE
Fixed issue that was not restoring the environment in Try mode when `stopOnCrash` was enabled

### DIFF
--- a/src/worker/interpreter/index.ts
+++ b/src/worker/interpreter/index.ts
@@ -239,7 +239,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
             this._environment = originalEnvironment;
             return returnValue;
         } catch (err: any) {
-            if (this.options.stopOnCrash && !(err instanceof Stmt.BlockEnd)) {
+            if (!this._tryMode && this.options.stopOnCrash && !(err instanceof Stmt.BlockEnd)) {
                 // Keep environment for Micro Debugger in case of a crash
                 originalEnvironment = this._environment;
             }


### PR DESCRIPTION
This was a side-effect of using the flag `._tryMode`