### PR TITLE
Made `ifToStr` to handle components that do not support `format`

### DIFF
--- a/src/core/brsTypes/Callable.ts
+++ b/src/core/brsTypes/Callable.ts
@@ -201,7 +201,7 @@ export class Callable implements Brs.BrsValue, Brs.Boxable {
     constructor(name: string | undefined, ...signatures: SignatureAndImplementation[]) {
         this.name = name;
         this.signatures = signatures;
-        if (!this.name || this.name === "[Function]") {
+        if (this.signatures.length && (!this.name || this.name === "[Function]")) {
             this.name = `$anon_${++anonCounter}`;
         }
     }
@@ -219,7 +219,7 @@ export class Callable implements Brs.BrsValue, Brs.Boxable {
     }
 
     toString(parent?: Brs.BrsType): string {
-        return `<Function: ${this.name?.toLowerCase()}>`;
+        return `<Function: ${this.name?.toLowerCase() ?? "UNDEFINED"}>`;
     }
 
     box() {

--- a/src/core/brsTypes/components/RoFunction.ts
+++ b/src/core/brsTypes/components/RoFunction.ts
@@ -17,10 +17,10 @@ export class RoFunction extends BrsComponent implements BrsValue, Unboxable {
     constructor(sub: Callable) {
         super("roFunction");
 
-        this.intrinsic = sub;
+        this.intrinsic = sub ?? new Callable(undefined);
         this.registerMethods({
             ifFunction: [this.getSub, this.setSub],
-            ifToStr: [new IfToStr(this).toStr],
+            ifToStr: [new IfToStr(this, /[<>]/g).toStr],
         });
     }
 
@@ -33,7 +33,7 @@ export class RoFunction extends BrsComponent implements BrsValue, Unboxable {
     }
 
     toString(_parent?: BrsType): string {
-        return this.intrinsic.toString().replace(/[<>]/g, "");
+        return this.intrinsic.toString();
     }
 
     private readonly getSub = new Callable("getSub", {

--- a/src/core/brsTypes/components/RoInvalid.ts
+++ b/src/core/brsTypes/components/RoInvalid.ts
@@ -2,6 +2,7 @@ import { BrsComponent } from "./BrsComponent";
 import { BrsValue, ValueKind, BrsBoolean, BrsInvalid } from "../BrsType";
 import { BrsType } from "..";
 import { Unboxable } from "../Boxing";
+import { IfToStr } from "../interfaces/IfToStr";
 
 export class RoInvalid extends BrsComponent implements BrsValue, Unboxable {
     readonly kind = ValueKind.Object;
@@ -15,6 +16,9 @@ export class RoInvalid extends BrsComponent implements BrsValue, Unboxable {
         super("roInvalid");
 
         this.intrinsic = BrsInvalid.Instance;
+        this.registerMethods({
+            ifToStr: [new IfToStr(this).toStr],
+        });
     }
 
     unbox() {

--- a/test/simulator/check-ifToStr.brs
+++ b/test/simulator/check-ifToStr.brs
@@ -1,0 +1,38 @@
+sub main()
+	obj = CreateObject("roBoolean")
+	print obj
+	print obj.toStr()
+	print "fail in Roku: Member function not found"' obj.toStr("%s")
+	obj = CreateObject("roDouble")
+	print obj
+	print obj.toStr()
+	print obj.toStr("%.1f")
+	obj = CreateObject("roFloat")
+	print obj
+	print obj.toStr()
+	print obj.toStr("%.1f")
+	obj = CreateObject("roFunction")
+	print obj
+	print obj.toStr()
+	print main
+	print main.toStr()
+	print "fail in Roku: Member function not found"' obj.toStr("%s")
+	obj = CreateObject("roInt")
+	print obj
+	print obj.toStr()
+	print obj.toStr("%.1f")
+	obj = CreateObject("roInvalid")
+	print obj
+	print obj.toStr()
+	print "fail in Roku: Dot operator in invalid"' obj.toStr("%s")
+	print invalid.toStr()
+	obj = CreateObject("roLongInteger")
+	print obj
+	print obj.toStr()
+	print obj.toStr("%.1f")
+	obj = CreateObject("roString")
+	obj.setString("test")
+	print obj
+	print obj.toStr()
+	print obj.toStr("%.3s")
+end sub

--- a/yarn.lock
+++ b/yarn.lock
@@ -6565,7 +6565,7 @@ split-string@^3.0.1:
 
 sprintf-js@lvcabral/sprintf.js:
   version "1.1.3"
-  resolved "https://codeload.github.com/lvcabral/sprintf.js/tar.gz/18edaf03dabe43367a041532229e73c0b18913b4"
+  resolved "https://codeload.github.com/lvcabral/sprintf.js/tar.gz/107a4c95817dd684157e07611e1d4b63f1685011"
 
 sprintf-js@~1.0.2:
   version "1.0.3"


### PR DESCRIPTION
The `toStr(format)` signature is only supported on numeric types and string, raised an exception when used on other components. Also fixed the output for `roInvalid` and `roFunction`, and `g` type handling of zero.