### PR TITLE
Invert the remote control mapping for `PageUp` and `PageDown` keys

### DIFF
--- a/docs/remote-control.md
+++ b/docs/remote-control.md
@@ -18,8 +18,8 @@ The default mapping of the keyboard and game pads to Roku remote control is desc
 | Backspace   |   6 or 16  |    Replay    | Instant replay button.                                                |
 | Enter       |     0      |    OK        | Select button.                                                        |
 | Insert      |   4 or 7   |    Info      | Information/Settings button                                           |
-| PageDown    |     2      |    Rewind    | Reverse scan button.                                                  |
-| PageUp      |     3      | Fast Forward | Forward scan button.                                                  |
+| PageUp      |     2      |    Rewind    | Reverse scan button.                                                  |
+| PageDown    |     3      | Fast Forward | Forward scan button.                                                  |
 | End         |   5 or 9   |  Play/Pause  | Play/Pause button.                                                    |
 | Ctrl+A      |    10      |     A        | A game button.                                                        |
 | Ctrl+Z      |    11      |     B        | B game button.                                                        |

--- a/src/api/control.ts
+++ b/src/api/control.ts
@@ -211,8 +211,8 @@ if (platform.inIOS || platform.inMacOS) {
     keysMap.set("Control+Digit8", "info");
     keysMap.set("Control+Pause", "break");
 }
-keysMap.set("PageDown", "rev");
-keysMap.set("PageUp", "fwd");
+keysMap.set("PageUp", "rev");
+keysMap.set("PageDown", "fwd");
 keysMap.set("Insert", "info");
 keysMap.set("Control+KeyA", "a");
 keysMap.set("Control+KeyZ", "b");


### PR DESCRIPTION
It makes more sense when you press `PageDown` to advance in lists and video, and in SceneGraph it moves cursor down in lists using FF, so the behavior is being inverted of the two keys.