### PR TITLE
Fixed the `Val()` global function to always return `Float` if no `radix` parameter is passed

### DIFF
--- a/src/core/brsTypes/Float.ts
+++ b/src/core/brsTypes/Float.ts
@@ -7,6 +7,7 @@ import { Double } from "./Double";
 import { Int64 } from "./Int64";
 import { RoFloat } from "./components/RoFloat";
 import Long from "long";
+import { vsprintf } from "sprintf-js";
 
 /**
  * Number of significant digits represented in an IEEE 32-bit floating point number.
@@ -213,7 +214,7 @@ export class Float implements Numeric, Comparable, Boxable {
     }
 
     toString(parent?: BrsType): string {
-        return this.value.toPrecision();
+        return vsprintf("%g", [this.value]);
     }
 
     box() {

--- a/src/core/stdlib/String.ts
+++ b/src/core/stdlib/String.ts
@@ -16,7 +16,7 @@ export const UCase = new Callable("UCase", {
         args: [new StdlibArgument("s", ValueKind.String)],
         returns: ValueKind.String,
     },
-    impl: (interpreter: Interpreter, s: BrsString) => new BrsString(s.value.toUpperCase()),
+    impl: (_: Interpreter, s: BrsString) => new BrsString(s.value.toUpperCase()),
 });
 
 /** Converts the string to all lowercase. */
@@ -25,7 +25,7 @@ export const LCase = new Callable("LCase", {
         args: [new StdlibArgument("s", ValueKind.String)],
         returns: ValueKind.String,
     },
-    impl: (interpreter: Interpreter, s: BrsString) => new BrsString(s.value.toLowerCase()),
+    impl: (_: Interpreter, s: BrsString) => new BrsString(s.value.toLowerCase()),
 });
 
 /**
@@ -37,7 +37,7 @@ export const Asc = new Callable("Asc", {
         args: [new StdlibArgument("letter", ValueKind.String)],
         returns: ValueKind.String,
     },
-    impl: (interpreter: Interpreter, str: BrsString) => new Int32(str.value.charCodeAt(0) || 0),
+    impl: (_: Interpreter, str: BrsString) => new Int32(str.value.charCodeAt(0) || 0),
 });
 
 /**
@@ -51,7 +51,7 @@ export const Chr = new Callable("Chr", {
         args: [new StdlibArgument("ch", ValueKind.Int32)],
         returns: ValueKind.String,
     },
-    impl: (interpreter: Interpreter, ch: Int32) => {
+    impl: (_: Interpreter, ch: Int32) => {
         const num = ch.getValue();
         if (num <= 0) return new BrsString("");
         else return new BrsString(String.fromCharCode(num));
@@ -66,8 +66,7 @@ export const Left = new Callable("Left", {
         args: [new StdlibArgument("s", ValueKind.String), new StdlibArgument("n", ValueKind.Int32)],
         returns: ValueKind.String,
     },
-    impl: (interpreter: Interpreter, s: BrsString, n: Int32) =>
-        new BrsString(s.value.slice(0, n.getValue())),
+    impl: (_: Interpreter, s: BrsString, n: Int32) => new BrsString(s.value.slice(0, n.getValue())),
 });
 
 /**
@@ -78,7 +77,7 @@ export const Right = new Callable("Right", {
         args: [new StdlibArgument("s", ValueKind.String), new StdlibArgument("n", ValueKind.Int32)],
         returns: ValueKind.String,
     },
-    impl: (interpreter: Interpreter, s: BrsString, n: Int32) => {
+    impl: (_: Interpreter, s: BrsString, n: Int32) => {
         if (n.getValue() <= 0) return new BrsString("");
         return new BrsString(s.value.slice(-n.getValue()));
     },
@@ -96,7 +95,7 @@ export const Instr = new Callable("Instr", {
         ],
         returns: ValueKind.String,
     },
-    impl: (interpreter: Interpreter, start: Int32, str: BrsString, search: BrsString) =>
+    impl: (_: Interpreter, start: Int32, str: BrsString, search: BrsString) =>
         new Int32(str.value.indexOf(search.value, start.getValue() - 1) + 1),
 });
 
@@ -108,7 +107,7 @@ export const Len = new Callable("Len", {
         args: [new StdlibArgument("s", ValueKind.String)],
         returns: ValueKind.Int32,
     },
-    impl: (interpreter: Interpreter, s: BrsString) => new Int32(s.value.length),
+    impl: (_: Interpreter, s: BrsString) => new Int32(s.value.length),
 });
 
 /**
@@ -124,7 +123,7 @@ export const Mid = new Callable(
             ],
             returns: ValueKind.String,
         },
-        impl: (interpreter: Interpreter, s: BrsString, p: Int32): BrsString => {
+        impl: (_: Interpreter, s: BrsString, p: Int32): BrsString => {
             let start = p.getValue() - 1;
             return new BrsString(s.value.substring(start));
         },
@@ -138,7 +137,7 @@ export const Mid = new Callable(
             ],
             returns: ValueKind.String,
         },
-        impl: (interpreter: Interpreter, s: BrsString, p: Int32, n: Int32): BrsString => {
+        impl: (_: Interpreter, s: BrsString, p: Int32, n: Int32): BrsString => {
             let start = p.getValue() - 1;
             return new BrsString(s.value.substring(start, start + n.getValue()));
         },
@@ -153,7 +152,7 @@ export const Str = new Callable("Str", {
         args: [new StdlibArgument("value", ValueKind.Float)],
         returns: ValueKind.String,
     },
-    impl: (interpreter: Interpreter, value: Float): BrsString => {
+    impl: (_: Interpreter, value: Float): BrsString => {
         const floatValue = value.getValue();
         const prefix = floatValue >= 0.0 ? " " : "";
         return new BrsString(prefix + String(floatValue));
@@ -171,7 +170,7 @@ export const StrI = new Callable("StrI", {
         ],
         returns: ValueKind.String,
     },
-    impl: (interpreter: Interpreter, value: Int32, brsRadix: Int32): BrsString => {
+    impl: (_: Interpreter, value: Int32, brsRadix: Int32): BrsString => {
         let radix = brsRadix.getValue();
         if (radix < 2 || radix > 36) {
             return new BrsString("");
@@ -196,7 +195,7 @@ export const STRING = new Callable("String", {
         ],
         returns: ValueKind.String,
     },
-    impl: (interpreter: Interpreter, n: Int32, str: BrsString): BrsString => {
+    impl: (_: Interpreter, n: Int32, str: BrsString): BrsString => {
         return new BrsString(str.value.repeat(n.getValue()));
     },
 });
@@ -209,7 +208,7 @@ export const StringI = new Callable("StringI", {
         args: [new StdlibArgument("n", ValueKind.Int32), new StdlibArgument("ch", ValueKind.Int32)],
         returns: ValueKind.String,
     },
-    impl: (interpreter: Interpreter, n: Int32, ch: Int32): BrsString => {
+    impl: (_: Interpreter, n: Int32, ch: Int32): BrsString => {
         return new BrsString(String.fromCharCode(ch.getValue()).repeat(n.getValue()));
     },
 });
@@ -230,7 +229,7 @@ export const Substitute = new Callable("Substitute", {
         returns: ValueKind.String,
     },
     impl: (
-        interpreter: Interpreter,
+        _: Interpreter,
         str: BrsString,
         arg0: BrsString,
         arg1: BrsString,
@@ -257,21 +256,21 @@ export const Val = new Callable("Val", {
         ],
         returns: ValueKind.Dynamic,
     },
-    impl: (interpreter: Interpreter, s: BrsString, brsRadix: Int32 | BrsInvalid): BrsNumber => {
+    impl: (_: Interpreter, s: BrsString, brsRadix: Int32 | BrsInvalid): BrsNumber => {
         const isFloat = s.value.includes(".");
-
-        let retNumber = 0;
         if (isFloat || brsRadix instanceof BrsInvalid) {
-            retNumber = Number(s.value);
+            const retNumber = Number(s.value);
+            if (Number.isNaN(retNumber)) {
+                return new Float(0);
+            }
+            return new Float(retNumber)
         } else {
-            retNumber = parseInt(s.value, brsRadix.getValue());
+            const retNumber = parseInt(s.value, brsRadix.getValue());
+            if (Number.isNaN(retNumber)) {
+                return new Int32(0);
+            }
+            return new Int32(retNumber)
         }
-
-        if (Number.isNaN(retNumber)) {
-            return new Int32(0);
-        }
-
-        return isFloat ? new Float(retNumber) : new Int32(retNumber);
     },
 });
 
@@ -283,7 +282,7 @@ export const StrToI = new Callable("StrToI", {
         args: [new StdlibArgument("s", ValueKind.String)],
         returns: ValueKind.Int32,
     },
-    impl: (interpreter: Interpreter, s: BrsString): BrsNumber => {
+    impl: (_: Interpreter, s: BrsString): BrsNumber => {
         let integerValue = parseInt(s.value);
 
         if (Number.isNaN(integerValue)) {

--- a/src/core/stdlib/String.ts
+++ b/src/core/stdlib/String.ts
@@ -263,13 +263,13 @@ export const Val = new Callable("Val", {
             if (Number.isNaN(retNumber)) {
                 return new Float(0);
             }
-            return new Float(retNumber)
+            return new Float(retNumber);
         } else {
             const retNumber = parseInt(s.value, brsRadix.getValue());
             if (Number.isNaN(retNumber)) {
                 return new Int32(0);
             }
-            return new Int32(retNumber)
+            return new Int32(retNumber);
         }
     },
 });

--- a/test/e2e/StdLib.test.js
+++ b/test/e2e/StdLib.test.js
@@ -61,6 +61,7 @@ describe("end to end standard libary", () => {
             " 252",
             "abababab",
             "!!!!!!!!",
+            " 1.23457e+12",
         ]);
     });
 
@@ -68,12 +69,12 @@ describe("end to end standard libary", () => {
         await execute([resourceFile("stdlib", "math.brs")], outputStreams);
 
         expect(allArgs(outputStreams.stdout.write).map((arg) => arg.trimEnd())).toEqual([
-            " 22.19795",
+            " 22.1979",
             " 2.85647",
-            " 3.342155",
-            " 0.4636476",
-            " 0.7073883",
-            " 0.9999997",
+            " 3.34215",
+            " 0.463648",
+            " 0.707388",
+            " 1",
             " 0.999204",
             " 3.5",
             " 17",

--- a/test/e2e/Syntax.test.js
+++ b/test/e2e/Syntax.test.js
@@ -81,7 +81,7 @@ describe("end to end syntax", () => {
             " 10", // boxed operations
             " 4",
             " 21",
-            " 2.333333",
+            " 2.33333",
             "Integer",
             "roInt",
             "roFloat",
@@ -131,13 +131,13 @@ describe("end to end syntax", () => {
         await execute([resourceFile("to-str-with-format.brs")], outputStreams);
 
         expect(allArgs(outputStreams.stdout.write).map((arg) => arg.trimEnd())).toEqual([
-            "float1 = 10000.45", // RBI 10000.5
-            "float2 = 10000.46", // RBI 10000.5
+            "float1 = 10000.5",
+            "float2 = 10000.5",
             "float3 = 10000.45678",
             "float3.toStr() = 10000.5",
             "0.123 = 0.123",
             "0.123.toStr() = 0.123",
-            "123.4567 = 123.4567", // RBI 123.457
+            "123.4567 = 123.457",
             "123.4567.toStr() = 123.457",
             "double = 10000.46", // RBI 10000.45703125
             "double.toStr() = 10000.5",

--- a/test/e2e/TypeChecking.test.js
+++ b/test/e2e/TypeChecking.test.js
@@ -121,7 +121,7 @@ describe("function argument type checking", () => {
             "longinteger& =  13",
             "assigning RHS of type 'longinteger' with value: 2147483647119",
             "integer% = -881",
-            "float! =  2147484000000",
+            "float! =  2.14748e+12",
             "double# =  2147483647119",
             "longinteger& =  2147483647119",
         ]);

--- a/test/e2e/resources/stdlib/strings.brs
+++ b/test/e2e/resources/stdlib/strings.brs
@@ -23,3 +23,4 @@ print Substitute("{0} and {1}", "Mary", "Bob")
 print StrToI("252")
 print String(4, "ab") ' abababab
 print StringI(8, 33)  ' !!!!!!!!
+print Val("1234567890123")' 1.23457e+12

--- a/test/stdlib/String.test.js
+++ b/test/stdlib/String.test.js
@@ -304,17 +304,17 @@ describe("global string functions", () => {
         });
 
         it("returns zero if the string is not a number", () => {
-            expect(Val.call(interpreter, new BrsString(""))).toEqual(new Int32(0));
+            expect(Val.call(interpreter, new BrsString(""))).toEqual(new Float(0));
 
-            expect(Val.call(interpreter, new BrsString("Not a Number"))).toEqual(new Int32(0));
+            expect(Val.call(interpreter, new BrsString("Not a Number"))).toEqual(new Float(0));
 
-            expect(Val.call(interpreter, new BrsString("10+2"))).toEqual(new Int32(0));
+            expect(Val.call(interpreter, new BrsString("10+2"))).toEqual(new Float(0));
         });
 
-        it("returns an integer from a string", () => {
-            expect(Val.call(interpreter, new BrsString("65535"))).toEqual(new Int32(65535));
+        it("returns a float from a string", () => {
+            expect(Val.call(interpreter, new BrsString("65535"))).toEqual(new Float(65535));
 
-            expect(Val.call(interpreter, new BrsString("0xFA"))).toEqual(new Int32(250));
+            expect(Val.call(interpreter, new BrsString("0xFA"))).toEqual(new Float(250));
         });
 
         it("returns an integer from a string and radix", () => {


### PR DESCRIPTION
In Roku the global function `Val()` convert all values to a `Float` unless the `radix` parameter is passed.
This PR fixes this behavior in `brs-engine` and also fixes the `toString()` parsing on Float