### PR TITLE
Fixed `m` context when the indexed function was accessed inside an AA

### DIFF
--- a/src/core/interpreter/index.ts
+++ b/src/core/interpreter/index.ts
@@ -1408,7 +1408,11 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                 );
             }
             try {
-                return source.get(index, true);
+                const target = source.get(index, true);
+                if (isBrsCallable(target) && source instanceof RoAssociativeArray) {
+                    target.setContext(source);
+                }
+                return target;
             } catch (err: any) {
                 this.addError(new BrsError(err.message, expression.closingSquare.location));
             }

--- a/test/e2e/Functions.test.js
+++ b/test/e2e/Functions.test.js
@@ -98,6 +98,9 @@ describe("end to end functions", () => {
             "bar",
             "bar",
             "invalid",
+            "Log: getText = Test Succeeded! 1",
+            "Log: getText = Test Succeeded! 2",
+            "Log: getText = Test Succeeded! 3",
         ]);
     });
 

--- a/test/e2e/resources/function/m-pointer-func.brs
+++ b/test/e2e/resources/function/m-pointer-func.brs
@@ -1,54 +1,54 @@
-Sub Main()
-    m.someValue = "root"
-    objA = { myMethod: do_something, someValue: "not root" }
-    print objA.myMethod()
-    anon_func_context()
-End Sub
+sub Main()
+  m.someValue = "root"
+  objA = {myMethod: do_something, someValue: "not root"}
+  print objA.myMethod()
+  anon_func_context()
+end sub
 
 function do_something()
-    print m.someValue
-    return GenericFunction()
+  print m.someValue
+  return GenericFunction()
 end function
 
-Function GenericFunction()
-    return m.someValue      'Must use Global m
-End Function
+function GenericFunction()
+  return m.someValue 'Must use Global m
+end function
 
 function anon_func_context()
-    a = {
-      foo: "bar",
-      printM: sub()
-            print(m.foo)
-      end sub
-    }
+  a = {
+    foo: "bar",
+    printM: sub()
+      print(m.foo)
+    end sub
+  }
   a.printM()
   a["printM"]()
   x = a["printM"]
   x()
-	' Other test
-	logger = createLogger()
-	for x = 1 to 3
-		logger.log()
-	next
+  ' Other test
+  logger = createLogger()
+  for x = 1 to 3
+    logger.log()
+  next
 end function
 
 function createLogger()
-	this = {}
-	this.counter = 0
-	this.method = "getText"
-	this.getText = GET_TEXT
-	this.log = LOG_MSG
-	return this
+  this = {}
+  this.counter = 0
+  this.method = "getText"
+  this.getText = GET_TEXT
+  this.log = LOG_MSG
+  return this
 end function
 
 function GET_TEXT()
-	if m.counter <> invalid
-		return "Test Succeeded! " + m.counter.toStr()
-	end if
-	return "Test Failed!"
+  if m.counter <> invalid
+    return "Test Succeeded! " + m.counter.toStr()
+  end if
+  return "Test Failed!"
 end function
 
 sub LOG_MSG()
-	m.counter++
-	print "Log: "; m.method; " = "; m[m.method]()
+  m.counter++
+  print "Log: "; m.method; " = "; m[m.method]()
 end sub

--- a/test/e2e/resources/function/m-pointer-func.brs
+++ b/test/e2e/resources/function/m-pointer-func.brs
@@ -22,7 +22,33 @@ function anon_func_context()
       end sub
     }
   a.printM()
-    a["printM"]()
+  a["printM"]()
   x = a["printM"]
   x()
+	' Other test
+	logger = createLogger()
+	for x = 1 to 3
+		logger.log()
+	next
 end function
+
+function createLogger()
+	this = {}
+	this.counter = 0
+	this.method = "getText"
+	this.getText = GET_TEXT
+	this.log = LOG_MSG
+	return this
+end function
+
+function GET_TEXT()
+	if m.counter <> invalid
+		return "Test Succeeded! " + m.counter.toStr()
+	end if
+	return "Test Failed!"
+end function
+
+sub LOG_MSG()
+	m.counter++
+	print "Log: "; m.method; " = "; m[m.method]()
+end sub


### PR DESCRIPTION
This is related to #494 this PR fixes a more complex scenario, see the e2e test.