### PR TITLE
Fixed parsing of arrays from XML string value field

### DIFF
--- a/src/core/brsTypes/BrsType.ts
+++ b/src/core/brsTypes/BrsType.ts
@@ -193,9 +193,8 @@ export function getBrsValueFromFieldType(type: string, value?: string): BrsType 
         case "roarray":
         case "array":
             returnValue = BrsInvalid.Instance;
-            const trimmedValue = value?.trim();
-            if (trimmedValue?.startsWith("[") && trimmedValue.endsWith("]")) {
-                const arrayItems = trimmedValue.slice(1, -1).trim();
+            if (value?.trim().startsWith("[") && value?.trim().endsWith("]")) {
+                const arrayItems = value.trim().slice(1, -1).trim();
                 if (arrayItems === "") {
                     returnValue = new RoArray([]);
                     break;

--- a/src/core/brsTypes/BrsType.ts
+++ b/src/core/brsTypes/BrsType.ts
@@ -193,15 +193,16 @@ export function getBrsValueFromFieldType(type: string, value?: string): BrsType 
         case "roarray":
         case "array":
             returnValue = BrsInvalid.Instance;
-            if (value?.trim().startsWith("[") && value.trim().endsWith("]")) {
-                if (value === "[]" || value === "[ ]") {
+            const trimmedValue = value?.trim();
+            if (trimmedValue?.startsWith("[") && trimmedValue.endsWith("]")) {
+                const arrayItems = trimmedValue.slice(1, -1).trim();
+                if (arrayItems === "") {
                     returnValue = new RoArray([]);
                     break;
                 }
-                const parsedValue = value
-                    .replace(/[\[\]]/g, "")
-                    .split(",")
-                    .map(Number);
+                // Remove brackets and split by comma, then trim each element
+                const elements = arrayItems.split(",").map((el) => el.trim());
+                const parsedValue = elements.map(Number);
                 returnValue = new RoArray(parsedValue.map((v) => new Float(isNaN(v) ? 0 : v)));
             }
             break;


### PR DESCRIPTION
Some arrays defined in XML field values had spaces and were not properly parsed:

```xml
    <Label 
      width = "300" 
      translation = "[ 0, 10 ]" 
      text = "Scroll Up/Down" 
      horizAlign = "right" />
```