### PR TITLE
Added support to use a CORS proxy with `roURLTransfer` and `Network` modules

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -8,7 +8,7 @@ As described on the [engine API documentation](engine-api.md), the `initialize()
 
 ```ts
 const deviceInfo = {
-  developerId: "34c6fceca75e456f25e7e99531e2425c6c1de443", // As Roku, segregates Registry data (can't have a dot)
+  developerId: "34c6fceca75e456f25e7e99531e2425c6c1de443", // As Roku, this ID segregates Registry data (can't be empty or have a dot)
   friendlyName: "BrightScript Engine Library",
   deviceModel: "8000X", // Roku TV (Midland)
   clientId: "6c5bf3a5-b2a5-4918-824d-7691d5c85364",
@@ -25,6 +25,7 @@ const deviceInfo = {
   startTime: Date.now(),
   audioVolume: 40,
   maxFps: 60,
+  corsProxy: "https://your-cors-proxy-instance.yourdomain.com/", // (optional) Add your CORS-Anywhere URL here, make sure you have the trailing slash
 };
 ```
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -24,7 +24,9 @@ There are several features from the **BrightScript** language and components tha
   * Check what formats (container and codec) can be used on each browser, using `roDeviceInfo.canDecodeVideo()`, to make sure your video can be played.
   * DASH streams are not yet supported.
 * The component `roUrlTransfer` is implemented with basic functionality but with the following limitations:
-  * To make a **web app** access urls from domains other than the one it is hosted, requires the server called to respond with the header `Access-Control-Allow-Origin`, [read more](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP).
+  * To make a **web app** access urls from domains other than the one it is hosted, the Cross-Origin Resource Sharing (CORS) browser policy requires the server called to respond with the header `Access-Control-Allow-Origin`, [read more](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS).
+    * A simple way to overcome this limitation is to use a CORS proxy like the [cors-anywhere](https://github.com/Rob--W/cors-anywhere), see [customization documentation](./customization.md) to learn how to configure `brs-engine` to use it.
+    * If you are using a Chromium based browser (Chrome, Edge, Brave, etc) you can install this [extension](https://chrome.google.com/webstore/detail/allow-cors-access-control/lhobafahddgcelffkeicbaginigeejlf) to bypass CORS.
   * The _async_ methods are actually synchronous and evaluated when `WaitMessage` or `GetMessage` are called.
   * Custom/Self-Signed SSL certificates are not supported, the engine will use default browser client certificate database.
   * As custom certificates are not supported these methods are just mocked and do nothing: `EnablePeerVerification`, `EnableHostVerification`, `SetCertificatesDepth`.

--- a/src/core/brsTypes/components/RoURLTransfer.ts
+++ b/src/core/brsTypes/components/RoURLTransfer.ts
@@ -104,8 +104,9 @@ export class RoURLTransfer extends BrsComponent implements BrsValue, BrsHttpAgen
         if (this.freshConnection) {
             this.xhr = new XMLHttpRequest();
         }
-        let method = this.reqMethod === "" ? methodParam : this.reqMethod;
-        this.xhr.open(method, this.url, false, this.user, this.password);
+        const method = this.reqMethod === "" ? methodParam : this.reqMethod;
+        const corsProxy = BrsDevice.deviceInfo.corsProxy ?? "";
+        this.xhr.open(method, corsProxy + this.url, false, this.user, this.password);
         this.xhr.responseType = typeParam;
         this.customHeaders.forEach((value: string, key: string) => {
             this.xhr.setRequestHeader(key, value);

--- a/src/core/common.ts
+++ b/src/core/common.ts
@@ -47,6 +47,7 @@ export interface DeviceInfo {
     entryPoint?: boolean;
     stopOnCrash?: boolean;
     platform?: Platform;
+    corsProxy?: string;
 }
 
 // Default Device Information

--- a/src/core/interpreter/Network.ts
+++ b/src/core/interpreter/Network.ts
@@ -1,3 +1,4 @@
+import { BrsDevice } from "../device/BrsDevice";
 /// #if !BROWSER
 import { XMLHttpRequest } from "../polyfill/XMLHttpRequest";
 /// #endif
@@ -15,7 +16,8 @@ export function download(
 ): any {
     try {
         const xhr = new XMLHttpRequest();
-        xhr.open("GET", url, false); // Note: synchronous
+        const corsProxy = BrsDevice.deviceInfo.corsProxy ?? "";
+        xhr.open("GET", corsProxy + url, false); // Note: synchronous
         xhr.responseType = type;
         customHeaders?.forEach((value: string, key: string) => {
             xhr.setRequestHeader(key, value);


### PR DESCRIPTION
Added a way to configure, using the `deviceInfo` object, a URL to a CORS proxy like https://github.com/Rob--W/cors-anywhere