### PR TITLE
Update `itemFocused` when `content` is set in aliased field

### DIFF
--- a/src/core/brsTypes/nodes/ArrayGrid.ts
+++ b/src/core/brsTypes/nodes/ArrayGrid.ts
@@ -87,7 +87,15 @@ export class ArrayGrid extends Group {
             throw new Error("RoSGNode indexes must be strings");
         }
         const fieldName = index.value.toLowerCase();
-        if (["jumptoitem", "animatetoitem"].includes(fieldName)) {
+        if (fieldName === "content") {
+            const retValue = super.set(index, value, alwaysNotify, kind);
+            let focus = -1;
+            if (value instanceof ContentNode && value.getNodeChildren().length) {
+                focus = 0;
+            }
+            this.set(new BrsString("jumpToItem"), new Int32(focus));
+            return retValue;
+        } else if (["jumptoitem", "animatetoitem"].includes(fieldName)) {
             const focusedIndex = jsValueOf(this.getFieldValue("itemFocused"));
             if (focusedIndex !== jsValueOf(value)) {
                 super.set(new BrsString("itemUnfocused"), new Int32(this.focusIndex));

--- a/src/core/brsTypes/nodes/Field.ts
+++ b/src/core/brsTypes/nodes/Field.ts
@@ -122,6 +122,11 @@ export type FieldModel = {
     alwaysNotify?: boolean;
 };
 
+export type FieldAlias = {
+    nodeId: string;
+    fieldName: string;
+};
+
 export class Field {
     private readonly permanentObservers: BrsCallback[] = [];
     private readonly unscopedObservers: BrsCallback[] = [];

--- a/src/core/scenegraph/SGNodeFactory.ts
+++ b/src/core/scenegraph/SGNodeFactory.ts
@@ -375,11 +375,11 @@ function addFields(interpreter: Interpreter, node: RoSGNode, typeDef: ComponentD
             if (fieldValue.alias?.includes(".")) {
                 const childName = fieldValue.alias.split(".")[0];
                 const childField = fieldValue.alias.split(".")[1];
-                const childNode = node.findNodeById(node, new BrsString(childName));
+                const childNode = node.findChildById(node, new BrsString(childName));
                 if (childNode instanceof RoSGNode) {
                     const field = childNode.getNodeFields().get(childField?.toLowerCase());
                     if (field) {
-                        node.addNodeFieldAlias(fieldName, field);
+                        node.addNodeFieldAlias(fieldName, field, childName, childField);
                     } else {
                         let msg = `error,Error creating XML component ${node.nodeSubtype}\n`;
                         msg += `-- Interface field alias failed: Node "${childName}" has no field named "${childField}"\n`;

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -143,7 +143,7 @@ describe("cli", () => {
         });
         expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
             "Main -----------------------------------------------",
-            "MAIN: poster node type:Node",
+            "MAIN: poster node type:roSGNode",
             "MAIN: poster node subtype:Poster",
             "MAIN: poster node width: 0",
             "MAIN: poster node height: 0",


### PR DESCRIPTION
Made sure the `itemFocused` is set when `content` is set on `ArrayGrid` (and derivates) generating events when field is observed, even as aliased field.

Fixed alias to only allow direct child fields to be linked.