### PR TITLE
Fixed `m` context when getting function with `index` #494

### DIFF
--- a/src/core/interpreter/index.ts
+++ b/src/core/interpreter/index.ts
@@ -1179,7 +1179,10 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                     return arg;
                 });
 
-                if (expression.callee instanceof Expr.DottedGet) {
+                if (
+                    expression.callee instanceof Expr.DottedGet ||
+                    expression.callee instanceof Expr.IndexedGet
+                ) {
                     mPointer = callee.getContext() ?? mPointer;
                 }
                 return this.inSubEnv((subInterpreter) => {

--- a/test/e2e/Functions.test.js
+++ b/test/e2e/Functions.test.js
@@ -95,6 +95,9 @@ describe("end to end functions", () => {
         expect(allArgs(outputStreams.stdout.write).map((arg) => arg.trimEnd())).toEqual([
             "not root",
             "root",
+            "bar",
+            "bar",
+            "invalid",
         ]);
     });
 

--- a/test/e2e/resources/function/m-pointer-func.brs
+++ b/test/e2e/resources/function/m-pointer-func.brs
@@ -2,6 +2,7 @@ Sub Main()
     m.someValue = "root"
     objA = { myMethod: do_something, someValue: "not root" }
     print objA.myMethod()
+    anon_func_context()
 End Sub
 
 function do_something()
@@ -12,3 +13,16 @@ end function
 Function GenericFunction()
     return m.someValue      'Must use Global m
 End Function
+
+function anon_func_context()
+    a = {
+      foo: "bar",
+      printM: sub()
+            print(m.foo)
+      end sub
+    }
+  a.printM()
+    a["printM"]()
+  x = a["printM"]
+  x()
+end function


### PR DESCRIPTION
The interpreter was not preserving the `m` context when the function was retrieved with `IndexedGet`