### PR TITLE
Moved `focusedNode` from `Environment` to `rootObjects` 

### DIFF
--- a/src/core/brsTypes/components/RoSGNode.ts
+++ b/src/core/brsTypes/components/RoSGNode.ts
@@ -304,11 +304,8 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         if (this.children.length === 0) {
             return false;
         }
-
         for (let childNode of this.children) {
-            if (rootObjects.focused === childNode) {
-                return true;
-            } else if (childNode.isChildrenFocused(interpreter)) {
+            if (rootObjects.focused === childNode || childNode.isChildrenFocused(interpreter)) {
                 return true;
             }
         }

--- a/src/core/brsTypes/components/RoSGNode.ts
+++ b/src/core/brsTypes/components/RoSGNode.ts
@@ -306,7 +306,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         }
 
         for (let childNode of this.children) {
-            if (interpreter.environment.getFocusedNode() === childNode) {
+            if (rootObjects.focused === childNode) {
                 return true;
             } else if (childNode.isChildrenFocused(interpreter)) {
                 return true;
@@ -383,7 +383,6 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
     /** Sets or removes the focus to/from the Node */
     setNodeFocus(interpreter: Interpreter, focusOn: boolean): boolean {
         let focusedChildString = new BrsString("focusedchild");
-        let currFocusedNode = interpreter.environment.getFocusedNode();
         if (focusOn) {
             if (!this.triedInitFocus) {
                 // Only try initial focus once
@@ -400,16 +399,16 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
                 }
             }
 
-            interpreter.environment.setFocusedNode(this);
+            rootObjects.focused = this;
 
             // Get the focus chain, with lowest ancestor first.
             let newFocusChain = this.createPath(this);
 
             // If there's already a focused node somewhere, we need to remove focus
             // from it and its ancestors.
-            if (currFocusedNode instanceof RoSGNode) {
+            if (rootObjects.focused instanceof RoSGNode) {
                 // Get the focus chain, with root-most ancestor first.
-                let currFocusChain = this.createPath(currFocusedNode);
+                let currFocusChain = this.createPath(rootObjects.focused);
 
                 // Find the lowest common ancestor (LCA) between the newly focused node
                 // and the current focused node.
@@ -432,10 +431,11 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             }
 
             // Finally, set the focusedChild of the newly focused node to itself (to mimic RBI behavior).
-            this.set(focusedChildString, this);
-        } else if (currFocusedNode === this) {
+            this.set(focusedChildString, this, false);
+        } else if (rootObjects.focused === this) {
             // If we're unsetting focus on ourself, we need to unset it on all ancestors as well.
-            interpreter.environment.setFocusedNode(BrsInvalid.Instance);
+            const currFocusedNode = rootObjects.focused;
+            rootObjects.focused = undefined;
             // Get the focus chain, with root-most ancestor first.
             let currFocusChain = this.createPath(currFocusedNode);
             currFocusChain.forEach((node) => {
@@ -491,7 +491,18 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
 
     /** Copies a field value from this Node to a Child node field */
     protected copyField(node: RoSGNode, fieldName: string, thisField?: string) {
-        node.setFieldValue(fieldName, this.getFieldValue(thisField ?? fieldName));
+        const value = this.getFieldValue(thisField ?? fieldName);
+        node.set(new BrsString(fieldName), value);
+        return value;
+    }
+
+    /** Links a field from another node to this node field */
+    protected linkField(node: RoSGNode, fieldName: string, thisField?: string) {
+        const field = node.getNodeFields().get(fieldName.toLowerCase());
+        if (field) {
+            this.fields.set((thisField ?? fieldName).toLowerCase(), field);
+        }
+        return field;
     }
 
     /** Message callback to handle observed fields with message port */
@@ -1650,8 +1661,8 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             args: [],
             returns: ValueKind.Boolean,
         },
-        impl: (interpreter: Interpreter) => {
-            return BrsBoolean.from(interpreter.environment.getFocusedNode() === this);
+        impl: (_: Interpreter) => {
+            return BrsBoolean.from(rootObjects.focused === this);
         },
     });
 
@@ -1684,7 +1695,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         },
         impl: (interpreter: Interpreter) => {
             // loop through all children DFS and check if any children has focus
-            if (interpreter.environment.getFocusedNode() === this) {
+            if (rootObjects.focused === this) {
                 return BrsBoolean.True;
             }
 
@@ -1812,6 +1823,8 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
 interface RootObjects {
     mGlobal: RoSGNode;
     rootScene?: Scene;
+    dialog?: RoSGNode;
+    focused?: RoSGNode;
     tasks: Task[];
 }
 export const rootObjects: RootObjects = { mGlobal: new RoSGNode([]), tasks: [] };

--- a/src/core/brsTypes/components/RoSGScreen.ts
+++ b/src/core/brsTypes/components/RoSGScreen.ts
@@ -287,14 +287,13 @@ export class RoSGScreen extends BrsComponent implements BrsValue, BrsDraw2D {
         },
         impl: (interpreter: Interpreter) => {
             if (this.sceneType && rootObjects.rootScene) {
-                console.log("showing screen - Initializing Scene");
                 const typeDef = interpreter.environment.nodeDefMap.get(
                     this.sceneType.value.toLowerCase()
                 );
                 initializeNode(interpreter, this.sceneType, typeDef, rootObjects.rootScene);
             }
             this.isDirty = true;
-            return BrsBoolean.False;
+            return BrsBoolean.True;
         },
     });
 

--- a/src/core/brsTypes/nodes/Button.ts
+++ b/src/core/brsTypes/nodes/Button.ts
@@ -219,7 +219,7 @@ export class Button extends Group {
         if (!this.isVisible()) {
             return;
         }
-        const nodeFocus = interpreter.environment.getFocusedNode() === this;
+        const nodeFocus = rootObjects.focused === this;
         const nodeTrans = this.getTranslation();
         const drawTrans = angle !== 0 ? rotateTranslation(nodeTrans, angle) : nodeTrans.slice();
         drawTrans[0] += origin[0];

--- a/src/core/brsTypes/nodes/ButtonGroup.ts
+++ b/src/core/brsTypes/nodes/ButtonGroup.ts
@@ -142,6 +142,7 @@ export class ButtonGroup extends LayoutGroup {
             this.isDirty = false;
         }
         this.refreshFocus(interpreter);
+        // TODO: update then width/height based on the # of buttons and layout direction
         this.updateBoundingRects(boundingRect, origin, angle);
         this.renderChildren(interpreter, drawTrans, angle, draw2D);
         this.updateParentRects(origin, angle);
@@ -158,8 +159,8 @@ export class ButtonGroup extends LayoutGroup {
         this.width = this.calculateButtonWidth(buttons, focusedFont.createDrawFont());
         for (let i = 0; i < buttonsCount; i++) {
             const buttonText = buttons[i];
-            let button = this.children[i] as Button;
             if (buttonText) {
+                let button = this.children[i] as Button;
                 if (!button) {
                     button = this.createButton();
                 }
@@ -177,6 +178,7 @@ export class ButtonGroup extends LayoutGroup {
                 button.setFieldValue("minWidth", new Float(this.width));
                 this.copyField(button, "maxWidth");
                 button.setFieldValue("showFocusFootprint", BrsBoolean.from(this.focusIndex === i));
+                // TODO: Implement support for field layoutDirection (vert, horiz)
                 const buttonY = i * (Math.max(buttonHeight, this.iconSize[1]) - this.vertOffset);
                 const offsetY = Math.max((this.iconSize[1] - buttonHeight) / 2, 0);
                 button.setFieldValue("translation", brsValueOf([0, buttonY + offsetY]));

--- a/src/core/brsTypes/nodes/ButtonGroup.ts
+++ b/src/core/brsTypes/nodes/ButtonGroup.ts
@@ -203,14 +203,16 @@ export class ButtonGroup extends LayoutGroup {
     }
 
     private refreshFocus(interpreter: Interpreter) {
-        const focusedNode = interpreter.environment.getFocusedNode();
+        const focusedNode = rootObjects.focused;
         if (
             this.children.length &&
             focusedNode instanceof RoSGNode &&
             (focusedNode === this || focusedNode.getNodeParent() === this)
         ) {
             const focusedButton = this.children[this.focusIndex];
-            interpreter.environment.setFocusedNode(focusedButton);
+            if (focusedNode !== focusedButton) {
+                rootObjects.focused = focusedButton;
+            }
         }
     }
 

--- a/src/core/brsTypes/nodes/LabelList.ts
+++ b/src/core/brsTypes/nodes/LabelList.ts
@@ -156,7 +156,7 @@ export class LabelList extends ArrayGrid {
         if (childCount === 0) {
             return;
         }
-        const nodeFocus = interpreter.environment.getFocusedNode() === this;
+        const nodeFocus = rootObjects.focused === this;
         const nodeTrans = this.getTranslation();
         const drawTrans = angle !== 0 ? rotateTranslation(nodeTrans, angle) : nodeTrans.slice();
         drawTrans[0] += origin[0];

--- a/src/core/brsTypes/nodes/LabelList.ts
+++ b/src/core/brsTypes/nodes/LabelList.ts
@@ -151,6 +151,7 @@ export class LabelList extends ArrayGrid {
             return;
         }
         const content = this.getFieldValue("content") as ContentNode;
+        // TODO: handle the content with sections
         const childCount = content.getNodeChildren().length;
         if (childCount === 0) {
             return;

--- a/src/core/brsTypes/nodes/Overhang.ts
+++ b/src/core/brsTypes/nodes/Overhang.ts
@@ -65,9 +65,9 @@ export class Overhang extends Group {
         this.registerDefaultFields(this.defaultFields);
         this.registerInitializedFields(initializedFields);
 
-        if (rootObjects.rootScene?.ui && rootObjects.rootScene.ui.resolution === "FHD") {
+        this.resolution = rootObjects.rootScene?.ui.resolution ?? "HD";
+        if (this.resolution === "FHD") {
             this.width = 1920;
-            this.resolution = "FHD";
             this.setFieldValue("width", new Float(this.width));
             this.setFieldValue("height", new Float(172));
             this.background = this.addPoster("", [0, 0], 172, this.width);
@@ -80,7 +80,6 @@ export class Overhang extends Group {
             this.clockText = this.addLabel("clockColor", [1682, 64], 40, 33, "center");
         } else {
             this.width = 1280;
-            this.resolution = "HD";
             this.setFieldValue("width", new Float(this.width));
             this.setFieldValue("height", new Float(115));
             this.background = this.addPoster("", [0, 0], 115, this.width);

--- a/src/core/brsTypes/nodes/Overhang.ts
+++ b/src/core/brsTypes/nodes/Overhang.ts
@@ -1,4 +1,4 @@
-import { Field, FieldModel } from "./Field";
+import { Field, FieldKind, FieldModel } from "./Field";
 import {
     AAMember,
     BrsString,
@@ -10,6 +10,7 @@ import {
     BrsBoolean,
     brsValueOf,
     rootObjects,
+    BrsType,
 } from "..";
 import { Group } from "./Group";
 import { Interpreter } from "../../interpreter";
@@ -56,7 +57,7 @@ export class Overhang extends Group {
     private readonly dividerFHD: string = "common:/images/divider_vertical_FHD.png";
     private readonly width: number;
     private readonly resolution: string;
-    private realign: boolean = false;
+    private realign: boolean;
 
     constructor(initializedFields: AAMember[] = [], readonly name: string = "Overhang") {
         super([], name);
@@ -101,6 +102,7 @@ export class Overhang extends Group {
         clock.set(new BrsString("control"), new BrsString("start"));
         this.children.push(clock);
         clock.setNodeParent(this);
+        this.realign = false;
     }
 
     private getTime() {
@@ -163,7 +165,11 @@ export class Overhang extends Group {
         return label;
     }
 
-    private updateChildren(realign: boolean) {
+    private updateChildren() {
+        const height = this.getFieldValue("height");
+        if (height instanceof Float && height.getValue()) {
+            this.background.set(new BrsString("height"), height);
+        }
         const backgroundUri = this.getFieldValue("backgroundUri") as BrsString;
         if (backgroundUri?.value) {
             this.background.set(new BrsString("uri"), backgroundUri);
@@ -211,19 +217,18 @@ export class Overhang extends Group {
         if (rightDividerUri?.value) {
             this.rightDivider.set(new BrsString("uri"), rightDividerUri);
         }
-        if (realign) {
-            this.alignChildren(showClock.toBoolean());
-        }
+        this.isDirty = false;
     }
 
-    private alignChildren(showClock: boolean) {
+    private alignChildren() {
         const isFHD = this.resolution === "FHD";
         const leftAlignX = isFHD ? 102 : 68;
         const logoWidth = this.logo.rectLocal.width;
         const optionsWidth = this.optionsText.rectLocal.width ?? (isFHD ? 168 : 112);
-        const clockTextWidth = showClock ? this.clockText.rectLocal.width : 0;
+        const showClock = this.getFieldValue("showClock") as BrsBoolean;
+        const clockTextWidth = showClock.toBoolean() ? this.clockText.rectLocal.width : 0;
         const clockOffset = isFHD ? 60 : 40;
-        const optionsOffset = showClock ? optionsWidth + clockOffset : optionsWidth;
+        const optionsOffset = showClock.toBoolean() ? optionsWidth + clockOffset : optionsWidth;
         const rightAlignX = this.width - leftAlignX - clockTextWidth;
         const translation = new BrsString("translation");
         if (isFHD) {
@@ -243,6 +248,12 @@ export class Overhang extends Group {
             this.rightDivider.set(translation, brsValueOf([rightAlignX - 24, 41]));
             this.clockText.set(translation, brsValueOf([rightAlignX, 44]));
         }
+        this.realign = false;
+    }
+
+    set(index: BrsType, value: BrsType, alwaysNotify: boolean = false, kind?: FieldKind) {
+        this.realign = true;
+        return super.set(index, value, alwaysNotify, kind);
     }
 
     renderNode(interpreter: Interpreter, origin: number[], angle: number, draw2D?: IfDraw2D) {
@@ -250,14 +261,15 @@ export class Overhang extends Group {
             return;
         }
         if (this.isDirty) {
-            this.updateChildren(this.realign);
-            this.realign = true;
-            this.isDirty = false;
+            this.updateChildren();
         }
         const size = this.getDimensions();
         const rect = { x: origin[0], y: origin[1], width: size.width, height: size.height };
         this.updateBoundingRects(rect, origin, angle);
         this.renderChildren(interpreter, origin, angle, draw2D);
         this.updateParentRects(origin, angle);
+        if (this.realign) {
+            this.alignChildren();
+        }
     }
 }

--- a/src/core/brsTypes/nodes/Scene.ts
+++ b/src/core/brsTypes/nodes/Scene.ts
@@ -12,6 +12,7 @@ import {
     RoArray,
     RoBitmap,
     RoMessagePort,
+    rootObjects,
     RoSGNode,
     toAssociativeArray,
 } from "..";
@@ -100,9 +101,8 @@ export class Scene extends Group {
 
     /** Handle SceneGraph onKeyEvent event */
     handleOnKeyEvent(interpreter: Interpreter, key: BrsString, press: BrsBoolean) {
-        const focusedNode = interpreter.environment.getFocusedNode();
-        if (focusedNode instanceof RoSGNode) {
-            const path = this.createPath(focusedNode, false);
+        if (rootObjects.focused instanceof RoSGNode) {
+            const path = this.createPath(rootObjects.focused, false);
             for (let node of path) {
                 if (this.handleKeyByNode(interpreter, node, key, press)) {
                     return true;

--- a/src/core/interpreter/Environment.ts
+++ b/src/core/interpreter/Environment.ts
@@ -1,13 +1,6 @@
 import { Identifier } from "../lexer";
 import { Location } from "../lexer/Token";
-import {
-    BrsComponent,
-    BrsType,
-    Int32,
-    RoAssociativeArray,
-    RoSGNode,
-    ValueKind,
-} from "../brsTypes";
+import { BrsComponent, BrsType, Int32, RoAssociativeArray, RoSGNode, ValueKind } from "../brsTypes";
 import { TypeMismatch } from "../error/TypeMismatch";
 import { ComponentDefinition } from "../scenegraph";
 

--- a/src/core/interpreter/Environment.ts
+++ b/src/core/interpreter/Environment.ts
@@ -2,7 +2,6 @@ import { Identifier } from "../lexer";
 import { Location } from "../lexer/Token";
 import {
     BrsComponent,
-    BrsInvalid,
     BrsType,
     Int32,
     RoAssociativeArray,
@@ -59,14 +58,6 @@ export class Environment {
     /** The BrightScript `m` pointer, analogous to JavaScript's `this` pointer. */
     private mPointer: RoAssociativeArray;
     private rootM: RoAssociativeArray;
-
-    /**
-     * The one true focus of the scenegraph app, only one component can have focus at a time.
-     * Note: this focus is only meaningful if the node being set focus to
-     * is a child of the main scene graph tree.  Otherwise, it will not follow the rule
-     * of stealing focus away from another node if a new node got focus.
-     */
-    private focusedNode: RoSGNode | BrsInvalid = BrsInvalid.Instance;
 
     /** Map holding component definitions of all parsed xml component files */
     public nodeDefMap = new Map<string, ComponentDefinition>();
@@ -280,7 +271,6 @@ export class Environment {
     public createSubEnvironment(includeModuleScope: boolean = true): Environment {
         let newEnvironment = new Environment(this.mPointer, this.rootM);
         newEnvironment.global = this.global;
-        newEnvironment.focusedNode = this.focusedNode;
         newEnvironment.nodeDefMap = this.nodeDefMap;
         newEnvironment.hostNode = this.hostNode;
         if (includeModuleScope) {
@@ -289,20 +279,5 @@ export class Environment {
             newEnvironment.module = new Map<string, BrsType>();
         }
         return newEnvironment;
-    }
-    /**
-     * Sets the currently focused node, which reacts to onKey button presses
-     * @param node either node object or invalid
-     */
-    public setFocusedNode(node: RoSGNode | BrsInvalid) {
-        this.focusedNode = node;
-    }
-
-    /**
-     * Gets the currently focused node, which reacts to onKey button presses
-     * @returns currently focused node
-     */
-    public getFocusedNode(): RoSGNode | BrsInvalid {
-        return this.focusedNode;
     }
 }

--- a/src/core/interpreter/index.ts
+++ b/src/core/interpreter/index.ts
@@ -257,13 +257,11 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
     inSubEnv(func: (interpreter: Interpreter) => BrsType, environment?: Environment): BrsType {
         let originalEnvironment = this._environment;
         let newEnv = environment ?? this._environment.createSubEnvironment();
-        newEnv.setFocusedNode(this._environment.getFocusedNode());
         let retValue: BrsComponent | undefined = undefined;
         try {
             this._environment = newEnv;
             const returnValue = func(this);
             this._environment = originalEnvironment;
-            this._environment.setFocusedNode(newEnv.getFocusedNode());
             return returnValue;
         } catch (err: any) {
             if (!this._tryMode && this.options.stopOnCrash && !(err instanceof Stmt.BlockEnd)) {
@@ -274,7 +272,6 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                 retValue.setReturn(true);
             }
             this._environment = originalEnvironment;
-            this._environment.setFocusedNode(newEnv.getFocusedNode());
             throw err;
         } finally {
             newEnv.removeReferences();


### PR DESCRIPTION
The focused node was being lost when sub-environments were created, moving to the singleton `rootObjects` simplifies and avoid replication of references.