### PR TITLE
Fixed `roVideoPlayer` method `getAudioTracks`

### DIFF
--- a/src/core/brsTypes/components/RoVideoPlayer.ts
+++ b/src/core/brsTypes/components/RoVideoPlayer.ts
@@ -413,7 +413,11 @@ export class RoVideoPlayer extends BrsComponent implements BrsValue {
             if (this.audioTracks.length) {
                 this.audioTracks.forEach((track, index) => {
                     if (track instanceof Array && track.length === 3) {
-                        const item = { Track: track[0], Language: track[1], Name: track[2] };
+                        const item = {
+                            Track: track[0].toString(),
+                            Language: track[1],
+                            Name: track[2],
+                        };
                         result.push(toAssociativeArray(item));
                     }
                 });

--- a/test/simulator/hls-video-test.brs
+++ b/test/simulator/hls-video-test.brs
@@ -48,7 +48,7 @@ sub main()
                 print position
             else if type(msg) = "roVideoPlayerEvent" and msg.isStreamStarted()
                 tracks = player.getAudioTracks()
-                print tracks.count(); " audio tracks available."
+                print tracks.count(); " audio tracks available.", tracks[currAudioTrack]
             else if type(msg) = "roSystemLogEvent"
                 logEvent = msg.getInfo()
                 if logEvent.logType = "bandwidth.minute"


### PR DESCRIPTION
The method `getAudioTracks` was returning the property track as Integer not String.