### PR TITLE
Fixed `MacOS` keyboard mapping for `Info` (asterisk) remote button

### DIFF
--- a/browser/index.js
+++ b/browser/index.js
@@ -86,7 +86,6 @@ customKeys.set("KeyA", "a"); // Keep consistency with older versions
 customKeys.set("KeyZ", "b"); // Keep consistency with older versions
 customKeys.set("PageUp", "ignore"); // do not handle on browser
 customKeys.set("PageDown", "ignore"); // do not handle on browser
-customKeys.set("Digit8", "info");
 customKeys.set("ShiftLeft", "playonly"); // Support for Prince of Persia
 customKeys.set("Shift+ArrowRight", "right"); // Support for Prince of Persia
 customKeys.set("Shift+ArrowLeft", "left"); // Support for Prince of Persia

--- a/docs/remote-control.md
+++ b/docs/remote-control.md
@@ -17,9 +17,9 @@ The default mapping of the keyboard and game pads to Roku remote control is desc
 | Arrow Keys  |Joys & D-Pad|    D-Pad     | Directional controls to navigate on menus and control games.          |
 | Backspace   |   6 or 16  |    Replay    | Instant replay button.                                                |
 | Enter       |     0      |    OK        | Select button.                                                        |
-| Insert      |   4 or 7   |    Info      | Information/Settings button                                           |
-| PageUp      |     2      |    Rewind    | Reverse scan button.                                                  |
-| PageDown    |     3      | Fast Forward | Forward scan button.                                                  |
+| Insert or Ctrl+8|   4 or 7   |    Info      | Information/Settings button                                       |
+| PageUp or Cmd+⬅️|     2      |    Rewind    | Reverse scan button.                                              |
+| PageDown or Cmd+➡️|     3      | Fast Forward | Forward scan button.                                            |
 | End         |   5 or 9   |  Play/Pause  | Play/Pause button.                                                    |
 | Ctrl+A      |    10      |     A        | A game button.                                                        |
 | Ctrl+Z      |    11      |     B        | B game button.                                                        |

--- a/src/api/control.ts
+++ b/src/api/control.ts
@@ -197,23 +197,24 @@ keysMap.set("Control+Escape", "home");
 keysMap.set("Backspace", "instantreplay");
 keysMap.set("End", "play");
 if (platform.inIOS || platform.inMacOS) {
-    keysMap.set("Command+Backspace", "backspace");
-    keysMap.set("Command+Enter", "play");
-    keysMap.set("Command+ArrowLeft", "rev");
-    keysMap.set("Command+ArrowRight", "fwd");
-    keysMap.set("Command+Digit8", "info");
+    keysMap.set("Meta+Backspace", "backspace");
+    keysMap.set("Meta+Enter", "play");
+    keysMap.set("Meta+ArrowLeft", "rev");
+    keysMap.set("Meta+ArrowRight", "fwd");
     keysMap.set("Control+KeyC", "break");
 } else {
     keysMap.set("Control+Backspace", "backspace");
     keysMap.set("Control+Enter", "play");
     keysMap.set("Control+ArrowLeft", "rev");
     keysMap.set("Control+ArrowRight", "fwd");
-    keysMap.set("Control+Digit8", "info");
     keysMap.set("Control+Pause", "break");
 }
 keysMap.set("PageUp", "rev");
 keysMap.set("PageDown", "fwd");
 keysMap.set("Insert", "info");
+keysMap.set("Help", "info");
+keysMap.set("Alt+Digit8", "info");
+keysMap.set("Control+Digit8", "info");
 keysMap.set("Control+KeyA", "a");
 keysMap.set("Control+KeyZ", "b");
 keysMap.set("F10", "volumemute");


### PR DESCRIPTION
The `info` key was mapped to `Insert` only and in Safari the keycode is `Help` for PC keyboards. Also the Cmd+8 key was not working, so switched to `Ctrl+8` and `Option+8` as alternatives.