### PR TITLE
Implemented `clone` method on `roSGNode`

### DIFF
--- a/src/core/brsTypes/nodes/Field.ts
+++ b/src/core/brsTypes/nodes/Field.ts
@@ -149,6 +149,10 @@ export class Field {
         return this.hidden;
     }
 
+    isAlwaysNotify() {
+        return this.alwaysNotify;
+    }
+
     setHidden(isHidden: boolean) {
         this.hidden = isHidden;
     }


### PR DESCRIPTION
The documentation on `clone` is not detailed, but after some tests, we realized that nodes with built in children (like `Overhang`) will have its children created even when the `isDeepCopy` flag is false.