### PR TITLE
Implemented mocked `roStreamSocket` component

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -50,6 +50,7 @@ module.exports = (env) => {
                 fallback: {
                     fs: false,
                     readline: false,
+                    net: false,
                     crypto: require.resolve("crypto-browserify"),
                     path: require.resolve("path-browserify"),
                     stream: require.resolve("stream-browserify"),

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -13,8 +13,6 @@ There are several features from the **BrightScript** language and components tha
   * `roHttpAgent`
   * `roMicrophone`
   * `roRSA`
-  * `roSocketAddress`
-  * `roStreamSocket`
   * `roTextToSpeech`
   * `roTextureManager`
   * `roTextureRequest`
@@ -39,7 +37,8 @@ There are several features from the **BrightScript** language and components tha
   * The following methods are also only mocked but do nothing: `EnableResume`, `SetHttpVersion` and `SetMinimumTransferRate`.
 * The component `roAppMemoryMonitor` will only return measured data in Node.JS and Chromium browsers. For browsers the memory heap info only accounts for the main thread, as WebWorkers do not have support for `performance.memory` API.
 * The `roInput` deep link events are supported, but the events related to Voice Commands are not.
-* The `roFileSystem` events are not yet implemented.
+* The `roFileSystem` is fully functional, but the message port events are not yet implemented.
+* The `roStreamSocket` component is mocked, was only implemented to prevent crash on apps that references it.
 * The global functions `Eval()`, `GetLastRunCompileError()` and `GetLastRunRuntimeError()` are not available.
 * The string `mod` cannot be used as variable or function parameter name, because it conflicts with remainder operator `Mod` (Roku devices allows that).
 * SDK 1.0 deprecated components are not supported, but will be implemented in the future as a legacy apps preservation initiative.

--- a/src/core/brsTypes/components/BrsObjects.ts
+++ b/src/core/brsTypes/components/BrsObjects.ts
@@ -54,6 +54,7 @@ import { Callable } from "../Callable";
 import { RoNDK } from "./RoNDK";
 import { RoCECStatus } from "./RoCECStatus";
 import { RoSocketAddress } from "./RoSocketAddress";
+import { RoStreamSocket } from "./RoStreamSocket";
 
 // Class to define a case-insensitive map of BrightScript objects.
 class BrsObjectsMap {
@@ -198,4 +199,5 @@ export const BrsObjects = new BrsObjectsMap([
     ["roNDK", (_: Interpreter) => new RoNDK()],
     ["roCECStatus", (interpreter: Interpreter) => new RoCECStatus(interpreter)],
     ["roSocketAddress", (interpreter: Interpreter) => new RoSocketAddress(interpreter)],
+    ["roStreamSocket", (interpreter: Interpreter) => new RoStreamSocket(interpreter)],
 ]);

--- a/src/core/brsTypes/components/RoStreamSocket.ts
+++ b/src/core/brsTypes/components/RoStreamSocket.ts
@@ -1,0 +1,531 @@
+import {
+    Callable,
+    ValueKind,
+    BrsString,
+    StdlibArgument,
+    BrsBoolean,
+    BrsType,
+    BrsComponent,
+    BrsValue,
+    Int32,
+    RoSocketAddress,
+    BrsInvalid,
+    Uninitialized,
+    RoByteArray,
+} from "..";
+import { Interpreter } from "../../interpreter";
+import { IfGetMessagePort, IfSetMessagePort } from "../interfaces/IfMessagePort";
+import * as net from "net";
+
+export class RoStreamSocket extends BrsComponent implements BrsValue {
+    readonly kind = ValueKind.Object;
+    private readonly interpreter: Interpreter;
+    private identity: number;
+    private socket?: net.Socket;
+    private address?: RoSocketAddress;
+    private sendToAddress?: RoSocketAddress;
+    private errorCode: number;
+
+    constructor(interpreter: Interpreter) {
+        super("roStreamSocket");
+        this.interpreter = interpreter;
+        try {
+            this.socket = new net.Socket();
+            this.errorCode = 0;
+        } catch (err: any) {
+            interpreter.stderr.write(
+                `warning,[roStreamSocket] Sockets are not supported in this environment.`
+            );
+            this.errorCode = 3474;
+        }
+        this.identity = generateUniqueId();
+        const setPortIface = new IfSetMessagePort(this);
+        const getPortIface = new IfGetMessagePort(this);
+        this.registerMethods({
+            ifSocket: [
+                this.send,
+                this.sendStr,
+                this.receive,
+                this.receiveStr,
+                this.close,
+                this.setAddress,
+                this.getAddress,
+                this.setSendToAddress,
+                this.getSendToAddress,
+                this.getReceivedFromAddress,
+                this.getCountRcvBuf,
+                this.getCountSendBuf,
+                this.status,
+            ],
+            ifSocketConnection: [
+                this.listen,
+                this.isListening,
+                this.connect,
+                this.accept,
+                this.isConnected,
+            ],
+            ifSocketAsync: [
+                this.isReadable,
+                this.isWritable,
+                this.isException,
+                this.notifyReadable,
+                this.notifyWritable,
+                this.notifyException,
+                this.getID,
+            ],
+            ifSocketStatus: [
+                this.eAgain,
+                this.eAlready,
+                this.eBadAddr,
+                this.eDestAddrReq,
+                this.eHostUnreach,
+                this.eInvalid,
+                this.eInProgress,
+                this.eWouldBlock,
+                this.eSuccess,
+                this.eOK,
+            ],
+            ifSetMessagePort: [setPortIface.setMessagePort],
+            ifGetMessagePort: [getPortIface.getMessagePort],
+        });
+    }
+
+    toString(parent?: BrsType): string {
+        return "<Component: roStreamSocket  >";
+    }
+
+    equalTo(other: BrsType): BrsBoolean {
+        return BrsBoolean.False;
+    }
+
+    /** Sends up to length bytes of data to the socket. */
+    private readonly send = new Callable("send", {
+        signature: {
+            args: [
+                new StdlibArgument("data", ValueKind.Object),
+                new StdlibArgument("startIndex", ValueKind.Int32),
+                new StdlibArgument("length", ValueKind.Int32),
+            ],
+            returns: ValueKind.Int32,
+        },
+        impl: (_: Interpreter, data: RoByteArray, startIndex: Int32, length: Int32) => {
+            try {
+                const sent = this.socket?.write(data.getByteArray());
+                return new Int32(sent ? data.getElements().length : 0);
+            } catch (err) {
+                return new Int32(0);
+            }
+        },
+    });
+
+    /** Sends the whole string to the socket, if possible. */
+    private readonly sendStr = new Callable("sendStr", {
+        signature: {
+            args: [new StdlibArgument("data", ValueKind.String)],
+            returns: ValueKind.Int32,
+        },
+        impl: (_: Interpreter, data: BrsString) => {
+            try {
+                const sent = this.socket?.write(data.value);
+                return new Int32(sent ? data.value.length : 0);
+            } catch (err) {
+                return new Int32(0);
+            }
+        },
+    });
+
+    /** Reads data from the socket. */
+    private readonly receive = new Callable("receive", {
+        signature: {
+            args: [
+                new StdlibArgument("data", ValueKind.Object),
+                new StdlibArgument("startIndex", ValueKind.Int32),
+                new StdlibArgument("length", ValueKind.Int32),
+            ],
+            returns: ValueKind.Int32,
+        },
+        impl: (_: Interpreter, data: RoByteArray, startIndex: Int32, length: Int32) => {
+            let buffer = Buffer.alloc(length.getValue());
+            try {
+                buffer = this.socket?.read(length.getValue()) ?? Buffer.alloc(0);
+                return new Int32(buffer.length);
+            } catch (err) {
+                return new Int32(0);
+            }
+        },
+    });
+
+    /** Reads data from the socket and stores the result in a string. */
+    private readonly receiveStr = new Callable("receiveStr", {
+        signature: {
+            args: [new StdlibArgument("length", ValueKind.Int32)],
+            returns: ValueKind.Int32,
+        },
+        impl: (_: Interpreter, length: Int32) => {
+            const str = this.socket?.read(length.getValue()) ?? "";
+            return new Int32(str.length);
+        },
+    });
+
+    /** Closes the socket */
+    private readonly close = new Callable("close", {
+        signature: {
+            args: [],
+            returns: ValueKind.Void,
+        },
+        impl: (_: Interpreter) => {
+            this.socket?.end();
+            return Uninitialized.Instance;
+        },
+    });
+
+    /** Sets the address for the socket */
+    private readonly setAddress = new Callable("setAddress", {
+        signature: {
+            args: [new StdlibArgument("sockAddr", ValueKind.Object)],
+            returns: ValueKind.Boolean,
+        },
+        impl: (_: Interpreter, sockAddr: RoSocketAddress) => {
+            this.address = sockAddr;
+            return BrsBoolean.True;
+        },
+    });
+
+    /** Returns the port. */
+    private readonly getAddress = new Callable("getAddress", {
+        signature: {
+            args: [],
+            returns: ValueKind.Object,
+        },
+        impl: (_: Interpreter) => {
+            return this.address ?? BrsInvalid.Instance;
+        },
+    });
+
+    /** Sets the send-to address for the socket */
+    private readonly setSendToAddress = new Callable("setSendToAddress", {
+        signature: {
+            args: [new StdlibArgument("sockAddr", ValueKind.Object)],
+            returns: ValueKind.Void,
+        },
+        impl: (_: Interpreter, sockAddr: RoSocketAddress) => {
+            this.sendToAddress = sockAddr;
+            return BrsInvalid.Instance;
+        },
+    });
+
+    /** Gets the send-to address of the socket */
+    private readonly getSendToAddress = new Callable("getSendToAddress", {
+        signature: {
+            args: [],
+            returns: ValueKind.Object,
+        },
+        impl: (_: Interpreter) => {
+            return this.sendToAddress ?? BrsInvalid.Instance;
+        },
+    });
+
+    /** Returns the roSocketAddress for the remote address of the last message received via the receive() method. */
+    private readonly getReceivedFromAddress = new Callable("getReceivedFromAddress", {
+        signature: {
+            args: [],
+            returns: ValueKind.Object,
+        },
+        impl: (_: Interpreter) => {
+            // Implementation of getReceivedFromAddress method
+            return BrsInvalid.Instance;
+        },
+    });
+
+    /** Gets the count of the receive buffer */
+    private readonly getCountRcvBuf = new Callable("getCountRcvBuf", {
+        signature: {
+            args: [],
+            returns: ValueKind.Int32,
+        },
+        impl: (_: Interpreter) => {
+            // Implementation of getCountRcvBuf method
+            return new Int32(0);
+        },
+    });
+
+    /** Gets the count of the send buffer */
+    private readonly getCountSendBuf = new Callable("getCountSendBuf", {
+        signature: {
+            args: [],
+            returns: ValueKind.Int32,
+        },
+        impl: (_: Interpreter) => {
+            // Implementation of getCountSendBuf method
+            return new Int32(0);
+        },
+    });
+
+    /** Gets the status of the socket */
+    private readonly status = new Callable("status", {
+        signature: {
+            args: [],
+            returns: ValueKind.Int32,
+        },
+        impl: (_: Interpreter) => {
+            return new Int32(this.errorCode);
+        },
+    });
+
+    /** Puts the socket into the listen state. */
+    private readonly listen = new Callable("listen", {
+        signature: {
+            args: [new StdlibArgument("backlog", ValueKind.Int32)],
+            returns: ValueKind.Boolean,
+        },
+        impl: (_: Interpreter, backlog: Int32) => {
+            // Implementation of listen method
+            return BrsBoolean.True;
+        },
+    });
+
+    /** Checks whether if the listen() method has been successfully called on this socket. */
+    private readonly isListening = new Callable("isListening", {
+        signature: {
+            args: [],
+            returns: ValueKind.Boolean,
+        },
+        impl: (_: Interpreter) => {
+            // Implementation of isListening method
+            return BrsBoolean.False;
+        },
+    });
+
+    /** Establishes a connection. */
+    private readonly connect = new Callable("connect", {
+        signature: {
+            args: [new StdlibArgument("address", ValueKind.Object)],
+            returns: ValueKind.Boolean,
+        },
+        impl: (_: Interpreter, address: RoSocketAddress) => {
+            // Implementation of connect method
+            return BrsBoolean.False;
+        },
+    });
+
+    /** Accepts an incoming connection */
+    private readonly accept = new Callable("accept", {
+        signature: {
+            args: [],
+            returns: ValueKind.Object,
+        },
+        impl: (_: Interpreter) => {
+            // Implementation of accept method
+            return BrsInvalid.Instance;
+        },
+    });
+
+    /** Checks if the socket is connected */
+    private readonly isConnected = new Callable("isConnected", {
+        signature: {
+            args: [],
+            returns: ValueKind.Boolean,
+        },
+        impl: (_: Interpreter) => {
+            const connected = !this.socket?.connecting && !this.socket?.destroyed;
+            return BrsBoolean.from(connected);
+        },
+    });
+    /** Checks if the socket is readable */
+    private readonly isReadable = new Callable("isReadable", {
+        signature: {
+            args: [],
+            returns: ValueKind.Boolean,
+        },
+        impl: (_: Interpreter) => {
+            return BrsBoolean.from(this.socket?.readable ?? false);
+        },
+    });
+
+    /** Checks if the socket is writable */
+    private readonly isWritable = new Callable("isWritable", {
+        signature: {
+            args: [],
+            returns: ValueKind.Boolean,
+        },
+        impl: (_: Interpreter) => {
+            return BrsBoolean.from(this.socket?.writable ?? false);
+        },
+    });
+
+    /** Checks if the socket has an exception */
+    private readonly isException = new Callable("isException", {
+        signature: {
+            args: [],
+            returns: ValueKind.Boolean,
+        },
+        impl: (_: Interpreter) => {
+            // Implementation of isException method
+            return BrsBoolean.False;
+        },
+    });
+
+    /** Notifies when the socket is readable */
+    private readonly notifyReadable = new Callable("notifyReadable", {
+        signature: {
+            args: [new StdlibArgument("enable", ValueKind.Boolean)],
+            returns: ValueKind.Void,
+        },
+        impl: (_: Interpreter, enable: BrsBoolean) => {
+            // Implementation of notifyReadable method
+            return Uninitialized.Instance;
+        },
+    });
+
+    /** Notifies when the socket is writable */
+    private readonly notifyWritable = new Callable("notifyWritable", {
+        signature: {
+            args: [new StdlibArgument("enable", ValueKind.Boolean)],
+            returns: ValueKind.Void,
+        },
+        impl: (_: Interpreter, enable: BrsBoolean) => {
+            // Implementation of notifyWritable method
+            return Uninitialized.Instance;
+        },
+    });
+
+    /** Notifies when the socket has an exception */
+    private readonly notifyException = new Callable("notifyException", {
+        signature: {
+            args: [new StdlibArgument("enable", ValueKind.Boolean)],
+            returns: ValueKind.Void,
+        },
+        impl: (_: Interpreter, enable: BrsBoolean) => {
+            // Implementation of notifyException method
+            return Uninitialized.Instance;
+        },
+    });
+
+    /** Gets the ID of the socket */
+    private readonly getID = new Callable("getID", {
+        signature: {
+            args: [],
+            returns: ValueKind.Int32,
+        },
+        impl: (_: Interpreter) => {
+            return new Int32(this.identity);
+        },
+    });
+    /** Returns the EAGAIN status */
+    private readonly eAgain = new Callable("eAgain", {
+        signature: {
+            args: [],
+            returns: ValueKind.Boolean,
+        },
+        impl: (_: Interpreter) => {
+            return BrsBoolean.from(this.errorCode === 11); // EAGAIN error code
+        },
+    });
+
+    /** Returns the EALREADY status */
+    private readonly eAlready = new Callable("eAlready", {
+        signature: {
+            args: [],
+            returns: ValueKind.Boolean,
+        },
+        impl: (_: Interpreter) => {
+            return BrsBoolean.from(this.errorCode === 114); // EALREADY error code
+        },
+    });
+
+    /** Returns the EBADADDR status */
+    private readonly eBadAddr = new Callable("eBadAddr", {
+        signature: {
+            args: [],
+            returns: ValueKind.Boolean,
+        },
+        impl: (_: Interpreter) => {
+            return BrsBoolean.from(this.errorCode === 14); // EBADADDR error code
+        },
+    });
+
+    /** Returns the EDESTADDRREQ status */
+    private readonly eDestAddrReq = new Callable("eDestAddrReq", {
+        signature: {
+            args: [],
+            returns: ValueKind.Boolean,
+        },
+        impl: (_: Interpreter) => {
+            return BrsBoolean.from(this.errorCode === 39); // EDESTADDRREQ error code
+        },
+    });
+
+    /** Returns the EHOSTUNREACH status */
+    private readonly eHostUnreach = new Callable("eHostUnreach", {
+        signature: {
+            args: [],
+            returns: ValueKind.Boolean,
+        },
+        impl: (_: Interpreter) => {
+            return BrsBoolean.from(this.errorCode === 65); // EHOSTUNREACH error code
+        },
+    });
+
+    /** Returns the EINVALID status */
+    private readonly eInvalid = new Callable("eInvalid", {
+        signature: {
+            args: [],
+            returns: ValueKind.Boolean,
+        },
+        impl: (_: Interpreter) => {
+            return BrsBoolean.from(this.errorCode === 22); // EINVALID error code
+        },
+    });
+
+    /** Returns the EINPROGRESS status */
+    private readonly eInProgress = new Callable("eInProgress", {
+        signature: {
+            args: [],
+            returns: ValueKind.Boolean,
+        },
+        impl: (_: Interpreter) => {
+            return BrsBoolean.from(this.errorCode === 36); // EINPROGRESS error code
+        },
+    });
+
+    /** Returns the EWOULDBLOCK status */
+    private readonly eWouldBlock = new Callable("eWouldBlock", {
+        signature: {
+            args: [],
+            returns: ValueKind.Boolean,
+        },
+        impl: (_: Interpreter) => {
+            return BrsBoolean.from(this.errorCode === 35); // EWOULDBLOCK error code
+        },
+    });
+
+    /** Checks whether there are no errors (the error number is 0). */
+    private readonly eSuccess = new Callable("eSuccess", {
+        signature: {
+            args: [],
+            returns: ValueKind.Boolean,
+        },
+        impl: (_: Interpreter) => {
+            // Implementation of eSuccess method
+            return BrsBoolean.from(this.errorCode === 0);
+        },
+    });
+
+    /** Checks whether there is no hard error, but possibly one of the following async conditions: EAGAIN, EALREADY, EINPROGRESS, EWOULDBLOCK. */
+    private readonly eOK = new Callable("eOK", {
+        signature: {
+            args: [],
+            returns: ValueKind.Int32,
+        },
+        impl: (_: Interpreter) => {
+            // Implementation of eOK method
+            return BrsBoolean.from(this.errorCode === 0);
+        },
+    });
+}
+
+function generateUniqueId(): number {
+    const min = 10000000;
+    const max = 99999999;
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+}

--- a/test/simulator/roStreamSocket.brs
+++ b/test/simulator/roStreamSocket.brs
@@ -1,0 +1,65 @@
+function main()
+    messagePort = CreateObject("roMessagePort")
+    connections = {}
+    buffer = CreateObject("roByteArray")
+    buffer[512] = 0
+    tcpListen = CreateObject("roStreamSocket")
+    tcpListen.setMessagePort(messagePort)
+    addr = CreateObject("roSocketAddress")
+    addr.setPort(54321)
+    tcpListen.setAddress(addr)
+    tcpListen.notifyReadable(true)
+    tcpListen.listen(4)
+    if not tcpListen.eOK()
+        print "Error creating listen socket"
+        stop
+    else
+        print "Listening on port 54321"
+    end if
+    while True
+        event = wait(0, messagePort)
+        if type(event) = "roSocketEvent"
+            changedID = event.getSocketID()
+            if changedID = tcpListen.getID() and tcpListen.isReadable()
+                ' New
+                newConnection = tcpListen.accept()
+                if newConnection = Invalid
+                    print "accept failed"
+                else
+                    print "accepted new connection " newConnection.getID()
+                    newConnection.notifyReadable(true)
+                    newConnection.setMessagePort(messagePort)
+                    connections[Stri(newConnection.getID())] = newConnection
+                end if
+            else
+                ' Activity on an open connection
+                connection = connections[Stri(changedID)]
+                closed = False
+                if connection.isReadable()
+                    received = connection.receive(buffer, 0, 512)
+                    print "received is " received
+                    if received > 0
+                        print "Echo input: '"; buffer.ToAsciiString(); "'"
+                        ' If we are unable to send, just drop data for now.
+                        ' You could use notifywritable and buffer data, but that is
+                        ' omitted for clarity.
+                        connection.send(buffer, 0, received)
+                    else if received=0 ' client closed
+                        closed = True
+                    end if
+                end if
+                if closed or not connection.eOK()
+                    print "closing connection " changedID
+                    connection.close()
+                    connections.delete(Stri(changedID))
+                end if
+            end if
+        end if
+    end while
+
+    print "Main loop exited"
+    tcpListen.close()
+    for each id in connections
+        connections[id].close()
+    end for
+End Function


### PR DESCRIPTION
This implementation closes #282 but as a mocked component, there is no way to open a socket in the browser and the node `net.socket` component is async and can't be used in `brs-engine` in the moment, so we close it as is (mocked) and improve it later when the `async` version of the engine is available.