### PR TITLE
Implemented support for `opacity` field on all renderable nodes.

### DIFF
--- a/src/core/brsTypes/components/RoSGNode.ts
+++ b/src/core/brsTypes/components/RoSGNode.ts
@@ -341,13 +341,25 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         return (this.getFieldValueJS("focusable") as boolean) ?? false;
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, draw2D?: IfDraw2D) {
-        this.renderChildren(interpreter, origin, angle, draw2D);
+    renderNode(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
+        this.renderChildren(interpreter, origin, angle, opacity, draw2D);
     }
 
-    renderChildren(interpreter: Interpreter, origin: number[], angle: number, draw2D?: IfDraw2D) {
+    renderChildren(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         this.children.forEach((node) => {
-            node.renderNode(interpreter, origin, angle, draw2D);
+            node.renderNode(interpreter, origin, angle, opacity, draw2D);
         });
         this.changed = false;
     }
@@ -1637,7 +1649,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         },
         impl: (interpreter: Interpreter) => {
             const root = this.createPath(this)[0];
-            root.renderNode(interpreter, [0, 0], 0);
+            root.renderNode(interpreter, [0, 0], 0, 1);
             return toAssociativeArray(this.rectToParent);
         },
     });
@@ -1650,7 +1662,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         },
         impl: (interpreter: Interpreter) => {
             const root = this.createPath(this)[0];
-            root.renderNode(interpreter, [0, 0], 0);
+            root.renderNode(interpreter, [0, 0], 0, 1);
             return toAssociativeArray(this.rectLocal);
         },
     });
@@ -1663,7 +1675,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         },
         impl: (interpreter: Interpreter) => {
             const root = this.createPath(this)[0];
-            root.renderNode(interpreter, [0, 0], 0);
+            root.renderNode(interpreter, [0, 0], 0, 1);
             return toAssociativeArray(this.rectToScene);
         },
     });

--- a/src/core/brsTypes/components/RoSGScreen.ts
+++ b/src/core/brsTypes/components/RoSGScreen.ts
@@ -211,11 +211,12 @@ export class RoSGScreen extends BrsComponent implements BrsValue, BrsDraw2D {
             this.processTimers();
             this.processTasks();
             // TODO: Optimize rendering by only rendering if there are changes
-            rootObjects.rootScene.renderNode(this.interpreter, [0, 0], 0, this.draw2D);
+            rootObjects.rootScene.renderNode(this.interpreter, [0, 0], 0, 1, this.draw2D);
             if (rootObjects.rootScene?.dialog?.getNodeParent() instanceof BrsInvalid) {
+                const dialog = rootObjects.rootScene.dialog;
                 const screenRect = { x: 0, y: 0, width: this.width, height: this.height };
                 this.draw2D.doDrawRotatedRect(screenRect, 255, 0, [0, 0], 0.5);
-                rootObjects.rootScene.dialog.renderNode(this.interpreter, [0, 0], 0, this.draw2D);
+                dialog.renderNode(this.interpreter, [0, 0], 0, 1, this.draw2D);
             }
             let timeStamp = performance.now();
             while (timeStamp - this.lastMessage < this.maxMs) {

--- a/src/core/brsTypes/nodes/BusySpinner.ts
+++ b/src/core/brsTypes/nodes/BusySpinner.ts
@@ -67,7 +67,13 @@ export class BusySpinner extends Group {
         }
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, draw2D?: IfDraw2D) {
+    renderNode(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             return;
         }
@@ -78,6 +84,7 @@ export class BusySpinner extends Group {
         const size = this.getDimensions();
         const rect = { x: drawTrans[0], y: drawTrans[1], width: size.width, height: size.height };
         const rotation = angle + this.getRotation();
+        opacity = opacity * this.getOpacity();
         const bmp = this.poster.getBitmap("uri");
         if (bmp?.isValid()) {
             this.poster.setFieldValue(
@@ -106,7 +113,7 @@ export class BusySpinner extends Group {
             }
         }
         this.updateBoundingRects(rect, origin, rotation);
-        this.renderChildren(interpreter, drawTrans, rotation, draw2D);
+        this.renderChildren(interpreter, drawTrans, rotation, opacity, draw2D);
         this.updateParentRects(origin, angle);
     }
 }

--- a/src/core/brsTypes/nodes/Button.ts
+++ b/src/core/brsTypes/nodes/Button.ts
@@ -177,7 +177,13 @@ export class Button extends Group {
         this.iconHeight = height;
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, draw2D?: IfDraw2D) {
+    renderNode(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             return;
         }
@@ -194,12 +200,13 @@ export class Button extends Group {
             height: Math.max(size.height, this.iconSize[1]),
         };
         const rotation = angle + this.getRotation();
+        opacity = opacity * this.getOpacity();
         if (this.isDirty) {
             this.updateChildren(nodeFocus);
             this.isDirty = false;
         }
         this.updateBoundingRects(rect, origin, angle);
-        this.renderChildren(interpreter, drawTrans, rotation, draw2D);
+        this.renderChildren(interpreter, drawTrans, rotation, opacity, draw2D);
         this.updateParentRects(origin, angle);
     }
 }

--- a/src/core/brsTypes/nodes/ButtonGroup.ts
+++ b/src/core/brsTypes/nodes/ButtonGroup.ts
@@ -139,7 +139,13 @@ export class ButtonGroup extends LayoutGroup {
         return handled;
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, draw2D?: IfDraw2D): void {
+    renderNode(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             return;
         }
@@ -159,9 +165,11 @@ export class ButtonGroup extends LayoutGroup {
             this.isDirty = false;
         }
         this.refreshFocus();
+        const rotation = angle + this.getRotation();
+        opacity = opacity * this.getOpacity();
         // TODO: update then width/height based on the # of buttons and layout direction
-        this.updateBoundingRects(boundingRect, origin, angle);
-        this.renderChildren(interpreter, drawTrans, angle, draw2D);
+        this.updateBoundingRects(boundingRect, origin, rotation);
+        this.renderChildren(interpreter, drawTrans, rotation, opacity, draw2D);
         this.updateParentRects(origin, angle);
     }
 

--- a/src/core/brsTypes/nodes/CheckList.ts
+++ b/src/core/brsTypes/nodes/CheckList.ts
@@ -107,6 +107,7 @@ export class CheckList extends LabelList {
         index: number,
         item: ContentNode,
         rect: Rect,
+        opacity: number,
         nodeFocus: boolean,
         itemFocus: boolean,
         draw2D?: IfDraw2D
@@ -122,9 +123,9 @@ export class CheckList extends LabelList {
         const iconIndex = itemFocus ? 1 : 0;
         const bmp = !hideIcon && iconGap > 0 ? this.getBitmap(icons[iconIndex]) : undefined;
         if (!itemFocus) {
-            this.renderUnfocused(text, rect, iconGap, true, bmp, draw2D);
+            this.renderUnfocused(text, rect, opacity, iconGap, true, bmp, draw2D);
         } else {
-            this.renderFocused(text, rect, nodeFocus, iconGap, true, bmp, draw2D);
+            this.renderFocused(text, rect, opacity, nodeFocus, iconGap, true, bmp, draw2D);
         }
     }
 

--- a/src/core/brsTypes/nodes/Dialog.ts
+++ b/src/core/brsTypes/nodes/Dialog.ts
@@ -104,7 +104,16 @@ export class Dialog extends Group {
             );
             this.title = this.addLabel("titleColor", [549, 477], 822, 46, 42, "top", "center");
             this.divider = this.addPoster(this.dividerUri, [549, 535.5], 822, 6);
-            this.message = this.addLabel("messageColor", [523, 588], 873, 38, 34);
+            this.message = this.addLabel(
+                "messageColor",
+                [523, 588],
+                873,
+                0,
+                34,
+                "top",
+                "left",
+                true
+            );
             this.setFieldValue("iconUri", new BrsString(this.iconUriFHD));
             this.buttonGroup.setFieldValue("minWidth", new Float(900));
             this.buttonGroup.setFieldValue("maxWidth", new Float(900));
@@ -131,7 +140,16 @@ export class Dialog extends Group {
             );
             this.title = this.addLabel("titleColor", [366, 318], 548, 30, 28, "top", "center");
             this.divider = this.addPoster(this.dividerUri, [366, 357], 548, 4);
-            this.message = this.addLabel("messageColor", [349, 392], 582, 26, 24);
+            this.message = this.addLabel(
+                "messageColor",
+                [349, 392],
+                582,
+                0,
+                24,
+                "top",
+                "left",
+                true
+            );
             this.setFieldValue("iconUri", new BrsString(this.iconUriHD));
             this.buttonGroup.setFieldValue("minWidth", new Float(600));
             this.buttonGroup.setFieldValue("maxWidth", new Float(600));
@@ -198,7 +216,13 @@ export class Dialog extends Group {
         return true;
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, draw2D?: IfDraw2D): void {
+    renderNode(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             return;
         }
@@ -217,8 +241,10 @@ export class Dialog extends Group {
         if (this.hasButtons) {
             this.setNodeFocus(interpreter, true);
         }
-        this.updateBoundingRects(boundingRect, origin, angle);
-        this.renderChildren(interpreter, drawTrans, angle, draw2D);
+        const rotation = angle + this.getRotation();
+        opacity = opacity * this.getOpacity();
+        this.updateBoundingRects(boundingRect, origin, rotation);
+        this.renderChildren(interpreter, drawTrans, rotation, opacity, draw2D);
         this.updateParentRects(origin, angle);
     }
 

--- a/src/core/brsTypes/nodes/Label.ts
+++ b/src/core/brsTypes/nodes/Label.ts
@@ -65,12 +65,18 @@ export class Label extends Group {
     getMeasured() {
         if (this.measured === undefined) {
             const size = this.getDimensions();
-            this.measured = this.renderLabel({ x: 0, y: 0, ...size }, 0);
+            this.measured = this.renderLabel({ x: 0, y: 0, ...size }, 0, 1);
         }
         return this.measured;
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, draw2D?: IfDraw2D) {
+    renderNode(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             return;
         }
@@ -81,15 +87,16 @@ export class Label extends Group {
         const size = this.getDimensions();
         const rect = { x: drawTrans[0], y: drawTrans[1], width: size.width, height: size.height };
         const rotation = angle + this.getRotation();
-        this.measured = this.renderLabel(rect, rotation, draw2D);
+        opacity = opacity * this.getOpacity();
+        this.measured = this.renderLabel(rect, rotation, opacity, draw2D);
         rect.width = Math.max(this.measured.width, size.width);
         rect.height = Math.max(this.measured.height, size.height);
         this.updateBoundingRects(rect, origin, rotation);
-        this.renderChildren(interpreter, drawTrans, rotation, draw2D);
+        this.renderChildren(interpreter, drawTrans, rotation, opacity, draw2D);
         this.updateParentRects(origin, angle);
     }
 
-    protected renderLabel(rect: Rect, rotation: number, draw2D?: IfDraw2D) {
+    protected renderLabel(rect: Rect, rotation: number, opacity: number, draw2D?: IfDraw2D) {
         const font = this.getFieldValue("font") as Font;
         const color = this.getFieldValueJS("color") as number;
         const textField = this.getFieldValueJS("text") as string;
@@ -109,6 +116,7 @@ export class Label extends Group {
                     textField,
                     font,
                     color,
+                    opacity,
                     rect,
                     horizAlign,
                     vertAlign,
@@ -128,6 +136,7 @@ export class Label extends Group {
                 textField,
                 font,
                 color,
+                opacity,
                 rect,
                 horizAlign,
                 vertAlign,

--- a/src/core/brsTypes/nodes/LabelList.ts
+++ b/src/core/brsTypes/nodes/LabelList.ts
@@ -106,6 +106,7 @@ export class LabelList extends ArrayGrid {
         _interpreter: Interpreter,
         rect: Rect,
         _rotation: number,
+        opacity: number,
         draw2D?: IfDraw2D
     ) {
         if (this.content.length === 0) {
@@ -125,12 +126,12 @@ export class LabelList extends ArrayGrid {
             const item = this.content[index];
             if (item instanceof ContentNode) {
                 if (!hasSections && this.wrap && index < lastIndex && r > 0) {
-                    itemRect.y += this.renderWrapDivider(itemRect, draw2D);
+                    itemRect.y += this.renderWrapDivider(itemRect, opacity, draw2D);
                 } else if (hasSections && this.wrap && this.metadata[index]?.divider && r > 0) {
                     const divText = this.metadata[index].sectionTitle;
-                    itemRect.y += this.renderSectionDivider(divText, itemRect, draw2D);
+                    itemRect.y += this.renderSectionDivider(divText, itemRect, opacity, draw2D);
                 }
-                this.renderItem(index, item, itemRect, nodeFocus, focused, draw2D);
+                this.renderItem(index, item, itemRect, opacity, nodeFocus, focused, draw2D);
             }
             itemRect.y += itemSize[1] + 1;
             lastIndex = index;
@@ -145,6 +146,7 @@ export class LabelList extends ArrayGrid {
         _index: number,
         item: ContentNode,
         rect: Rect,
+        opacity: number,
         nodeFocus: boolean,
         itemFocus: boolean,
         draw2D?: IfDraw2D
@@ -156,15 +158,16 @@ export class LabelList extends ArrayGrid {
         const iconIndex = itemFocus ? 1 : 0;
         const bmp = iconGap > 0 ? item.getBitmap(icons[iconIndex]) : undefined;
         if (!itemFocus) {
-            this.renderUnfocused(text, rect, iconGap, false, bmp, draw2D);
+            this.renderUnfocused(text, rect, opacity, iconGap, false, bmp, draw2D);
         } else {
-            this.renderFocused(text, rect, nodeFocus, iconGap, false, bmp, draw2D);
+            this.renderFocused(text, rect, opacity, nodeFocus, iconGap, false, bmp, draw2D);
         }
     }
 
     protected renderUnfocused(
         text: string,
         rect: Rect,
+        opacity: number,
         iconGap: number,
         iconColor: boolean,
         iconBmp?: RoBitmap,
@@ -175,14 +178,15 @@ export class LabelList extends ArrayGrid {
         const align = this.getFieldValueJS("textHorizAlign") as string;
         const textRect = { ...rect, x: rect.x + iconGap };
         if (iconBmp) {
-            this.renderIcon(iconBmp, rect, draw2D, iconColor ? color : undefined);
+            this.renderIcon(iconBmp, rect, opacity, draw2D, iconColor ? color : undefined);
         }
-        this.drawText(text, font, color, textRect, align, "center", 0, draw2D);
+        this.drawText(text, font, color, opacity, textRect, align, "center", 0, draw2D);
     }
 
     protected renderFocused(
         text: string,
         rect: Rect,
+        opacity: number,
         nodeFocus: boolean,
         iconGap: number,
         iconColor: boolean,
@@ -196,25 +200,31 @@ export class LabelList extends ArrayGrid {
         const drawFocus = this.getFieldValueJS("drawFocusFeedback") as boolean;
         const drawFocusOnTop = this.getFieldValueJS("drawFocusFeedbackOnTop") as boolean;
         if (drawFocus && !drawFocusOnTop) {
-            this.renderFocus(rect, nodeFocus, draw2D);
+            this.renderFocus(rect, opacity, nodeFocus, draw2D);
         }
         if (iconBmp) {
-            this.renderIcon(iconBmp, rect, draw2D, iconColor ? color : undefined);
+            this.renderIcon(iconBmp, rect, opacity, draw2D, iconColor ? color : undefined);
         }
-        this.drawText(text, font, color, textRect, align, "center", 0, draw2D);
+        this.drawText(text, font, color, opacity, textRect, align, "center", 0, draw2D);
         if (drawFocus && drawFocusOnTop) {
-            this.renderFocus(rect, nodeFocus, draw2D);
+            this.renderFocus(rect, opacity, nodeFocus, draw2D);
         }
         this.hasNinePatch = this.hasNinePatch && drawFocus;
     }
 
-    protected renderIcon(bmp: RoBitmap, rect: Rect, draw2D?: IfDraw2D, color?: number) {
+    protected renderIcon(
+        bmp: RoBitmap,
+        rect: Rect,
+        opacity: number,
+        draw2D?: IfDraw2D,
+        color?: number
+    ) {
         const iconY = rect.y + (rect.height / 2 - bmp.height / 2);
         const iconRect = { ...rect, y: iconY, width: bmp.width, height: bmp.height };
-        this.drawImage(bmp, iconRect, 0, draw2D, color);
+        this.drawImage(bmp, iconRect, 0, opacity, draw2D, color);
     }
 
-    protected renderFocus(itemRect: Rect, nodeFocus: boolean, draw2D?: IfDraw2D) {
+    protected renderFocus(itemRect: Rect, opacity: number, nodeFocus: boolean, draw2D?: IfDraw2D) {
         const focusBitmap = this.getBitmap("focusBitmapUri");
         const focusFootprint = this.getBitmap("focusFootprintBitmapUri");
         this.hasNinePatch = (focusBitmap?.ninePatch || focusFootprint?.ninePatch) === true;
@@ -226,10 +236,10 @@ export class LabelList extends ArrayGrid {
         };
         if (nodeFocus && focusBitmap) {
             const rect = focusBitmap.ninePatch ? ninePatchRect : itemRect;
-            this.drawImage(focusBitmap, rect, 0, draw2D);
+            this.drawImage(focusBitmap, rect, 0, opacity, draw2D);
         } else if (!nodeFocus && focusFootprint) {
             const rect = focusFootprint.ninePatch ? ninePatchRect : itemRect;
-            this.drawImage(focusFootprint, rect, 0, draw2D);
+            this.drawImage(focusFootprint, rect, 0, opacity, draw2D);
         }
     }
 }

--- a/src/core/brsTypes/nodes/MarkupGrid.ts
+++ b/src/core/brsTypes/nodes/MarkupGrid.ts
@@ -97,6 +97,7 @@ export class MarkupGrid extends ArrayGrid {
         interpreter: Interpreter,
         rect: Rect,
         rotation: number,
+        opacity: number,
         draw2D?: IfDraw2D
     ) {
         if (this.content.length === 0) {
@@ -134,12 +135,12 @@ export class MarkupGrid extends ArrayGrid {
             itemRect.height = rowHeights[rowIndex / numCols] ?? itemSize[1];
             if (!hasSections && this.wrap && rowIndex < lastIndex && r > 0) {
                 const divRect = { ...itemRect, width: rowWidth };
-                const divHeight = this.renderWrapDivider(divRect, draw2D);
+                const divHeight = this.renderWrapDivider(divRect, opacity, draw2D);
                 itemRect.y += divHeight + spacing[1];
             } else if (hasSections && this.wrap && this.metadata[rowIndex]?.divider && r > 0) {
                 const divRect = { ...itemRect, width: rowWidth };
                 const divText = this.metadata[rowIndex].sectionTitle;
-                const divHeight = this.renderSectionDivider(divText, divRect, draw2D);
+                const divHeight = this.renderSectionDivider(divText, divRect, opacity, draw2D);
                 itemRect.y += divHeight + spacing[1];
             }
             for (let c = 0; c < numCols; c++) {
@@ -148,7 +149,7 @@ export class MarkupGrid extends ArrayGrid {
                 if (index >= this.content.length) {
                     break;
                 }
-                this.renderItemComponent(interpreter, index, itemRect, rotation, draw2D);
+                this.renderItemComponent(interpreter, index, itemRect, rotation, opacity, draw2D);
                 itemRect.x += itemRect.width + (columnSpacings[c] ?? spacing[0]);
                 lastIndex = index;
             }

--- a/src/core/brsTypes/nodes/MarkupList.ts
+++ b/src/core/brsTypes/nodes/MarkupList.ts
@@ -98,6 +98,7 @@ export class MarkupList extends ArrayGrid {
         interpreter: Interpreter,
         rect: Rect,
         rotation: number,
+        opacity: number,
         draw2D?: IfDraw2D
     ) {
         if (this.content.length === 0) {
@@ -132,12 +133,12 @@ export class MarkupList extends ArrayGrid {
             itemRect.height = rowHeights[rowIndex] ?? itemSize[1];
             if (!hasSections && this.wrap && rowIndex < lastIndex && r > 0) {
                 const divRect = { ...itemRect, width: rowWidth };
-                const divHeight = this.renderWrapDivider(divRect, draw2D);
+                const divHeight = this.renderWrapDivider(divRect, opacity, draw2D);
                 itemRect.y += divHeight + spacing[1];
             } else if (hasSections && this.wrap && this.metadata[rowIndex]?.divider && r > 0) {
                 const divRect = { ...itemRect, width: rowWidth };
                 const divText = this.metadata[rowIndex].sectionTitle;
-                const divHeight = this.renderSectionDivider(divText, divRect, draw2D);
+                const divHeight = this.renderSectionDivider(divText, divRect, opacity, draw2D);
                 itemRect.y += divHeight + spacing[1];
             }
             itemRect.width = itemSize[0];
@@ -145,7 +146,7 @@ export class MarkupList extends ArrayGrid {
             if (index >= this.content.length) {
                 break;
             }
-            this.renderItemComponent(interpreter, index, itemRect, rotation, draw2D);
+            this.renderItemComponent(interpreter, index, itemRect, rotation, opacity, draw2D);
             lastIndex = index;
             itemRect.x = rect.x;
             itemRect.y += itemRect.height + (rowSpacings[r] ?? spacing[1]);

--- a/src/core/brsTypes/nodes/Overhang.ts
+++ b/src/core/brsTypes/nodes/Overhang.ts
@@ -213,7 +213,13 @@ export class Overhang extends Group {
         return super.set(index, value, alwaysNotify, kind);
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, draw2D?: IfDraw2D) {
+    renderNode(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             return;
         }
@@ -222,8 +228,9 @@ export class Overhang extends Group {
         }
         const size = this.getDimensions();
         const rect = { x: origin[0], y: origin[1], width: size.width, height: size.height };
+        opacity = opacity * this.getOpacity();
         this.updateBoundingRects(rect, origin, angle);
-        this.renderChildren(interpreter, origin, angle, draw2D);
+        this.renderChildren(interpreter, origin, angle, opacity, draw2D);
         this.updateParentRects(origin, angle);
         if (this.realign) {
             this.alignChildren();

--- a/src/core/brsTypes/nodes/RadioButtonList.ts
+++ b/src/core/brsTypes/nodes/RadioButtonList.ts
@@ -46,6 +46,7 @@ export class RadioButtonList extends LabelList {
         index: number,
         item: ContentNode,
         rect: Rect,
+        opacity: number,
         nodeFocus: boolean,
         itemFocus: boolean,
         draw2D?: IfDraw2D
@@ -59,9 +60,9 @@ export class RadioButtonList extends LabelList {
         const iconIndex = itemFocus ? 1 : 0;
         const bmp = showIcon ? this.getBitmap(icons[iconIndex]) : undefined;
         if (!itemFocus) {
-            this.renderUnfocused(text, rect, iconGap, true, bmp, draw2D);
+            this.renderUnfocused(text, rect, opacity, iconGap, true, bmp, draw2D);
         } else {
-            this.renderFocused(text, rect, nodeFocus, iconGap, true, bmp, draw2D);
+            this.renderFocused(text, rect, opacity, nodeFocus, iconGap, true, bmp, draw2D);
         }
     }
 }

--- a/src/core/brsTypes/nodes/Rectangle.ts
+++ b/src/core/brsTypes/nodes/Rectangle.ts
@@ -20,7 +20,13 @@ export class Rectangle extends Group {
         this.registerInitializedFields(initializedFields);
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, draw2D?: IfDraw2D) {
+    renderNode(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             return;
         }
@@ -31,12 +37,12 @@ export class Rectangle extends Group {
         const size = this.getDimensions();
         const rotation = angle + this.getRotation();
         const color = this.getFieldValueJS("color") as number;
-        const opacity = this.getFieldValueJS("opacity") as number;
+        opacity = opacity * this.getOpacity();
         const center = this.getScaleRotateCenter();
         const rect = { x: drawTrans[0], y: drawTrans[1], width: size.width, height: size.height };
         draw2D?.doDrawRotatedRect(rect, color, rotation, center, opacity);
         this.updateBoundingRects(rect, origin, rotation);
-        this.renderChildren(interpreter, drawTrans, rotation, draw2D);
+        this.renderChildren(interpreter, drawTrans, rotation, opacity, draw2D);
         this.updateParentRects(origin, angle);
     }
 }

--- a/src/core/brsTypes/nodes/Scene.ts
+++ b/src/core/brsTypes/nodes/Scene.ts
@@ -104,12 +104,19 @@ export class Scene extends Group {
         this.fields.get("currentdesignresolution")?.setValue(toAssociativeArray(this.ui));
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, draw2D?: IfDraw2D) {
+    renderNode(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             return;
         }
         const rotation = angle + this.getRotation();
         const backColor = this.getFieldValueJS("backgroundColor") as number;
+        opacity = opacity * this.getOpacity();
         draw2D?.doClearCanvas(backColor);
         const backURI = this.getFieldValueJS("backgroundUri") as string;
         if (draw2D && backURI.trim() !== "") {
@@ -118,10 +125,10 @@ export class Scene extends Group {
             if (bitmap instanceof RoBitmap && bitmap.isValid()) {
                 const scaleX = this.ui.width / bitmap.width;
                 const scaleY = this.ui.height / bitmap.height;
-                draw2D.doDrawScaledObject(0, 0, scaleX, scaleY, bitmap);
+                draw2D.doDrawScaledObject(0, 0, scaleX, scaleY, bitmap, undefined, opacity);
             }
         }
-        this.renderChildren(interpreter, origin, rotation, draw2D);
+        this.renderChildren(interpreter, origin, rotation, opacity, draw2D);
     }
 
     /** Handle SceneGraph onKeyEvent event */

--- a/src/core/brsTypes/nodes/StandardDialog.ts
+++ b/src/core/brsTypes/nodes/StandardDialog.ts
@@ -91,7 +91,13 @@ export class StandardDialog extends Group {
         return super.set(index, value, alwaysNotify, kind);
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, draw2D?: IfDraw2D): void {
+    renderNode(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             return;
         }
@@ -111,8 +117,9 @@ export class StandardDialog extends Group {
         if (isBrsString(backColor)) {
             this.background.set(new BrsString("blendColor"), backColor);
         }
+        opacity = opacity * this.getOpacity();
         this.updateBoundingRects(boundingRect, origin, angle);
-        this.renderChildren(interpreter, drawTrans, angle, draw2D);
+        this.renderChildren(interpreter, drawTrans, angle, opacity, draw2D);
         this.updateParentRects(origin, angle);
     }
 

--- a/src/core/brsTypes/nodes/StandardProgressDialog.ts
+++ b/src/core/brsTypes/nodes/StandardProgressDialog.ts
@@ -46,7 +46,13 @@ export class StandardProgressDialog extends StandardDialog {
         this.linkField(this.progressItem, "text", "message");
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, draw2D?: IfDraw2D): void {
+    renderNode(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         const title = jsValueOf(this.getFieldValue("title")) as string;
         const message = jsValueOf(this.getFieldValue("message")) as string;
         if (title === "") {
@@ -59,6 +65,6 @@ export class StandardProgressDialog extends StandardDialog {
         if (message === "") {
             this.set(new BrsString("message"), new BrsString("Please wait..."));
         }
-        super.renderNode(interpreter, origin, angle, draw2D);
+        super.renderNode(interpreter, origin, angle, opacity, draw2D);
     }
 }

--- a/src/core/brsTypes/nodes/StdDlgProgressItem.ts
+++ b/src/core/brsTypes/nodes/StdDlgProgressItem.ts
@@ -46,7 +46,13 @@ export class StdDlgProgressItem extends Group {
         this.linkField(this.label, "text");
     }
 
-    renderNode(interpreter: Interpreter, origin: number[], angle: number, draw2D?: IfDraw2D): void {
+    renderNode(
+        interpreter: Interpreter,
+        origin: number[],
+        angle: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
         if (!this.isVisible()) {
             return;
         }
@@ -84,8 +90,9 @@ export class StdDlgProgressItem extends Group {
             boundingRect.width = labelSize.width;
             this.set(new BrsString("width"), new Float(boundingRect.width));
         }
+        opacity = opacity * this.getOpacity();
         this.updateBoundingRects(boundingRect, origin, angle);
-        this.renderChildren(interpreter, drawTrans, angle, draw2D);
+        this.renderChildren(interpreter, drawTrans, angle, opacity, draw2D);
         this.updateParentRects(origin, angle);
     }
 

--- a/src/core/scenegraph/SGNodeFactory.ts
+++ b/src/core/scenegraph/SGNodeFactory.ts
@@ -60,6 +60,7 @@ export enum SGNodeType {
     Rectangle = "Rectangle",
     Label = "Label",
     ScrollingLabel = "ScrollingLabel",
+    ScrollableText = "ScrollableText",
     Font = "Font",
     Poster = "Poster",
     ArrayGrid = "ArrayGrid",
@@ -75,7 +76,6 @@ export enum SGNodeType {
     Scene = "Scene",
     MiniKeyboard = "MiniKeyboard",
     TextEditBox = "TextEditBox",
-    ScrollableText = "ScrollableText",
     Overhang = "Overhang",
     RSGPalette = "RSGPalette",
     Video = "Video",
@@ -128,6 +128,7 @@ export class SGNodeFactory {
             case SGNodeType.Node:
                 return new RoSGNode([], name);
             case SGNodeType.Group:
+            case SGNodeType.ScrollableText:
                 return new Group([], name);
             case SGNodeType.LayoutGroup:
                 return new LayoutGroup([], name);
@@ -308,7 +309,7 @@ export function initializeNode(
 
             // Pre-render default state of the tree.
             if (node instanceof Scene) {
-                node.renderNode(interpreter, [0, 0], 0);
+                node.renderNode(interpreter, [0, 0], 0, 1);
             }
 
             interpreter.inSubEnv((subInterpreter) => {


### PR DESCRIPTION
Only `Rectangle` had support for `opacity` now all nodes and its children use and recursively combine the values.
Also improved `Poster` node to populate `bitmapWidth`, `bitmapHeight` and `bitmapMargins` fields and show the fallback bitmap using `failedBitmapUri` and `failedBitmapOpacity`