### PR TITLE
Moved `FileSystem` to `BrsDevice`

### DIFF
--- a/src/core/BrsDevice.ts
+++ b/src/core/BrsDevice.ts
@@ -1,8 +1,11 @@
 import { dataBufferIndex, DataType, DebugCommand } from "./common";
+import { FileSystem } from "./FileSystem";
 
 export class BrsDevice {
     static readonly deviceInfo: Map<string, any> = new Map<string, any>();
     static readonly registry: Map<string, string> = new Map<string, string>();
+    static readonly fileSystem: FileSystem = new FileSystem();
+
     static sharedArray: Int32Array = new Int32Array(0);
     static displayEnabled: boolean = true;
     static lastRemote: number = 0;

--- a/src/core/FileSystem.ts
+++ b/src/core/FileSystem.ts
@@ -2,18 +2,19 @@ import MemoryFileSystem from "memory-fs";
 import * as path from "path";
 import * as zenFS from "@zenfs/core";
 import * as nodeFS from "fs";
+import { Zip } from "@lvcabral/zip";
 
 /** Proxy Object to make File System volumes case insensitive, same as Roku devices */
 
 export class FileSystem {
     private readonly paths: Map<string, string>;
-    readonly root?: string;
-    readonly ext?: string;
-    readonly pfs: typeof zenFS.fs | typeof nodeFS; // pkg:
-    readonly xfs: typeof zenFS.fs | typeof nodeFS; // ext1:
-    readonly tfs: MemoryFileSystem; // tmp:
-    readonly cfs: MemoryFileSystem; // cachefs:
-    readonly mfs: MemoryFileSystem; // common:
+    private root?: string;
+    private ext?: string;
+    private pfs: typeof zenFS.fs | typeof nodeFS; // pkg:
+    private xfs: typeof zenFS.fs | typeof nodeFS; // ext1:
+    private tfs: MemoryFileSystem; // tmp:
+    private cfs: MemoryFileSystem; // cachefs:
+    private mfs: MemoryFileSystem; // common:
 
     constructor(root?: string, ext?: string) {
         this.paths = new Map();
@@ -44,6 +45,22 @@ export class FileSystem {
     }
     private getOriginalPath(uri: string) {
         return this.paths.get(uri.toLowerCase().replace(/\/+/g, "/").trim());
+    }
+
+    setRoot(root: string) {
+        this.root = root;
+        this.pfs = nodeFS;
+    }
+
+    setExt(ext: string) {
+        this.ext = ext;
+        this.xfs = nodeFS;
+    }
+
+    resetMemoryFS() {
+        this.tfs = new MemoryFileSystem();
+        this.cfs = new MemoryFileSystem();
+        this.mfs = new MemoryFileSystem();
     }
 
     getFS(uri: string) {
@@ -179,4 +196,37 @@ export function writeUri(uri: string): boolean {
 export function memoryUri(uri: string): boolean {
     uri = uri.toLowerCase();
     return validUri(uri) && !(uri.startsWith("pkg:/") || uri.startsWith("ext1:/"));
+}
+
+/**
+ * Initializes the File System with the provided zip files.
+ * @param pkgZip ArrayBuffer with the package zip file.
+ * @param extZip ArrayBuffer with the external storage zip file.
+ */
+export async function configureFileSystem(
+    pkgZip?: ArrayBuffer,
+    extZip?: ArrayBuffer
+): Promise<void> {
+    const fsConfig = { mounts: {} };
+    if (zenFS.fs?.existsSync("pkg:/")) {
+        zenFS.umount("pkg:");
+    }
+    if (pkgZip) {
+        Object.assign(fsConfig.mounts, {
+            "pkg:": { backend: Zip, data: pkgZip, caseSensitive: false },
+        });
+    } else {
+        Object.assign(fsConfig.mounts, {
+            "pkg:": zenFS.InMemory,
+        });
+    }
+    if (extZip) {
+        if (zenFS.fs?.existsSync("ext1:/")) {
+            zenFS.umount("ext1:");
+        }
+        Object.assign(fsConfig.mounts, {
+            "ext1:": { backend: Zip, data: extZip, caseSensitive: false },
+        });
+    }
+    return zenFS.configure(fsConfig);
 }

--- a/src/core/brsTypes/components/RoAudioMetadata.ts
+++ b/src/core/brsTypes/components/RoAudioMetadata.ts
@@ -11,6 +11,7 @@ import { Callable, StdlibArgument } from "../Callable";
 import { BrsComponent } from "./BrsComponent";
 import { Interpreter } from "../../interpreter";
 import mp3Parser from "mp3-parser";
+import { BrsDevice } from "../../BrsDevice";
 
 export class RoAudioMetadata extends BrsComponent implements BrsValue {
     readonly kind = ValueKind.Object;
@@ -36,7 +37,7 @@ export class RoAudioMetadata extends BrsComponent implements BrsValue {
     private loadFile(interpreter: Interpreter, file: string) {
         let audio: Buffer | undefined;
         try {
-            audio = interpreter.fileSystem?.readFileSync(file);
+            audio = BrsDevice.fileSystem?.readFileSync(file);
         } catch (err: any) {
             if (interpreter.isDevMode) {
                 interpreter.stderr.write(

--- a/src/core/brsTypes/components/RoAudioResource.ts
+++ b/src/core/brsTypes/components/RoAudioResource.ts
@@ -26,7 +26,7 @@ export class RoAudioResource extends BrsComponent implements BrsValue {
             this.audioId = sysIndex;
         } else {
             try {
-                const fsys = interpreter.fileSystem;
+                const fsys = BrsDevice.fileSystem;
                 this.valid = fsys !== undefined;
                 if (fsys) {
                     const id = parseInt(fsys.readFileSync(name.value, "utf8"));

--- a/src/core/brsTypes/components/RoBitmap.ts
+++ b/src/core/brsTypes/components/RoBitmap.ts
@@ -59,7 +59,7 @@ export class RoBitmap extends BrsComponent implements BrsValue, BrsDraw2D {
             image = param;
         } else if (param instanceof BrsString) {
             try {
-                image = interpreter.fileSystem?.readFileSync(param.value);
+                image = BrsDevice.fileSystem?.readFileSync(param.value);
                 this.alphaEnable = false;
                 this.name = param.value;
             } catch (err: any) {

--- a/src/core/brsTypes/components/RoByteArray.ts
+++ b/src/core/brsTypes/components/RoByteArray.ts
@@ -3,9 +3,10 @@ import { BrsValue, ValueKind, BrsBoolean, BrsInvalid, BrsString } from "../BrsTy
 import { BrsComponent, BrsIterable } from "./BrsComponent";
 import { Callable, StdlibArgument } from "../Callable";
 import { Interpreter } from "../../interpreter";
-import { validUri, writeUri } from "../../interpreter/FileSystem";
+import { validUri, writeUri } from "../../FileSystem";
 import { crc32 } from "crc";
 import { IfEnum } from "../interfaces/IfEnum";
+import { BrsDevice } from "../../BrsDevice";
 
 export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
     readonly kind = ValueKind.Object;
@@ -184,9 +185,9 @@ export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
             ],
             returns: ValueKind.Boolean,
         },
-        impl: (interpreter: Interpreter, filepath: BrsString, index: Int32, length: Int32) => {
+        impl: (_: Interpreter, filepath: BrsString, index: Int32, length: Int32) => {
             try {
-                const fsys = interpreter.fileSystem;
+                const fsys = BrsDevice.fileSystem;
                 if (fsys && validUri(filepath.value)) {
                     let array: Uint8Array = fsys.readFileSync(filepath.value);
                     if (index.getValue() > 0 || length.getValue() > 0) {
@@ -218,9 +219,9 @@ export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
             ],
             returns: ValueKind.Boolean,
         },
-        impl: (interpreter: Interpreter, filepath: BrsString, index: Int32, length: Int32) => {
+        impl: (_: Interpreter, filepath: BrsString, index: Int32, length: Int32) => {
             try {
-                const fsys = interpreter.fileSystem;
+                const fsys = BrsDevice.fileSystem;
                 if (fsys && writeUri(filepath.value)) {
                     if (index.getValue() > 0 || length.getValue() > 0) {
                         let start = index.getValue();
@@ -251,9 +252,9 @@ export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
             ],
             returns: ValueKind.Boolean,
         },
-        impl: (interpreter: Interpreter, filepath: BrsString, index: Int32, length: Int32) => {
+        impl: (_: Interpreter, filepath: BrsString, index: Int32, length: Int32) => {
             try {
-                const fsys = interpreter.fileSystem;
+                const fsys = BrsDevice.fileSystem;
                 if (fsys && writeUri(filepath.value)) {
                     let file: Uint8Array = fsys.readFileSync(filepath.value);
                     let array: Uint8Array;

--- a/src/core/brsTypes/components/RoChannelStore.ts
+++ b/src/core/brsTypes/components/RoChannelStore.ts
@@ -75,8 +75,8 @@ export class RoChannelStore extends BrsComponent implements BrsValue {
             valueProcessors: [processors.parseNumbers],
         };
         const data: RoAssociativeArray[] = [];
-        if (interpreter.fileSystem.existsSync(`pkg:/csfake/${xml}.xml`)) {
-            const xmlData = interpreter.fileSystem.readFileSync(`pkg:/csfake/${xml}.xml`);
+        if (BrsDevice.fileSystem.existsSync(`pkg:/csfake/${xml}.xml`)) {
+            const xmlData = BrsDevice.fileSystem.readFileSync(`pkg:/csfake/${xml}.xml`);
             parseString(xmlData, options, function (err: any, parsed: any) {
                 let errMessage = "";
                 if (err) {
@@ -129,7 +129,7 @@ export class RoChannelStore extends BrsComponent implements BrsValue {
             ignoreAttrs: true,
             valueProcessors: [processors.parseNumbers],
         };
-        const fs = interpreter.fileSystem;
+        const fs = BrsDevice.fileSystem;
         const data: FlexObject = { id: xml };
         if (fs.existsSync(`pkg:/csfake/${xml}.xml`)) {
             const xmlData = fs.readFileSync(`pkg:/csfake/${xml}.xml`);

--- a/src/core/brsTypes/components/RoFontRegistry.ts
+++ b/src/core/brsTypes/components/RoFontRegistry.ts
@@ -3,7 +3,7 @@ import { BrsComponent } from "./BrsComponent";
 import { BrsType } from "..";
 import { Callable, StdlibArgument } from "../Callable";
 import { Interpreter } from "../../interpreter";
-import { validUri } from "../../interpreter/FileSystem";
+import { validUri } from "../../FileSystem";
 import { Int32 } from "../Int32";
 import { RoArray } from "./RoArray";
 import { RoFont } from "./RoFont";
@@ -56,11 +56,11 @@ export class RoFontRegistry extends BrsComponent implements BrsValue {
 
     registerFont(interpreter: Interpreter, fontPath: string) {
         try {
-            const fsys = interpreter.fileSystem;
+            const fsys = BrsDevice.fileSystem;
             if (!fsys || !validUri(fontPath)) {
                 return BrsBoolean.False;
             }
-            const fontData = interpreter.fileSystem.readFileSync(fontPath);
+            const fontData = BrsDevice.fileSystem.readFileSync(fontPath);
             const fontObj = opentype.parse(fontData.buffer);
             // Get font metrics
             const fontMetrics = {

--- a/src/core/brsTypes/components/RoImageMetadata.ts
+++ b/src/core/brsTypes/components/RoImageMetadata.ts
@@ -13,6 +13,7 @@ import { BrsComponent } from "./BrsComponent";
 import { Interpreter } from "../../interpreter";
 import { ExifSections, exifTags, exifTagEnums, ExifTag } from "../ExifTags";
 import * as exifParser from "exif-parser";
+import { BrsDevice } from "../../BrsDevice";
 
 export class RoImageMetadata extends BrsComponent implements BrsValue {
     readonly kind = ValueKind.Object;
@@ -44,7 +45,7 @@ export class RoImageMetadata extends BrsComponent implements BrsValue {
     private loadFile(interpreter: Interpreter, file: string) {
         let image: Buffer | undefined;
         try {
-            image = interpreter.fileSystem?.readFileSync(file);
+            image = BrsDevice.fileSystem?.readFileSync(file);
         } catch (err: any) {
             if (interpreter.isDevMode) {
                 interpreter.stderr.write(

--- a/src/core/brsTypes/components/RoLocalization.ts
+++ b/src/core/brsTypes/components/RoLocalization.ts
@@ -69,7 +69,7 @@ export class RoLocalization extends BrsComponent implements BrsValue {
             returns: ValueKind.String,
         },
         impl: (interpreter: Interpreter, dirName: BrsString, fileName: BrsString) => {
-            const fsys = interpreter.fileSystem;
+            const fsys = BrsDevice.fileSystem;
             if (!fsys) {
                 return new BrsString("");
             }

--- a/src/core/brsTypes/components/RoTextureManager.ts
+++ b/src/core/brsTypes/components/RoTextureManager.ts
@@ -16,12 +16,13 @@ import {
     toAssociativeArray,
 } from "..";
 import { Interpreter } from "../../interpreter";
-import { validUri } from "../../interpreter/FileSystem";
+import { validUri } from "../../FileSystem";
 import { download } from "../../interpreter/Network";
 import { RoTextureRequestEvent } from "../events/RoTextureRequestEvent";
 import { drawObjectToComponent } from "../interfaces/IfDraw2D";
 import { BrsHttpAgent, IfHttpAgent } from "../interfaces/IfHttpAgent";
 import { IfGetMessagePort, IfSetMessagePort } from "../interfaces/IfMessagePort";
+import { BrsDevice } from "../../BrsDevice";
 
 // Singleton instance of RoTextureManager
 let textureManager: RoTextureManager;
@@ -135,7 +136,7 @@ export class RoTextureManager extends BrsComponent implements BrsValue, BrsHttpA
             }
         } else {
             try {
-                return this.interpreter.fileSystem.readFileSync(request.uri);
+                return BrsDevice.fileSystem.readFileSync(request.uri);
             } catch (err: any) {
                 if (this.interpreter.isDevMode) {
                     this.interpreter.stderr.write(

--- a/src/core/brsTypes/components/RoURLTransfer.ts
+++ b/src/core/brsTypes/components/RoURLTransfer.ts
@@ -227,7 +227,7 @@ export class RoURLTransfer extends BrsComponent implements BrsValue, BrsHttpAgen
         let error = "";
         try {
             const xhr = this.getConnection("POST", "arraybuffer");
-            const fsys = this.interpreter.fileSystem;
+            const fsys = BrsDevice.fileSystem;
             if (fsys.existsSync(inputPath)) {
                 const body = fsys.readFileSync(inputPath);
                 xhr.send(body);
@@ -271,7 +271,7 @@ export class RoURLTransfer extends BrsComponent implements BrsValue, BrsHttpAgen
     }
 
     saveDownloadedFile(filePath: string, data: any) {
-        const fsys = this.interpreter.fileSystem;
+        const fsys = BrsDevice.fileSystem;
         if (!fsys) {
             return;
         }
@@ -547,7 +547,7 @@ export class RoURLTransfer extends BrsComponent implements BrsValue, BrsHttpAgen
             returns: ValueKind.Int32,
         },
         impl: (_: Interpreter, filePath: BrsString) => {
-            const fsys = this.interpreter.fileSystem;
+            const fsys = BrsDevice.fileSystem;
             if (fsys.existsSync(filePath.value)) {
                 const body = fsys.readFileSync(filePath.value);
                 const reply = this.postFromStringEvent(body);
@@ -568,7 +568,7 @@ export class RoURLTransfer extends BrsComponent implements BrsValue, BrsHttpAgen
             returns: ValueKind.Boolean,
         },
         impl: (_: Interpreter, filePath: BrsString) => {
-            const fsys = this.interpreter.fileSystem;
+            const fsys = BrsDevice.fileSystem;
             if (!fsys.existsSync(filePath.value)) {
                 return BrsBoolean.False;
             }
@@ -595,7 +595,7 @@ export class RoURLTransfer extends BrsComponent implements BrsValue, BrsHttpAgen
             returns: ValueKind.Boolean,
         },
         impl: (_: Interpreter, fromFile: BrsString, toFile: BrsString) => {
-            const fsys = this.interpreter.fileSystem;
+            const fsys = BrsDevice.fileSystem;
             if (!fsys.existsSync(fromFile.value)) {
                 return BrsBoolean.False;
             }

--- a/src/core/interpreter/index.ts
+++ b/src/core/interpreter/index.ts
@@ -55,7 +55,6 @@ import Long from "long";
 import { Scope, Environment, NotFound } from "./Environment";
 import { toCallable } from "./BrsFunction";
 import { BlockEnd, GotoLabel } from "../parser/Statement";
-import { FileSystem } from "./FileSystem";
 import { runDebugger } from "./MicroDebugger";
 import { DataType, DebugCommand, defaultDeviceInfo, numberToHex, parseTextFile } from "../common";
 import { BrsDevice } from "../BrsDevice";
@@ -117,7 +116,6 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
         end: { line: -1, column: -1 },
     };
 
-    readonly fileSystem: FileSystem;
     readonly options: ExecutionOptions = defaultExecutionOptions;
     readonly manifest: Map<string, any> = new Map<string, any>();
     readonly translations: Map<string, string> = new Map<string, string>();
@@ -207,7 +205,12 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
         Object.assign(this.options, options);
         this.stdout = new OutputProxy(this.options.stdout, this.options.post);
         this.stderr = new OutputProxy(this.options.stderr, this.options.post);
-        this.fileSystem = new FileSystem(this.options.root, this.options.ext);
+        if (this.options.root) {
+            BrsDevice.fileSystem.setRoot(this.options.root);
+        }
+        if (this.options.ext) {
+            BrsDevice.fileSystem.setExt(this.options.ext);
+        }
         for (const [key, value] of Object.entries(defaultDeviceInfo)) {
             if (!["registry", "fonts"].includes(key)) {
                 BrsDevice.deviceInfo.set(key, value);

--- a/src/core/stdlib/File.ts
+++ b/src/core/stdlib/File.ts
@@ -1,7 +1,8 @@
 import { Callable, ValueKind, BrsString, BrsBoolean, StdlibArgument, RoList } from "../brsTypes";
 import { Interpreter } from "../interpreter";
-import { getVolume, validUri, writeUri } from "../interpreter/FileSystem";
+import { getVolume, validUri, writeUri } from "../FileSystem";
 import * as nanomatch from "nanomatch";
+import { BrsDevice } from "../BrsDevice";
 
 /** Copies a file from src to dst, return true if successful */
 export const CopyFile = new Callable("CopyFile", {
@@ -13,7 +14,7 @@ export const CopyFile = new Callable("CopyFile", {
         returns: ValueKind.Boolean,
     },
     impl: (interpreter: Interpreter, src: BrsString, dst: BrsString) => {
-        const fsys = interpreter.fileSystem;
+        const fsys = BrsDevice.fileSystem;
         try {
             if (!writeUri(dst.value) || !fsys.existsSync(src.value)) {
                 return BrsBoolean.False;
@@ -42,7 +43,7 @@ export const MoveFile = new Callable("MoveFile", {
         returns: ValueKind.Boolean,
     },
     impl: (interpreter: Interpreter, src: BrsString, dst: BrsString) => {
-        const fsys = interpreter.fileSystem;
+        const fsys = BrsDevice.fileSystem;
         try {
             if (
                 !writeUri(src.value) ||
@@ -72,7 +73,7 @@ export const DeleteFile = new Callable("DeleteFile", {
         returns: ValueKind.Boolean,
     },
     impl: (interpreter: Interpreter, file: BrsString) => {
-        const fsys = interpreter.fileSystem;
+        const fsys = BrsDevice.fileSystem;
         try {
             if (!writeUri(file.value)) {
                 return BrsBoolean.False;
@@ -97,7 +98,7 @@ export const DeleteDirectory = new Callable("DeleteDirectory", {
         returns: ValueKind.Boolean,
     },
     impl: (interpreter: Interpreter, dir: BrsString) => {
-        const fsys = interpreter.fileSystem;
+        const fsys = BrsDevice.fileSystem;
         try {
             if (!writeUri(dir.value)) {
                 return BrsBoolean.False;
@@ -122,7 +123,7 @@ export const CreateDirectory = new Callable("CreateDirectory", {
         returns: ValueKind.Boolean,
     },
     impl: (interpreter: Interpreter, dir: BrsString) => {
-        const fsys = interpreter.fileSystem;
+        const fsys = BrsDevice.fileSystem;
         try {
             if (!writeUri(dir.value)) {
                 return BrsBoolean.False;
@@ -164,7 +165,7 @@ export const ListDir = new Callable("ListDir", {
         returns: ValueKind.Object,
     },
     impl: (interpreter: Interpreter, dir: BrsString) => {
-        const fsys = interpreter.fileSystem;
+        const fsys = BrsDevice.fileSystem;
         try {
             if (!validUri(dir.value)) {
                 interpreter.stderr.write(
@@ -192,7 +193,7 @@ export const ReadAsciiFile = new Callable("ReadAsciiFile", {
         returns: ValueKind.String,
     },
     impl: (interpreter: Interpreter, filePath: BrsString) => {
-        const fsys = interpreter.fileSystem;
+        const fsys = BrsDevice.fileSystem;
         try {
             if (!validUri(filePath.value)) {
                 return new BrsString("");
@@ -222,7 +223,7 @@ export const WriteAsciiFile = new Callable("WriteAsciiFile", {
         returns: ValueKind.Boolean,
     },
     impl: (interpreter: Interpreter, filePath: BrsString, text: BrsString) => {
-        const fsys = interpreter.fileSystem;
+        const fsys = BrsDevice.fileSystem;
         try {
             if (!writeUri(filePath.value)) {
                 return BrsBoolean.False;
@@ -250,7 +251,7 @@ export const MatchFiles = new Callable("MatchFiles", {
         returns: ValueKind.Object,
     },
     impl: (interpreter: Interpreter, pathArg: BrsString, patternIn: BrsString) => {
-        const fsys = interpreter.fileSystem;
+        const fsys = BrsDevice.fileSystem;
         try {
             if (!validUri(pathArg.value)) {
                 return new RoList([]);

--- a/src/core/stdlib/Run.ts
+++ b/src/core/stdlib/Run.ts
@@ -31,10 +31,10 @@ function runFiles(interpreter: Interpreter, filenames: BrsString[], args: BrsTyp
         });
         const sourceMap = new Map<string, string>();
         filenames.forEach((filename) => {
-            if (interpreter.fileSystem.existsSync(filename.value)) {
+            if (BrsDevice.fileSystem.existsSync(filename.value)) {
                 sourceMap.set(
                     filename.value,
-                    interpreter.fileSystem.readFileSync(filename.value, "utf8")
+                    BrsDevice.fileSystem.readFileSync(filename.value, "utf8")
                 );
             }
         });

--- a/test/e2e/E2ETests.js
+++ b/test/e2e/E2ETests.js
@@ -44,6 +44,7 @@ exports.createMockStreams = function () {
 
 /** Executes the specified BrightScript files, capturing their output in the provided streams. */
 exports.execute = async function (filenames, options, deepLink) {
+    brs.BrsDevice.fileSystem.resetMemoryFS();
     const payload = createPayloadFromFiles(filenames, deviceData);
     if (deepLink) {
         payload.deepLink = deepLink;

--- a/test/stdlib/File.test.js
+++ b/test/stdlib/File.test.js
@@ -1,5 +1,5 @@
 const brs = require("../../bin/brs.node");
-const { Interpreter } = brs;
+const { Interpreter, BrsDevice } = brs;
 const {
     ListDir,
     CopyFile,
@@ -24,7 +24,8 @@ describe("global file I/O functions", () => {
         interpreter = new Interpreter({
             root: "hello/world",
         }); // reset the file systems
-        fsys = interpreter.fileSystem;
+        fsys = BrsDevice.fileSystem;
+        fsys.resetMemoryFS();
     });
 
     describe("ListDir", () => {


### PR DESCRIPTION
The `FileSystem` was being replicated on every `Interpreter`, it belongs to the Device.