### PR TITLE
Fixed `registry` access on `Task` node and observer trigger

### DIFF
--- a/src/core/brsTypes/nodes/Field.ts
+++ b/src/core/brsTypes/nodes/Field.ts
@@ -301,7 +301,7 @@ export class Field {
         return value;
     }
 
-    private isEqual(oldValue: BrsType, newValue: BrsType) {
+    private isEqual(oldValue: BrsType, newValue: BrsType): boolean {
         if (isAnyNumber(oldValue) && isAnyNumber(newValue)) {
             return oldValue.getValue() === newValue.getValue();
         } else if (isBrsString(oldValue) && isBrsString(newValue)) {
@@ -311,7 +311,7 @@ export class Field {
         } else if (oldValue instanceof RoSGNode && newValue instanceof RoSGNode) {
             return oldValue === newValue && !newValue.changed;
         } else {
-            return oldValue === newValue;
+            return oldValue.equalTo(newValue).toBoolean();
         }
     }
 

--- a/src/core/device/BrsDevice.ts
+++ b/src/core/device/BrsDevice.ts
@@ -94,7 +94,7 @@ export class BrsDevice {
      */
     static setDeviceInfo(deviceInfo: DeviceInfo) {
         Object.entries(deviceInfo).forEach(([key, value]) => {
-            if (key !== "registry" && key !== "assets") {
+            if (!key.startsWith("registry") && key !== "assets") {
                 if (key === "developerId") {
                     // Prevent developerId from having "." to avoid issues on registry persistence
                     value = value.replace(".", ":");

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -373,7 +373,9 @@ export async function executeTask(payload: TaskPayload, customOptions?: Partial<
         return;
     }
     interpreter.setManifest(payload.manifest);
-    if (payload.device.registry?.size) {
+    if (payload.device.registryBuffer) {
+        BrsDevice.setRegistry(payload.device.registryBuffer);
+    } else if (payload.device.registry?.size) {
         BrsDevice.setRegistry(payload.device.registry);
     }
     BrsDevice.setDeviceInfo(payload.device);


### PR DESCRIPTION
The `registryBuffer` was not being used on `executeTask` and node fields with non comparable values were not triggering observer callbacks.