### PR TITLE
Fixed runtime error stack trace on Callables

### DIFF
--- a/src/core/interpreter/BrsFunction.ts
+++ b/src/core/interpreter/BrsFunction.ts
@@ -38,7 +38,11 @@ export function toCallable(func: Expr.Function, name: string = "[Function]") {
             }
             if (interpreter.environment.gotoLabel !== "") {
                 interpreter.addError(
-                    new RuntimeError(RuntimeErrorDetail.MissingLineNumber, location)
+                    new RuntimeError(
+                        RuntimeErrorDetail.MissingLineNumber,
+                        location,
+                        interpreter.stack.slice(0, -1)
+                    )
                 );
             }
             return BrsInvalid.Instance;

--- a/src/core/stdlib/CreateObject.ts
+++ b/src/core/stdlib/CreateObject.ts
@@ -40,7 +40,11 @@ export const CreateObject = new Callable("CreateObject", {
                 return BrsInvalid.Instance;
             } else if (minParams >= 0 && additionalArgs.length !== minParams) {
                 interpreter.addError(
-                    new RuntimeError(RuntimeErrorDetail.RoWrongNumberOfParams, interpreter.location)
+                    new RuntimeError(
+                        RuntimeErrorDetail.RoWrongNumberOfParams,
+                        interpreter.location,
+                        interpreter.stack.slice(0, -1)
+                    )
                 );
             }
             try {

--- a/src/core/stdlib/GlobalUtilities.ts
+++ b/src/core/stdlib/GlobalUtilities.ts
@@ -117,7 +117,11 @@ export const ObjFun = new Callable("ObjFun", {
             }
         }
         interpreter.addError(
-            new RuntimeError(RuntimeErrorDetail.MemberFunctionNotFound, interpreter.location)
+            new RuntimeError(
+                RuntimeErrorDetail.MemberFunctionNotFound,
+                interpreter.location,
+                interpreter.stack.slice(0, -1)
+            )
         );
     },
 });

--- a/src/core/stdlib/Math.ts
+++ b/src/core/stdlib/Math.ts
@@ -48,7 +48,11 @@ export const Cint = new Callable("Cint", {
             return toInt32(x, "round");
         }
         interpreter.addError(
-            new RuntimeError(RuntimeErrorDetail.TypeMismatch, interpreter.location)
+            new RuntimeError(
+                RuntimeErrorDetail.TypeMismatch,
+                interpreter.location,
+                interpreter.stack.slice(0, -1)
+            )
         );
     },
 });
@@ -76,7 +80,11 @@ export const Fix = new Callable("Fix", {
             return toInt32(x, "trunc");
         }
         interpreter.addError(
-            new RuntimeError(RuntimeErrorDetail.TypeMismatch, interpreter.location)
+            new RuntimeError(
+                RuntimeErrorDetail.TypeMismatch,
+                interpreter.location,
+                interpreter.stack.slice(0, -1)
+            )
         );
     },
 });
@@ -95,7 +103,11 @@ export const Int = new Callable("Int", {
             return toInt32(x);
         }
         interpreter.addError(
-            new RuntimeError(RuntimeErrorDetail.TypeMismatch, interpreter.location)
+            new RuntimeError(
+                RuntimeErrorDetail.TypeMismatch,
+                interpreter.location,
+                interpreter.stack.slice(0, -1)
+            )
         );
     },
 });


### PR DESCRIPTION
The stack trace was including the callable function and that is internal to the interpreter.