### PR TITLE
Fixed crash when XML component references a script on `source` folder

### DIFF
--- a/src/core/device/BrsDevice.ts
+++ b/src/core/device/BrsDevice.ts
@@ -33,6 +33,7 @@ export class BrsDevice {
 
     static sharedArray: Int32Array = new Int32Array(0);
     static displayEnabled: boolean = true;
+    static taskThread: boolean = false;
     static lastRemote: number = 0;
     static lastKeyTime: number = Date.now();
     static currKeyTime: number = Date.now();

--- a/src/core/interpreter/Environment.ts
+++ b/src/core/interpreter/Environment.ts
@@ -43,6 +43,7 @@ export class Environment {
      * @see Scope.Module
      */
     private module = new Map<string, BrsType>();
+    private locations = new Map<string, Location>();
     /**
      * Variables and anonymous functions accessible only within a function's body.
      * @see Scope.Function
@@ -68,7 +69,7 @@ export class Environment {
      * @param scope The logical region from a particular variable or function that defines where it may be accessed from
      * @param name the name of the variable to define (in the form of an `Identifier`)
      * @param value the value of the variable to define
-     * @param location the location in the source file where this variable was defined (only for Function scope)
+     * @param location the location in the source file where this variable was defined (optional)
      */
     public define(scope: Scope, name: string, value: BrsType, location?: Location): void {
         let destination: Map<string, BrsType>;
@@ -106,6 +107,10 @@ export class Environment {
             }
             case Scope.Module:
                 destination = this.module;
+                this.locations.set(lowercaseName, location!);
+                break;
+            case Scope.Global:
+                destination = this.global;
                 break;
             default:
                 destination = this.global;
@@ -113,6 +118,15 @@ export class Environment {
         }
 
         destination.set(lowercaseName, value);
+    }
+
+    /**
+     * Returns the module function location
+     * @param name module function name
+     * @returns if exists returns the location
+     */
+    public getDefinedLocation(name: string): Location | undefined {
+        return this.locations.get(name.toLowerCase());
     }
 
     /**

--- a/src/core/interpreter/Environment.ts
+++ b/src/core/interpreter/Environment.ts
@@ -282,8 +282,10 @@ export class Environment {
         newEnvironment.hostNode = this.hostNode;
         if (includeModuleScope) {
             newEnvironment.module = this.module;
+            newEnvironment.locations = this.locations;
         } else {
             newEnvironment.module = new Map<string, BrsType>();
+            newEnvironment.locations = new Map<string, Location>();
         }
         return newEnvironment;
     }

--- a/src/core/scenegraph/index.ts
+++ b/src/core/scenegraph/index.ts
@@ -221,6 +221,7 @@ export async function getInterpreterWithSubEnvs(
             let statements = await componentScopeResolver.resolve(component);
             interpreter.inSubEnv((subInterpreter) => {
                 let componentMPointer = new RoAssociativeArray([]);
+                subInterpreter.options.entryPoint = false;
                 subInterpreter.environment.setM(componentMPointer);
                 subInterpreter.environment.setRootM(componentMPointer);
                 subInterpreter.exec(statements);


### PR DESCRIPTION
Sometimes the scope was lost due to an exception happening during parse.