### PR TITLE
Added a queue to `SharedObject` to prevent concurrency issues

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -80,7 +80,6 @@ import packageInfo from "../../package.json";
 
 // Interpreter Library
 const brsWrkLib = getWorkerLibPath();
-let brsWorker: Worker;
 
 // Package API
 export {
@@ -121,7 +120,11 @@ let bandwidthTimeout: NodeJS.Timeout | null = null;
 let latestBandwidth: number = 0;
 let httpConnectLog: boolean = false;
 
-// App Shared Buffers
+// App Workers and Shared Buffers
+let brsWorker: Worker;
+const tasks: Map<number, Worker> = new Map();
+const taskSyncFromMain: Map<number, SharedObject> = new Map();
+const taskSyncToMain: Map<number, SharedObject> = new Map();
 const registryBuffer = new SharedObject(registryInitialSize, registryMaxSize);
 let sharedBuffer: ArrayBufferLike;
 let sharedArray: Int32Array;
@@ -475,10 +478,6 @@ function runApp(payload: AppPayload) {
         apiException("error", `[api] Error running ${currentApp.title}: ${err.message}`);
     }
 }
-
-const tasks: Map<number, Worker> = new Map();
-const taskSyncFromMain: Map<number, SharedObject> = new Map();
-const taskSyncToMain: Map<number, SharedObject> = new Map();
 
 function runTask(taskData: TaskData) {
     if (tasks.has(taskData.id) || !taskData.m?.top?.functionname) {

--- a/src/core/SharedObject.ts
+++ b/src/core/SharedObject.ts
@@ -60,7 +60,11 @@ class SharedObject {
                 result.value.then((status) => {
                     if (status === "ok") {
                         this.store(obj);
-                        console.log("[API] Buffer released. Stored data.", obj.field, this.getVersion());
+                        console.log(
+                            "[API] Buffer released. Stored data.",
+                            obj.field,
+                            this.getVersion()
+                        );
                     } else {
                         console.error("[API] Error storing shared data", status);
                     }

--- a/src/core/SharedObject.ts
+++ b/src/core/SharedObject.ts
@@ -7,13 +7,13 @@
  *--------------------------------------------------------------------------------------------*/
 class SharedObject {
     private readonly offset = 8;
+    private readonly queue: { obj: any; version: number; timeout: number }[] = [];
     private lengthIdx = 0;
     private versionIdx = 1;
     private buffer: SharedArrayBuffer;
     private view: Uint8Array;
     private maxSize: number;
     private atomicView: Int32Array;
-    private queue: { obj: any; version: number; timeout: number }[] = [];
     private isProcessing: boolean = false;
 
     constructor(initialSize?: number, maxSize?: number) {

--- a/src/core/brsTypes/nodes/Task.ts
+++ b/src/core/brsTypes/nodes/Task.ts
@@ -93,11 +93,6 @@ export class Task extends RoSGNode {
             const taskUpdate: TaskUpdate = { id: this.id, field: mapKey, value: jsValueOf(value) };
             postMessage(taskUpdate);
         }
-        console.log(
-            `Setting field in ${this.thread ? "Task thread" : "Main Thread"}: `,
-            mapKey,
-            sync
-        );
         return super.set(index, value, alwaysNotify, kind);
     }
 


### PR DESCRIPTION
The `waitAsync` call in `SharedObject` was being triggered concurrently when more than one update were pending, fixed implementing a queue.