### PR TITLE
Updated web demo app to upscale the display when in fullscreen mode

### DIFF
--- a/browser/index.js
+++ b/browser/index.js
@@ -302,6 +302,15 @@ display.addEventListener("dblclick", function (event) {
     }
 });
 
+document.onfullscreenchange = function () {
+    if (document.fullscreenElement) {
+        brs.redraw(true);
+    } else {
+        brs.redraw(false, 854, 480);
+        display.style.top = "29px";
+    }
+};
+
 display.addEventListener("mousedown", function (event) {
     if (event.detail === 2) {
         event.preventDefault();


### PR DESCRIPTION
The web demo app was keeping the dimensions of 854x480 when going full screen, and not taking advantage of the rendering from the engine that can upscale up to FHD.