### PR TITLE
Fix File System when using `root` or `ext` CLI flags and running on Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -20,10 +20,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-
-    - name: Install Homebrew packages
-      run: |
-        brew install pango jpeg librsvg
 
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3

--- a/src/core/brsTypes/components/RoFileSystem.ts
+++ b/src/core/brsTypes/components/RoFileSystem.ts
@@ -76,6 +76,9 @@ export class RoFileSystem extends BrsComponent implements BrsValue {
                 const volumes = fsys.volumesSync().map((s) => new BrsString(s));
                 return new RoList(volumes);
             } catch (err: any) {
+                if (interpreter.isDevMode) {
+                    interpreter.stderr.write(`warning,roFileSystem.getVolumeList: ${err.message}`);
+                }
                 return new RoList([]);
             }
         },
@@ -110,6 +113,11 @@ export class RoFileSystem extends BrsComponent implements BrsValue {
                     return new RoList(subPaths);
                 }
             } catch (err: any) {
+                if (interpreter.isDevMode) {
+                    interpreter.stderr.write(
+                        `warning,roFileSystem.getDirectoryListing: ${err.message}`
+                    );
+                }
                 return new RoList([]);
             }
             return new RoList([]);
@@ -131,6 +139,11 @@ export class RoFileSystem extends BrsComponent implements BrsValue {
                 fsys.mkdirSync(pathArg.value);
                 return BrsBoolean.True;
             } catch (err: any) {
+                if (interpreter.isDevMode) {
+                    interpreter.stderr.write(
+                        `warning,roFileSystem.createDirectory: ${err.message}`
+                    );
+                }
                 return BrsBoolean.False;
             }
         },
@@ -154,6 +167,9 @@ export class RoFileSystem extends BrsComponent implements BrsValue {
                 }
                 return BrsBoolean.True;
             } catch (err: any) {
+                if (interpreter.isDevMode) {
+                    interpreter.stderr.write(`warning,roFileSystem.delete: ${err.message}`);
+                }
                 return BrsBoolean.False;
             }
         },
@@ -178,6 +194,9 @@ export class RoFileSystem extends BrsComponent implements BrsValue {
                 fsys.writeFileSync(toPath.value, content);
                 return BrsBoolean.True;
             } catch (err: any) {
+                if (interpreter.isDevMode) {
+                    interpreter.stderr.write(`warning,roFileSystem.copyFile: ${err.message}`);
+                }
                 return BrsBoolean.False;
             }
         },
@@ -206,6 +225,9 @@ export class RoFileSystem extends BrsComponent implements BrsValue {
                 fsys.renameSync(fromPath.value, toPath.value);
                 return BrsBoolean.True;
             } catch (err: any) {
+                if (interpreter.isDevMode) {
+                    interpreter.stderr.write(`warning,roFileSystem.rename: ${err.message}`);
+                }
                 return BrsBoolean.False;
             }
         },
@@ -222,6 +244,9 @@ export class RoFileSystem extends BrsComponent implements BrsValue {
                 const fsys = interpreter.fileSystem;
                 return BrsBoolean.from(fsys.existsSync(pathArg.value));
             } catch (err: any) {
+                if (interpreter.isDevMode) {
+                    interpreter.stderr.write(`warning,roFileSystem.exists: ${err.message}`);
+                }
                 return BrsBoolean.False;
             }
         },
@@ -252,6 +277,9 @@ export class RoFileSystem extends BrsComponent implements BrsValue {
                 });
                 return new RoList(matchedFiles);
             } catch (err: any) {
+                if (interpreter.isDevMode) {
+                    interpreter.stderr.write(`warning,roFileSystem.find: ${err.message}`);
+                }
                 return new RoList([]);
             }
         },
@@ -275,6 +303,9 @@ export class RoFileSystem extends BrsComponent implements BrsValue {
                 }
                 return new RoList(this.findOnTree(fsys, jsRegex, pathArg.value));
             } catch (err: any) {
+                if (interpreter.isDevMode) {
+                    interpreter.stderr.write(`warning,roFileSystem.findRecurse: ${err.message}`);
+                }
                 return new RoList([]);
             }
         },
@@ -306,6 +337,9 @@ export class RoFileSystem extends BrsComponent implements BrsValue {
 
                 return new RoList(matchedFiles);
             } catch (err: any) {
+                if (interpreter.isDevMode) {
+                    interpreter.stderr.write(`warning,roFileSystem.match: ${err.message}`);
+                }
                 return new RoList([]);
             }
         },
@@ -337,9 +371,7 @@ export class RoFileSystem extends BrsComponent implements BrsValue {
                 result.permissions = perm;
             } catch (err: any) {
                 if (interpreter.isDevMode) {
-                    interpreter.stderr.write(
-                        `warning,roFileSystem.stat: Error parsing status: ${err.message}`
-                    );
+                    interpreter.stderr.write(`warning,roFileSystem.stat: ${err.message}`);
                 }
             }
             return toAssociativeArray(result);

--- a/src/core/interpreter/FileSystem.ts
+++ b/src/core/interpreter/FileSystem.ts
@@ -61,18 +61,13 @@ export class FileSystem {
 
     getPath(uri: string) {
         if (this.root && uri.trim().toLowerCase().startsWith("pkg:")) {
-            uri = uri
-                .trim()
-                .toLowerCase()
-                .replace("pkg:", this.root + "/");
+            uri = this.root + "/" + uri.trim().slice(4);
         } else if (this.ext && uri.trim().toLowerCase().startsWith("ext1:")) {
-            uri = uri
-                .trim()
-                .toLowerCase()
-                .replace("ext1:", this.ext + "/");
+            uri = this.ext + "/" + uri.trim().slice(5);
+        } else {
+            uri = uri.toLowerCase();
         }
         return uri
-            .toLowerCase()
             .replace("tmp:", "")
             .replace("cachefs:", "")
             .replace("common:", "")

--- a/src/core/stdlib/File.ts
+++ b/src/core/stdlib/File.ts
@@ -22,6 +22,11 @@ export const CopyFile = new Callable("CopyFile", {
             fsys.writeFileSync(dst.value, content);
             return BrsBoolean.True;
         } catch (err: any) {
+            if (interpreter.isDevMode) {
+                interpreter.stderr.write(
+                    `warning,*** ERROR: Copying '${src.value}' to '${dst.value}': ${err.message}`
+                );
+            }
             return BrsBoolean.False;
         }
     },
@@ -50,6 +55,11 @@ export const MoveFile = new Callable("MoveFile", {
             fsys.renameSync(src.value, dst.value);
             return BrsBoolean.True;
         } catch (err: any) {
+            if (interpreter.isDevMode) {
+                interpreter.stderr.write(
+                    `warning,*** ERROR: Moving '${src.value}' to '${dst.value}': ${err.message}`
+                );
+            }
             return BrsBoolean.False;
         }
     },
@@ -70,6 +80,11 @@ export const DeleteFile = new Callable("DeleteFile", {
             fsys.unlinkSync(file.value);
             return BrsBoolean.True;
         } catch (err: any) {
+            if (interpreter.isDevMode) {
+                interpreter.stderr.write(
+                    `warning,*** ERROR: Deleting '${file.value}': ${err.message}`
+                );
+            }
             return BrsBoolean.False;
         }
     },
@@ -90,6 +105,11 @@ export const DeleteDirectory = new Callable("DeleteDirectory", {
             fsys.rmdirSync(dir.value);
             return BrsBoolean.True;
         } catch (err: any) {
+            if (interpreter.isDevMode) {
+                interpreter.stderr.write(
+                    `warning,*** ERROR: Deleting '${dir.value}': ${err.message}`
+                );
+            }
             return BrsBoolean.False;
         }
     },
@@ -110,6 +130,11 @@ export const CreateDirectory = new Callable("CreateDirectory", {
             fsys.mkdirSync(dir.value);
             return BrsBoolean.True;
         } catch (err: any) {
+            if (interpreter.isDevMode) {
+                interpreter.stderr.write(
+                    `warning,*** ERROR: Creating '${dir.value}': ${err.message}`
+                );
+            }
             return BrsBoolean.False;
         }
     },
@@ -150,7 +175,11 @@ export const ListDir = new Callable("ListDir", {
                 return new RoList(subPaths);
             }
         } catch (err: any) {
-            interpreter.stderr.write(`warning,*** ERROR: Listing '${dir.value}': ${err.message}`);
+            if (interpreter.isDevMode) {
+                interpreter.stderr.write(
+                    `warning,*** ERROR: Listing '${dir.value}': ${err.message}`
+                );
+            }
         }
         return new RoList([]);
     },
@@ -162,14 +191,19 @@ export const ReadAsciiFile = new Callable("ReadAsciiFile", {
         args: [new StdlibArgument("filepath", ValueKind.String)],
         returns: ValueKind.String,
     },
-    impl: (interpreter: Interpreter, filepath: BrsString) => {
+    impl: (interpreter: Interpreter, filePath: BrsString) => {
         const fsys = interpreter.fileSystem;
         try {
-            if (!validUri(filepath.value)) {
+            if (!validUri(filePath.value)) {
                 return new BrsString("");
             }
-            return new BrsString(fsys.readFileSync(filepath.value, "utf8"));
+            return new BrsString(fsys.readFileSync(filePath.value, "utf8"));
         } catch (err: any) {
+            if (interpreter.isDevMode) {
+                interpreter.stderr.write(
+                    `warning,*** ERROR: Reading '${filePath.value}': ${err.message}`
+                );
+            }
             return new BrsString("");
         }
     },
@@ -193,6 +227,11 @@ export const WriteAsciiFile = new Callable("WriteAsciiFile", {
             fsys.writeFileSync(filePath.value, text.value, "utf8");
             return BrsBoolean.True;
         } catch (err: any) {
+            if (interpreter.isDevMode) {
+                interpreter.stderr.write(
+                    `warning,*** ERROR: Writing '${filePath.value}': ${err.message}`
+                );
+            }
             return BrsBoolean.False;
         }
     },
@@ -225,6 +264,11 @@ export const MatchFiles = new Callable("MatchFiles", {
 
             return new RoList(matchedFiles);
         } catch (err: any) {
+            if (interpreter.isDevMode) {
+                interpreter.stderr.write(
+                    `warning,*** ERROR: Matching '${pathArg.value}' with '${patternIn.value}': ${err.message}`
+                );
+            }
             return new RoList([]);
         }
     },


### PR DESCRIPTION
Because Linux file system is case sensitive, using the flags `root` and `ext` was preventing access files with mixed case in their names.