### PR TITLE
Prevent transforming `DeviceInfo` into a `Map`

### DIFF
--- a/src/core/brsTypes/components/RoAppInfo.ts
+++ b/src/core/brsTypes/components/RoAppInfo.ts
@@ -60,8 +60,8 @@ export class RoAppInfo extends BrsComponent implements BrsValue {
             args: [],
             returns: ValueKind.String,
         },
-        impl: (interpreter: Interpreter) => {
-            return new BrsString(BrsDevice.deviceInfo.get("developerId"));
+        impl: (_: Interpreter) => {
+            return new BrsString(BrsDevice.deviceInfo.developerId);
         },
     });
 

--- a/src/core/brsTypes/components/RoAppManager.ts
+++ b/src/core/brsTypes/components/RoAppManager.ts
@@ -136,7 +136,7 @@ export class RoAppManager extends BrsComponent implements BrsValue {
             returns: ValueKind.Object,
         },
         impl: (interpreter: Interpreter) => {
-            const app = BrsDevice.deviceInfo.get("appList")?.find((app: AppData) => app.running);
+            const app = BrsDevice.deviceInfo.appList?.find((app: AppData) => app.running);
             const exitInfo = {
                 exit_code: app?.exitReason ?? AppExitReason.UNKNOWN,
                 media_player_state: "stopped",
@@ -192,13 +192,15 @@ export class RoAppManager extends BrsComponent implements BrsValue {
             ],
             returns: ValueKind.Boolean,
         },
-        impl: (interpreter: Interpreter, channelId: BrsString, version: BrsString) => {
-            const appList = BrsDevice.deviceInfo.get("appList");
+        impl: (_: Interpreter, channelId: BrsString, version: BrsString) => {
+            const appList = BrsDevice.deviceInfo.appList;
             if (appList instanceof Array) {
                 const app = appList.find((app) => {
                     return app.id === channelId.value;
                 });
-                return BrsBoolean.from(app && compareVersions(app.version, version.value) >= 0);
+                return BrsBoolean.from(
+                    app !== undefined && compareVersions(app.version, version.value) >= 0
+                );
             }
             return BrsBoolean.False;
         },
@@ -220,7 +222,7 @@ export class RoAppManager extends BrsComponent implements BrsValue {
             version: BrsString,
             params: RoAssociativeArray
         ) => {
-            const appList = BrsDevice.deviceInfo.get("appList");
+            const appList = BrsDevice.deviceInfo.appList;
             if (appList instanceof Array) {
                 const app = appList.find((app) => {
                     return app.id === channelId.value;
@@ -271,7 +273,7 @@ export class RoAppManager extends BrsComponent implements BrsValue {
         },
         impl: (_: Interpreter) => {
             const result = new RoArray([]);
-            const appList = BrsDevice.deviceInfo.get("appList");
+            const appList = BrsDevice.deviceInfo.appList;
             if (appList instanceof Array) {
                 appList.forEach((app) => {
                     const appObj = { id: app.id, title: app.title, version: app.version };

--- a/src/core/brsTypes/components/RoAudioResource.ts
+++ b/src/core/brsTypes/components/RoAudioResource.ts
@@ -18,7 +18,7 @@ export class RoAudioResource extends BrsComponent implements BrsValue {
 
     constructor(name: BrsString) {
         super("roAudioResource");
-        this.maxStreams = Math.min(BrsDevice.deviceInfo.get("maxSimulStreams"), 3) || 2;
+        this.maxStreams = BrsDevice.deviceInfo.maxSimulStreams;
         this.valid = true;
         const sysIndex = DefaultSounds.findIndex((wav) => wav === name.value.toLowerCase());
         if (sysIndex > -1) {

--- a/src/core/brsTypes/components/RoBitmap.ts
+++ b/src/core/brsTypes/components/RoBitmap.ts
@@ -49,8 +49,7 @@ export class RoBitmap extends BrsComponent implements BrsValue, BrsDraw2D {
         this.rgbaLast = 0;
         this.rgbaRedraw = true;
         this.valid = true;
-        const platform = BrsDevice.deviceInfo.get("platform");
-        this.disposeCanvas = platform?.inIOS ?? false;
+        this.disposeCanvas = BrsDevice.deviceInfo.platform?.inIOS ?? false;
         this.width = 1;
         this.height = 1;
         this.name = "";

--- a/src/core/brsTypes/components/RoChannelStore.ts
+++ b/src/core/brsTypes/components/RoChannelStore.ts
@@ -466,11 +466,11 @@ export class RoChannelStore extends BrsComponent implements BrsValue {
                 json = `{channel_data="${this.credData}"}`;
                 status = 0;
             }
-            const app = BrsDevice.deviceInfo.get("appList")?.find((app: AppData) => app.running);
+            const app = BrsDevice.deviceInfo.appList?.find((app: AppData) => app.running);
             const channelCred = {
                 channelId: app?.id ?? "dev",
                 json: json,
-                publisherDeviceId: BrsDevice.deviceInfo.get("clientId") ?? "",
+                publisherDeviceId: BrsDevice.deviceInfo.clientId,
                 status: status,
             };
             return toAssociativeArray(channelCred);

--- a/src/core/brsTypes/components/RoDateTime.ts
+++ b/src/core/brsTypes/components/RoDateTime.ts
@@ -266,7 +266,7 @@ export class RoDateTime extends BrsComponent implements BrsValue {
         },
         impl: (interpreter: Interpreter, format: BrsString) => {
             const rokuDateTokens = ["EEEE", "EEE", "dd", "d", "MMMM", "MMM", "MM", "M", "yy", "y"];
-            const locale = (BrsDevice.deviceInfo.get("locale") ?? "en_US").replace("_", "-");
+            const locale = BrsDevice.deviceInfo.locale.replace("_", "-");
             const dateFormat = format.value.trim() === "" ? "short" : format.value;
             let dateString = this.formatDate(dateFormat, locale);
             if (dateString === "") {
@@ -285,7 +285,7 @@ export class RoDateTime extends BrsComponent implements BrsValue {
         },
         impl: (interpreter: Interpreter, format: BrsString) => {
             const rokuTimeTokens = ["HH", "H", "hh", "h", "mm", "m", "a"];
-            const locale = (BrsDevice.deviceInfo.get("locale") ?? "en_US").replace("_", "-");
+            const locale = BrsDevice.deviceInfo.locale.replace("_", "-");
             const dateFormat = format.value.trim() === "" ? "short" : format.value;
             let timeString = this.formatTime(dateFormat, locale);
             if (timeString === "") {
@@ -469,7 +469,7 @@ export class RoDateTime extends BrsComponent implements BrsValue {
                 const tzDate = new Date(date.toLocaleString("en-US", { timeZone: timeZone }));
                 return Math.round((tzDate.getTime() - utcDate.getTime()) / 6e4);
             };
-            return new Int32(-getOffset(BrsDevice.deviceInfo.get("timeZone")) + 0);
+            return new Int32(-getOffset(BrsDevice.deviceInfo.timeZone) + 0);
         },
     });
 

--- a/src/core/brsTypes/components/RoDeviceCrypto.ts
+++ b/src/core/brsTypes/components/RoDeviceCrypto.ts
@@ -32,11 +32,11 @@ export class RoDeviceCrypto extends BrsComponent implements BrsValue {
          *  the real device.
          */
         this.keys = new Map();
-        let deviceId = BrsDevice.deviceInfo.get("clientId").replaceAll("-", "");
+        let deviceId = BrsDevice.deviceInfo.clientId.replaceAll("-", "");
         this.keys.set("device", this.format256BitKey(deviceId));
-        let devId = BrsDevice.deviceInfo.get("developerId");
+        let devId = BrsDevice.deviceInfo.developerId;
         this.keys.set("channel", this.format256BitKey(devId));
-        let model = BrsDevice.deviceInfo.get("deviceModel");
+        let model = BrsDevice.deviceInfo.deviceModel;
         this.keys.set("model", this.format256BitKey(`${model}${devId}`));
 
         this.registerMethods({ ifDeviceCrypto: [this.encrypt, this.decrypt] });

--- a/src/core/brsTypes/components/RoDeviceInfo.ts
+++ b/src/core/brsTypes/components/RoDeviceInfo.ts
@@ -45,11 +45,11 @@ export class RoDeviceInfo extends BrsComponent implements BrsValue {
 
     constructor() {
         super("roDeviceInfo");
-        this.deviceModel = BrsDevice.deviceInfo.get("deviceModel");
-        const device = BrsDevice.deviceInfo?.get("models")?.get(this.deviceModel);
+        this.deviceModel = BrsDevice.deviceInfo.deviceModel;
+        const device = BrsDevice.deviceInfo.models?.get(this.deviceModel);
         this.modelType = device ? device[1] : "STB";
-        this.firmware = BrsDevice.deviceInfo.get("firmwareVersion");
-        this.displayMode = BrsDevice.deviceInfo.get("displayMode") ?? "720p";
+        this.firmware = BrsDevice.deviceInfo.firmwareVersion;
+        this.displayMode = BrsDevice.deviceInfo.displayMode;
         this.displayAspectRatio = "16x9";
         this.displayResolution = { h: 720, w: 1280 };
         this.displayModeName = "HD";
@@ -61,7 +61,7 @@ export class RoDeviceInfo extends BrsComponent implements BrsValue {
             this.displayResolution = { h: 1080, w: 1920 };
             this.displayModeName = "FHD";
         }
-        this.captionsMode = BrsDevice.deviceInfo.get("captionsMode") ?? "Off";
+        this.captionsMode = BrsDevice.deviceInfo.captionsMode;
         const setPortIface = new IfSetMessagePort(this, this.getNewEvents.bind(this));
         const getPortIface = new IfGetMessagePort(this);
         this.registerMethods({
@@ -171,9 +171,9 @@ export class RoDeviceInfo extends BrsComponent implements BrsValue {
             args: [],
             returns: ValueKind.Object,
         },
-        impl: (interpreter: Interpreter) => {
+        impl: (_: Interpreter) => {
             const model = this.deviceModel;
-            const device = BrsDevice.deviceInfo?.get("models")?.get(model);
+            const device = BrsDevice.deviceInfo.models?.get(model);
             return new BrsString(
                 device ? device[0].replace(/ *\([^)]*\) */g, "") : `Roku (${model})`
             );
@@ -203,7 +203,7 @@ export class RoDeviceInfo extends BrsComponent implements BrsValue {
                 ModelNumber: this.deviceModel,
                 VendorName: "Roku",
                 VendorUSBName: "Roku",
-                SerialNumber: BrsDevice.deviceInfo?.get("serialNumber"),
+                SerialNumber: BrsDevice.deviceInfo.serialNumber,
             });
         },
     });
@@ -215,7 +215,7 @@ export class RoDeviceInfo extends BrsComponent implements BrsValue {
             returns: ValueKind.String,
         },
         impl: (interpreter: Interpreter) => {
-            return new BrsString(BrsDevice.deviceInfo.get("friendlyName"));
+            return new BrsString(BrsDevice.deviceInfo.friendlyName);
         },
     });
 
@@ -255,8 +255,8 @@ export class RoDeviceInfo extends BrsComponent implements BrsValue {
             args: [],
             returns: ValueKind.Int32,
         },
-        impl: (interpreter: Interpreter) => {
-            return new Int32(BrsDevice.deviceInfo.get("audioVolume"));
+        impl: (_: Interpreter) => {
+            return new Int32(BrsDevice.deviceInfo.audioVolume);
         },
     });
 
@@ -266,8 +266,8 @@ export class RoDeviceInfo extends BrsComponent implements BrsValue {
             args: [],
             returns: ValueKind.String,
         },
-        impl: (interpreter: Interpreter) => {
-            return new BrsString(BrsDevice.deviceInfo.get("clientId"));
+        impl: (_: Interpreter) => {
+            return new BrsString(BrsDevice.deviceInfo.clientId);
         },
     });
 
@@ -277,8 +277,8 @@ export class RoDeviceInfo extends BrsComponent implements BrsValue {
             args: [],
             returns: ValueKind.String,
         },
-        impl: (interpreter: Interpreter) => {
-            return new BrsString(BrsDevice.deviceInfo.get("clientId"));
+        impl: (_: Interpreter) => {
+            return new BrsString(BrsDevice.deviceInfo.clientId);
         },
     });
 
@@ -288,8 +288,8 @@ export class RoDeviceInfo extends BrsComponent implements BrsValue {
             args: [],
             returns: ValueKind.String,
         },
-        impl: (interpreter: Interpreter) => {
-            return new BrsString(BrsDevice.deviceInfo.get("RIDA"));
+        impl: (_: Interpreter) => {
+            return new BrsString(BrsDevice.deviceInfo.RIDA);
         },
     });
 
@@ -321,8 +321,8 @@ export class RoDeviceInfo extends BrsComponent implements BrsValue {
             args: [],
             returns: ValueKind.String,
         },
-        impl: (interpreter: Interpreter) => {
-            return new BrsString(BrsDevice.deviceInfo.get("countryCode"));
+        impl: (_: Interpreter) => {
+            return new BrsString(BrsDevice.deviceInfo.countryCode);
         },
     });
 
@@ -332,8 +332,8 @@ export class RoDeviceInfo extends BrsComponent implements BrsValue {
             args: [],
             returns: ValueKind.String,
         },
-        impl: (interpreter: Interpreter) => {
-            return new BrsString(BrsDevice.deviceInfo.get("countryCode"));
+        impl: (_: Interpreter) => {
+            return new BrsString(BrsDevice.deviceInfo.countryCode);
         },
     });
 
@@ -343,8 +343,8 @@ export class RoDeviceInfo extends BrsComponent implements BrsValue {
             args: [],
             returns: ValueKind.String,
         },
-        impl: (interpreter: Interpreter) => {
-            return new BrsString(BrsDevice.deviceInfo.get("captionLanguage"));
+        impl: (_: Interpreter) => {
+            return new BrsString(BrsDevice.deviceInfo.captionLanguage);
         },
     });
 
@@ -354,8 +354,8 @@ export class RoDeviceInfo extends BrsComponent implements BrsValue {
             args: [],
             returns: ValueKind.String,
         },
-        impl: (interpreter: Interpreter) => {
-            return new BrsString(BrsDevice.deviceInfo.get("timeZone"));
+        impl: (_: Interpreter) => {
+            return new BrsString(BrsDevice.deviceInfo.timeZone);
         },
     });
 
@@ -365,8 +365,8 @@ export class RoDeviceInfo extends BrsComponent implements BrsValue {
             args: [],
             returns: ValueKind.String,
         },
-        impl: (interpreter: Interpreter) => {
-            return new BrsString(BrsDevice.deviceInfo.get("locale"));
+        impl: (_: Interpreter) => {
+            return new BrsString(BrsDevice.deviceInfo.locale);
         },
     });
 
@@ -376,8 +376,8 @@ export class RoDeviceInfo extends BrsComponent implements BrsValue {
             args: [],
             returns: ValueKind.String,
         },
-        impl: (interpreter: Interpreter) => {
-            return new BrsString(BrsDevice.deviceInfo.get("clockFormat"));
+        impl: (_: Interpreter) => {
+            return new BrsString(BrsDevice.deviceInfo.clockFormat);
         },
     });
 
@@ -530,10 +530,8 @@ export class RoDeviceInfo extends BrsComponent implements BrsValue {
             args: [],
             returns: ValueKind.String,
         },
-        impl: (interpreter: Interpreter) => {
-            const device = BrsDevice.deviceInfo
-                ?.get("models")
-                ?.get(BrsDevice.deviceInfo.get("deviceModel"));
+        impl: (_: Interpreter) => {
+            const device = BrsDevice.deviceInfo.models?.get(this.deviceModel);
             return new BrsString(device ? device[2] : "opengl");
         },
     });
@@ -544,13 +542,13 @@ export class RoDeviceInfo extends BrsComponent implements BrsValue {
             args: [new StdlibArgument("feature", ValueKind.String)],
             returns: ValueKind.Boolean,
         },
-        impl: (interpreter: Interpreter, feature: BrsString) => {
+        impl: (_: Interpreter, feature: BrsString) => {
             const features = ["gaming_hardware", "usb_hardware", "simulation_engine"];
-            const custom = BrsDevice.deviceInfo.get("customFeatures");
+            const custom = BrsDevice.deviceInfo.customFeatures;
             if (custom instanceof Array && custom.length > 0) {
                 features.push(...custom);
             }
-            const platform = BrsDevice.deviceInfo.get("platform");
+            const platform = BrsDevice.deviceInfo.platform;
             if (isPlatform(platform)) {
                 for (const [key, value] of Object.entries(platform)) {
                     if (value) {
@@ -642,10 +640,10 @@ export class RoDeviceInfo extends BrsComponent implements BrsValue {
             args: [new StdlibArgument("options", ValueKind.Dynamic)],
             returns: ValueKind.Object,
         },
-        impl: (interpreter: Interpreter, options: RoAssociativeArray) => {
+        impl: (_: Interpreter, options: RoAssociativeArray) => {
             if (options instanceof RoAssociativeArray) {
                 const decode: FlexObject = {};
-                const codecs = BrsDevice.deviceInfo.get("audioCodecs") as string[];
+                const codecs = BrsDevice.deviceInfo.audioCodecs as string[];
                 const codec = options.get(new BrsString("codec"));
                 if (codec instanceof BrsString && codecs?.includes(codec.value.toLowerCase())) {
                     decode.result = true;
@@ -679,7 +677,7 @@ export class RoDeviceInfo extends BrsComponent implements BrsValue {
             args: [],
             returns: ValueKind.Object,
         },
-        impl: (_interpreter) => {
+        impl: (_: Interpreter) => {
             // This method is deprecated in Roku
             return new RoAssociativeArray([]);
         },
@@ -691,9 +689,9 @@ export class RoDeviceInfo extends BrsComponent implements BrsValue {
             args: [new StdlibArgument("options", ValueKind.Dynamic)],
             returns: ValueKind.Object,
         },
-        impl: (interpreter: Interpreter, options: RoAssociativeArray) => {
+        impl: (_: Interpreter, options: RoAssociativeArray) => {
             if (options instanceof RoAssociativeArray) {
-                const formats = BrsDevice.deviceInfo.get("videoFormats") as Map<string, string[]>;
+                const formats = BrsDevice.deviceInfo.videoFormats;
                 const codecs = formats?.get("codecs") ?? [];
                 const containers = formats?.get("containers") ?? [];
                 const codec = options.get(new BrsString("codec"));
@@ -802,7 +800,7 @@ export class RoDeviceInfo extends BrsComponent implements BrsValue {
             returns: ValueKind.String,
         },
         impl: (_: Interpreter) => {
-            const connInfo: ConnectionInfo = BrsDevice.deviceInfo.get("connectionInfo");
+            const connInfo: ConnectionInfo = BrsDevice.deviceInfo.connectionInfo;
             return new BrsString(connInfo.type);
         },
     });
@@ -814,7 +812,7 @@ export class RoDeviceInfo extends BrsComponent implements BrsValue {
             returns: ValueKind.String,
         },
         impl: (_: Interpreter) => {
-            const connInfo: ConnectionInfo = BrsDevice.deviceInfo.get("connectionInfo");
+            const connInfo: ConnectionInfo = BrsDevice.deviceInfo.connectionInfo;
             const result: FlexObject = {
                 active: 1,
                 default: 1,
@@ -828,7 +826,7 @@ export class RoDeviceInfo extends BrsComponent implements BrsValue {
                 result.protocol = "IEEE 802.11g";
                 result.signal = -140;
             }
-            const ips = BrsDevice.deviceInfo.get("localIps") as string[];
+            const ips = BrsDevice.deviceInfo.localIps;
             if (ips.length > 0) {
                 ips.some((iface: string) => {
                     if (iface.split(",")[0] === connInfo.name) {
@@ -919,10 +917,9 @@ export class RoDeviceInfo extends BrsComponent implements BrsValue {
             args: [],
             returns: ValueKind.Object,
         },
-        impl: (interpreter: Interpreter) => {
-            const ips = BrsDevice.deviceInfo.get("localIps") as string[];
+        impl: (_: Interpreter) => {
             const result: FlexObject = {};
-            ips.forEach(function (iface: string) {
+            BrsDevice.deviceInfo.localIps.forEach(function (iface: string) {
                 result[iface.split(",")[0]] = iface.split(",")[1];
             });
             return toAssociativeArray(result);

--- a/src/core/brsTypes/components/RoFontRegistry.ts
+++ b/src/core/brsTypes/components/RoFontRegistry.ts
@@ -39,7 +39,7 @@ export class RoFontRegistry extends BrsComponent implements BrsValue {
             ],
         });
         this.fontRegistry = new Map();
-        this.defaultFontFamily = BrsDevice.deviceInfo.get("defaultFont");
+        this.defaultFontFamily = BrsDevice.deviceInfo.defaultFont;
         this.registerFont(`common:/Fonts/${this.defaultFontFamily}-Regular.ttf`);
         this.registerFont(`common:/Fonts/${this.defaultFontFamily}-Bold.ttf`);
         this.registerFont(`common:/Fonts/${this.defaultFontFamily}-Italic.ttf`);

--- a/src/core/brsTypes/components/RoHdmiStatus.ts
+++ b/src/core/brsTypes/components/RoHdmiStatus.ts
@@ -19,10 +19,10 @@ export class RoHdmiStatus extends BrsComponent implements BrsValue {
         super("roHdmiStatus");
         this.active = 1; // Default to active
 
-        const deviceModel = BrsDevice.deviceInfo.get("deviceModel");
-        const device = BrsDevice.deviceInfo?.get("models")?.get(deviceModel);
+        const deviceModel = BrsDevice.deviceInfo.deviceModel;
+        const device = BrsDevice.deviceInfo.models?.get(deviceModel);
         this.modelType = device ? device[1] : "STB";
-        this.displayMode = BrsDevice.deviceInfo.get("displayMode") ?? "720p";
+        this.displayMode = BrsDevice.deviceInfo.displayMode;
         const setPortIface = new IfSetMessagePort(this, this.getNewEvents.bind(this));
         const getPortIface = new IfGetMessagePort(this);
         this.registerMethods({

--- a/src/core/brsTypes/components/RoLocalization.ts
+++ b/src/core/brsTypes/components/RoLocalization.ts
@@ -13,7 +13,7 @@ export class RoLocalization extends BrsComponent implements BrsValue {
     // Constructor can only be used by RoFontRegistry()
     constructor() {
         super("roLocalization");
-        this.locale = BrsDevice.deviceInfo.get("locale");
+        this.locale = BrsDevice.deviceInfo.locale;
         this.registerMethods({ ifLocalization: [this.getPluralString, this.getLocalizedAsset] });
     }
 

--- a/src/core/brsTypes/components/RoRegistry.ts
+++ b/src/core/brsTypes/components/RoRegistry.ts
@@ -31,7 +31,7 @@ export class RoRegistry extends BrsComponent implements BrsValue {
             returns: ValueKind.Boolean,
         },
         impl: (_: Interpreter, section: BrsString) => {
-            let devId = BrsDevice.deviceInfo.get("developerId");
+            let devId = BrsDevice.deviceInfo.developerId;
             [...BrsDevice.registry.keys()].forEach((key) => {
                 let regSection = `${devId}.${section}`;
                 if (key.startsWith(regSection)) {
@@ -61,7 +61,7 @@ export class RoRegistry extends BrsComponent implements BrsValue {
             returns: ValueKind.Object,
         },
         impl: (_: Interpreter) => {
-            let devId = BrsDevice.deviceInfo.get("developerId");
+            let devId = BrsDevice.deviceInfo.developerId;
             let sections = new Set<string>();
             [...BrsDevice.registry.keys()].forEach((key) => {
                 if (key.split(".")[0] === devId) {
@@ -83,7 +83,7 @@ export class RoRegistry extends BrsComponent implements BrsValue {
             returns: ValueKind.Int32,
         },
         impl: (_: Interpreter) => {
-            const devId = BrsDevice.deviceInfo.get("developerId");
+            const devId = BrsDevice.deviceInfo.developerId;
             let space = 32 * 1024;
             BrsDevice.registry.forEach((value, key) => {
                 if (key.split(".")[0] === devId) {

--- a/src/core/brsTypes/components/RoRegistrySection.ts
+++ b/src/core/brsTypes/components/RoRegistrySection.ts
@@ -16,7 +16,7 @@ export class RoRegistrySection extends BrsComponent implements BrsValue {
     constructor(section: BrsString) {
         super("roRegistrySection");
         this.section = section.value;
-        this.devId = BrsDevice.deviceInfo.get("developerId");
+        this.devId = BrsDevice.deviceInfo.developerId;
         this.registerMethods({
             ifRegistrySection: [
                 this.read,
@@ -50,8 +50,7 @@ export class RoRegistrySection extends BrsComponent implements BrsValue {
             returns: ValueKind.String,
         },
         impl: (_: Interpreter, key: BrsString) => {
-            let devId = BrsDevice.deviceInfo.get("developerId");
-            let value = BrsDevice.registry.get(`${devId}.${this.section}.${key.value}`);
+            let value = BrsDevice.registry.get(`${this.devId}.${this.section}.${key.value}`);
             if (!value) {
                 value = "";
             }
@@ -66,11 +65,10 @@ export class RoRegistrySection extends BrsComponent implements BrsValue {
             returns: ValueKind.Dynamic,
         },
         impl: (_: Interpreter, keysArray: RoArray) => {
-            let devId = BrsDevice.deviceInfo.get("developerId");
             let keys = keysArray.getElements() as BrsString[];
             let result = new RoAssociativeArray([]);
             keys.forEach((key) => {
-                let fullKey = `${devId}.${this.section}.${key.value}`;
+                let fullKey = `${this.devId}.${this.section}.${key.value}`;
                 let value = BrsDevice.registry.get(fullKey);
                 if (value) {
                     result.set(key, new BrsString(value));

--- a/src/core/brsTypes/components/RoRemoteInfo.ts
+++ b/src/core/brsTypes/components/RoRemoteInfo.ts
@@ -69,7 +69,7 @@ export class RoRemoteInfo extends BrsComponent implements BrsValue {
 }
 
 function getRemote(_: Interpreter, index: number): RemoteControl {
-    const remotes = BrsDevice.deviceInfo.get("remoteControls");
+    const remotes = BrsDevice.deviceInfo.remoteControls;
     if (remotes instanceof Array && remotes.length && index < remotes.length) {
         if (index < 0) {
             index = BrsDevice.lastRemote;

--- a/src/core/brsTypes/components/RoScreen.ts
+++ b/src/core/brsTypes/components/RoScreen.ts
@@ -54,15 +54,14 @@ export class RoScreen extends BrsComponent implements BrsValue, BrsDraw2D {
 
         let defaultWidth = 854;
         let defaultHeight = 480;
-        if (BrsDevice.deviceInfo.get("displayMode") === "1080p") {
+        if (BrsDevice.deviceInfo.displayMode === "1080p") {
             defaultWidth = 1920;
             defaultHeight = 1080;
-        } else if (BrsDevice.deviceInfo.get("displayMode") === "720p") {
+        } else if (BrsDevice.deviceInfo.displayMode === "720p") {
             defaultWidth = 1280;
             defaultHeight = 720;
         }
-        const platform = BrsDevice.deviceInfo.get("platform");
-        this.disposeCanvas = platform?.inIOS ?? false;
+        this.disposeCanvas = BrsDevice.deviceInfo.platform?.inIOS ?? false;
         this.lastMessage = performance.now();
         this.isDirty = true;
         this.width = defaultWidth;
@@ -98,7 +97,7 @@ export class RoScreen extends BrsComponent implements BrsValue, BrsDraw2D {
         this.context = new Array<BrsCanvasContext2D>(this.doubleBuffer ? 2 : 1);
         this.createDisplayBuffer();
         this.alphaEnable = false;
-        const maxFps = BrsDevice.deviceInfo.get("maxFps") || 60;
+        const maxFps = BrsDevice.deviceInfo.maxFps;
         this.maxMs = Math.trunc((1 / maxFps) * 1000);
         const ifDraw2D = new IfDraw2D(this);
         const ifSetMsgPort = new IfSetMessagePort(this, this.getNewEvents.bind(this));

--- a/src/core/brsTypes/components/RoURLTransfer.ts
+++ b/src/core/brsTypes/components/RoURLTransfer.ts
@@ -776,7 +776,7 @@ export class RoURLTransfer extends BrsComponent implements BrsValue, BrsHttpAgen
             returns: ValueKind.String,
         },
         impl: (_: Interpreter) => {
-            const firmware = BrsDevice.deviceInfo.get("firmwareVersion");
+            const firmware = BrsDevice.deviceInfo.firmwareVersion;
             const os = getRokuOSVersion(firmware);
             const short = `${os.get("major")}.${os.get("minor")}`;
             const long = `${short}.${os.get("revision")}.${os.get("build")}-${os.get("plid")}`;

--- a/src/core/brsTypes/interfaces/IfHttpAgent.ts
+++ b/src/core/brsTypes/interfaces/IfHttpAgent.ts
@@ -37,12 +37,9 @@ export class IfHttpAgent {
             ],
             returns: ValueKind.Boolean,
         },
-        impl: (interpreter: Interpreter, name: BrsString, value: BrsString) => {
+        impl: (_: Interpreter, name: BrsString, value: BrsString) => {
             if (name.value.toLowerCase() === "x-roku-reserved-dev-id") {
-                this.component.customHeaders.set(
-                    name.value,
-                    BrsDevice.deviceInfo.get("developerId")
-                );
+                this.component.customHeaders.set(name.value, BrsDevice.deviceInfo.developerId);
             } else {
                 this.component.customHeaders.set(name.value, value.value);
             }
@@ -56,11 +53,11 @@ export class IfHttpAgent {
             args: [new StdlibArgument("headers", ValueKind.Dynamic)],
             returns: ValueKind.Boolean,
         },
-        impl: (interpreter: Interpreter, headers: RoAssociativeArray) => {
+        impl: (_: Interpreter, headers: RoAssociativeArray) => {
             this.component.customHeaders.clear();
             headers.elements.forEach((value: BrsType, key: string) => {
                 if (key.toLowerCase() === "x-roku-reserved-dev-id") {
-                    this.component.customHeaders.set(key, BrsDevice.deviceInfo.get("developerId"));
+                    this.component.customHeaders.set(key, BrsDevice.deviceInfo.developerId);
                 } else {
                     this.component.customHeaders.set(key, (value as BrsString).value);
                 }

--- a/src/core/device/BrsDevice.ts
+++ b/src/core/device/BrsDevice.ts
@@ -1,9 +1,9 @@
-import { dataBufferIndex, DataType, DebugCommand } from "../common";
+import { dataBufferIndex, DataType, DebugCommand, defaultDeviceInfo, DeviceInfo } from "../common";
 import { FileSystem } from "./FileSystem";
 import { OutputProxy } from "./OutputProxy";
 
 export class BrsDevice {
-    static readonly deviceInfo: Map<string, any> = new Map<string, any>();
+    static readonly deviceInfo: DeviceInfo = defaultDeviceInfo;
     static readonly registry: Map<string, string> = new Map<string, string>();
     static readonly fileSystem: FileSystem = new FileSystem();
     static readonly isDevMode = process.env.NODE_ENV === "development";
@@ -33,6 +33,22 @@ export class BrsDevice {
      */
     static setSharedArray(sharedArray: Int32Array) {
         this.sharedArray = sharedArray;
+    }
+
+    /**
+     * Set the device info
+     * @param deviceInfo DeviceInfo to be set
+     */
+    static setDeviceInfo(deviceInfo: DeviceInfo) {
+        Object.entries(deviceInfo).forEach(([key, value]) => {
+            if (key !== "registry" && key !== "assets") {
+                if (key === "developerId") {
+                    // Prevent developerId from having "." to avoid issues on registry persistence
+                    value = value.replace(".", ":");
+                }
+                this.deviceInfo[key] = value;
+            }
+        });
     }
 
     /**

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -136,7 +136,7 @@ export async function getReplInterpreter(payload: Partial<AppPayload>) {
         if (payload.device.registry?.size) {
             BrsDevice.setRegistry(payload.device.registry);
         }
-        setupDeviceData(payload.device);
+        BrsDevice.setDeviceInfo(payload.device);
     }
     return replInterpreter;
 }
@@ -328,7 +328,7 @@ function setupPayload(interpreter: Interpreter, payload: AppPayload): SourceResu
     if (payload.device.registry?.size) {
         BrsDevice.setRegistry(payload.device.registry);
     }
-    setupDeviceData(payload.device);
+    BrsDevice.setDeviceInfo(payload.device);
     setupTranslations(interpreter);
     return setupPackageFiles(payload);
 }
@@ -358,23 +358,6 @@ function setupInputParams(
         inputMap.set(key, value);
     });
     return BrsTypes.toAssociativeArray(inputMap);
-}
-
-/**
- * Updates the interpreter DeviceInfo Map with the provided data and
- * initializes the common: file system with device internal libraries.
- * @param device object with device info data
- */
-function setupDeviceData(device: DeviceInfo) {
-    Object.keys(device).forEach((key) => {
-        if (key !== "registry" && key !== "assets") {
-            if (key === "developerId") {
-                // Prevent the developerId from having dots to avoid issues with the registry persistence
-                BrsDevice.deviceInfo.set(key, device[key].replace(".", ":"));
-            }
-            BrsDevice.deviceInfo.set(key, device[key]);
-        }
-    });
 }
 
 /**
@@ -422,7 +405,7 @@ function setupTranslations(interpreter: Interpreter) {
     let xmlText = "";
     let trType = "";
     let trTarget = "";
-    const locale = BrsDevice.deviceInfo.get("locale") || "en_US";
+    const locale = BrsDevice.deviceInfo.locale;
     try {
         const fsys = BrsDevice.fileSystem;
         if (fsys?.existsSync(`pkg:/locale/${locale}/translations.ts`)) {

--- a/src/core/interpreter/index.ts
+++ b/src/core/interpreter/index.ts
@@ -57,7 +57,7 @@ import { Scope, Environment, NotFound } from "./Environment";
 import { toCallable } from "./BrsFunction";
 import { BlockEnd, GotoLabel } from "../parser/Statement";
 import { runDebugger } from "./MicroDebugger";
-import { DataType, DebugCommand, defaultDeviceInfo, numberToHex, parseTextFile } from "../common";
+import { DataType, DebugCommand, numberToHex, parseTextFile } from "../common";
 /// #if !BROWSER
 import * as v8 from "v8";
 /// #endif

--- a/src/core/interpreter/index.ts
+++ b/src/core/interpreter/index.ts
@@ -207,11 +207,6 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
         if (this.options.ext) {
             BrsDevice.fileSystem.setExt(this.options.ext);
         }
-        for (const [key, value] of Object.entries(defaultDeviceInfo)) {
-            if (!["registry", "fonts"].includes(key)) {
-                BrsDevice.deviceInfo.set(key, value);
-            }
-        }
         const global = new Set<string>();
         Object.keys(StdLib)
             .map((name) => (StdLib as any)[name])

--- a/src/core/stdlib/index.ts
+++ b/src/core/stdlib/index.ts
@@ -35,7 +35,7 @@ export const UpTime = new Callable("UpTime", {
         returns: ValueKind.Float,
     },
     impl: (_: Interpreter) => {
-        const startTime = BrsDevice.deviceInfo.get("startTime");
+        const startTime = BrsDevice.deviceInfo.startTime;
         return new Float(Math.round((Date.now() - startTime) / 1000));
     },
 });


### PR DESCRIPTION
There was no need to have the `DeviceInfo` object as a Map, as it is now part of `BrsDevice`