### PR TITLE
Fixed Critical bug with `formatJson` #383

### DIFF
--- a/test/e2e/StdLib.test.js
+++ b/test/e2e/StdLib.test.js
@@ -134,6 +134,17 @@ describe("end to end standard libary", () => {
         ]);
     });
 
+    test("stdlib/nested-array-formatjson.brs", async () => {
+        await execute([resourceFile("stdlib", "nested-array-formatjson.brs")], outputStreams);
+
+        expect(allArgs(outputStreams.stdout.write).map((arg) => arg.trimEnd())).toEqual([
+            `["Array A",["Array B",["Array C"]],["Array C"]]`,
+            "",
+        ]);
+        let errOutput = allArgs(outputStreams.stderr.write).filter((arg) => arg !== "\n");
+        expect(errOutput[0].includes("FormatJSON: Nested object reference")).toBeTruthy();
+    });
+
     test("stdlib/run.brs", async () => {
         await execute([resourceFile("stdlib", "run.brs")], outputStreams);
 

--- a/test/e2e/resources/stdlib/nested-array-formatjson.brs
+++ b/test/e2e/resources/stdlib/nested-array-formatjson.brs
@@ -1,0 +1,13 @@
+function main()
+	a = ["Array A"]
+	b = ["Array B"]
+	c = ["Array C"]
+	a.push(b)
+	a.push(c)
+	b.push(c)
+	'Should print: ["Array A",["Array B",["Array C"]],["Array C"]]
+	print formatJson(a)
+	'Should fail : BRIGHTSCRIPT: ERROR: FormatJSON: Nested object reference
+	c.push(a)
+	print formatJson(a)
+end function


### PR DESCRIPTION
The code was checking for circular reference, but was not allowing any re-use on object nesting. 
Changed to rely on Javascript stack, we detect the circular reference when a `RangeError` occurs.
Added an e2e test for the scenario.