### PR TITLE
Implemented shared `m.global` object

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -613,7 +613,7 @@ function mainCallback(event: MessageEvent) {
     } else if (isAppData(event.data)) {
         notifyAll("launch", { app: event.data.id, params: event.data.params ?? new Map() });
     } else if (isTaskData(event.data)) {
-        console.log(
+        console.debug(
             "[API] Task data received from Main Thread: ",
             event.data.name,
             TaskState[event.data.state]
@@ -629,7 +629,7 @@ function mainCallback(event: MessageEvent) {
             endTask(event.data.id);
         }
     } else if (isTaskUpdate(event.data)) {
-        console.log(
+        console.debug(
             "[API] Task update received from Main thread: ",
             event.data.id,
             event.data.field
@@ -695,7 +695,7 @@ function taskCallback(event: MessageEvent) {
     } else if (typeof event.data.captionsMode === "string") {
         deviceData.captionsMode = event.data.captionsMode;
     } else if (isTaskData(event.data)) {
-        console.log(
+        console.debug(
             "[API] Task data received from Task Thread: ",
             event.data.name,
             TaskState[event.data.state]
@@ -704,7 +704,7 @@ function taskCallback(event: MessageEvent) {
             endTask(event.data.id);
         }
     } else if (isTaskUpdate(event.data)) {
-        console.log(
+        console.debug(
             "[API] Task update received from Task thread: ",
             event.data.id,
             event.data.field

--- a/src/core/SharedObject.ts
+++ b/src/core/SharedObject.ts
@@ -125,7 +125,7 @@ class SharedObject {
         }
     }
 
-    load(resetVersion: boolean = false): any | null {
+    load(resetVersion: boolean = false) {
         const currentLength = Atomics.load(this.atomicView, 0);
         if (currentLength < 1) {
             return {};
@@ -140,7 +140,7 @@ class SharedObject {
             return JSON.parse(serialized);
         } catch (error) {
             console.error("Error parsing data:", error, serialized);
-            return null;
+            return {};
         }
     }
 

--- a/src/core/brsTypes/components/RoSGNode.ts
+++ b/src/core/brsTypes/components/RoSGNode.ts
@@ -12,17 +12,15 @@ import {
     AAMember,
     BrsType,
     RoMessagePort,
-    Timer,
     Int32,
     RoArray,
     RoAssociativeArray,
     toAssociativeArray,
     BrsEvent,
-    Scene,
-    Task,
     jsValueOf,
     getTextureManager,
     isBrsString,
+    rootObjects,
 } from "..";
 import { Callable, StdlibArgument } from "../Callable";
 import { Stmt } from "../../parser";
@@ -1879,16 +1877,3 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         },
     });
 }
-
-/**
- * An object that holds the Node that represents the m.global, the root Scene,
- * the currently focused node and the arrays of tasks and timers.
- * */
-interface RootObjects {
-    mGlobal: RoSGNode;
-    rootScene?: Scene;
-    focused?: RoSGNode;
-    tasks: Task[];
-    timers: Timer[];
-}
-export const rootObjects: RootObjects = { mGlobal: new RoSGNode([]), tasks: [], timers: [] };

--- a/src/core/brsTypes/components/RoSGScreen.ts
+++ b/src/core/brsTypes/components/RoSGScreen.ts
@@ -208,6 +208,7 @@ export class RoSGScreen extends BrsComponent implements BrsValue, BrsDraw2D {
         }
         // Handle Scene Events
         if (rootObjects.rootScene) {
+            rootObjects.mGlobal.refresh();
             this.processTimers();
             this.processTasks();
             // TODO: Optimize rendering by only rendering if there are changes

--- a/src/core/brsTypes/index.ts
+++ b/src/core/brsTypes/index.ts
@@ -527,9 +527,10 @@ export function toNode(x: any, type: string, subtype: string): RoSGNode {
         node = SGNodeFactory.createNode(type, subtype) ?? new RoSGNode([], subtype);
     }
     for (const key in x) {
-        if (key !== "_node_" && key !== "_children_" && key !== "_observed_") {
-            node.setFieldValue(key, brsValueOf(x[key]));
+        if (key.startsWith("_") && key.endsWith("_") && key.length > 2) {
+            continue;
         }
+        node.setFieldValue(key, brsValueOf(x[key]));
     }
     if (x["_children_"]) {
         x["_children_"].forEach((child: any) => {

--- a/src/core/brsTypes/index.ts
+++ b/src/core/brsTypes/index.ts
@@ -627,7 +627,7 @@ export function fromSGNode(node: RoSGNode): FlexObject {
             if (isUnboxable(fieldValue)) {
                 fieldValue = fieldValue.unbox();
             }
-            if (field.isPortObserved(node)) {
+            if (node instanceof Task && field.isPortObserved(node)) {
                 observed.push(name);
             }
             result[name] = jsValueOf(fieldValue);
@@ -651,10 +651,10 @@ export function fromSGNode(node: RoSGNode): FlexObject {
  * @returns A JavaScript object with a SharedArrayBuffer.
  */
 export function fromGlobalNode(node: Global): FlexObject {
-    const result: FlexObject = {};
-    result["_node_"] = `${getNodeType(node.nodeSubtype)}:${node.nodeSubtype}`;
-    result["_buffer_"] = node.sharedObject.getBuffer();
-
+    const result: FlexObject = {
+        _node_: `${getNodeType(node.nodeSubtype)}:${node.nodeSubtype}`,
+        _buffer_: node.sharedObject.getBuffer(),
+    };
     return result;
 }
 

--- a/src/core/brsTypes/index.ts
+++ b/src/core/brsTypes/index.ts
@@ -42,6 +42,10 @@ import { RoSGNodeEvent } from "./events/RoSGNodeEvent";
 import { RoSGScreenEvent } from "./events/RoSGScreenEvent";
 import { isUnboxable } from "./Boxing";
 import { RoSGNode } from "./components/RoSGNode";
+import { Global } from "./nodes/Global";
+import { Scene } from "./nodes/Scene";
+import { Task } from "./nodes/Task";
+import { Timer } from "./nodes/Timer";
 import { Field } from "./nodes/Field";
 import { getNodeType, SGNodeFactory } from "../scenegraph/SGNodeFactory";
 import { BrsObjects } from "./components/BrsObjects";
@@ -385,7 +389,13 @@ export const ValidDateFormats = [
  * This is to be used to behave like and convert to a BrightScript Associative Array.
  */
 export interface FlexObject {
-    [key: string]: BrsConvertible | BrsConvertible[] | FlexObject | FlexObject[] | Map<string, any>;
+    [key: string]:
+        | BrsConvertible
+        | BrsConvertible[]
+        | FlexObject
+        | FlexObject[]
+        | Map<string, any>
+        | SharedArrayBuffer;
 }
 
 /**
@@ -505,8 +515,17 @@ function fromObject(x: any): BrsType {
  * @param subtype The subtype of the node.
  * @returns A RoSGNode with the converted fields.
  */
-function toNode(x: any, type: string, subtype: string): RoSGNode {
-    const node = SGNodeFactory.createNode(type, subtype) ?? new RoSGNode([], subtype);
+export function toNode(x: any, type: string, subtype: string): RoSGNode {
+    let node: RoSGNode;
+    if (x["_buffer_"]) {
+        node = new Global([]);
+        if (node instanceof Global) {
+            node.sharedObject.setBuffer(x["_buffer_"]);
+            x = node.sharedObject.load();
+        }
+    } else {
+        node = SGNodeFactory.createNode(type, subtype) ?? new RoSGNode([], subtype);
+    }
     for (const key in x) {
         if (key !== "_node_" && key !== "_children_" && key !== "_observed_") {
             node.setFieldValue(key, brsValueOf(x[key]));
@@ -572,6 +591,8 @@ export function jsValueOf(x: BrsType): any {
                 return x.elements.map(jsValueOf);
             } else if (x instanceof RoByteArray) {
                 return x.elements;
+            } else if (x instanceof Global) {
+                return fromGlobalNode(x);
             } else if (x instanceof RoSGNode) {
                 return fromSGNode(x);
             } else if (x instanceof RoAssociativeArray) {
@@ -622,3 +643,29 @@ export function fromSGNode(node: RoSGNode): FlexObject {
 
     return result;
 }
+
+/**
+ * Converts a Global node to a JavaScript object, using the SharedObject buffer.
+ * @param node The Global node to convert.
+ * @returns A JavaScript object with a SharedArrayBuffer.
+ */
+export function fromGlobalNode(node: Global): FlexObject {
+    const result: FlexObject = {};
+    result["_node_"] = `${getNodeType(node.nodeSubtype)}:${node.nodeSubtype}`;
+    result["_buffer_"] = node.sharedObject.getBuffer();
+
+    return result;
+}
+
+/**
+ * An object that holds the Node that represents the m.global, the root Scene,
+ * the currently focused node and the arrays of tasks and timers.
+ * */
+interface RootObjects {
+    mGlobal: Global;
+    rootScene?: Scene;
+    focused?: RoSGNode;
+    tasks: Task[];
+    timers: Timer[];
+}
+export const rootObjects: RootObjects = { mGlobal: new Global([]), tasks: [], timers: [] };

--- a/src/core/brsTypes/nodes/Field.ts
+++ b/src/core/brsTypes/nodes/Field.ts
@@ -19,6 +19,7 @@ import {
     isUnboxable,
     isAnyNumber,
     isBoxedNumber,
+    Task,
 } from "..";
 import { Callable } from "../Callable";
 import { Interpreter } from "../../interpreter";
@@ -266,9 +267,14 @@ export class Field {
         );
     }
 
-    isPortObserved(hostNode: RoSGNode) {
+    isPortObserved(hostNode: Task) {
         return (
-            this.unscopedObservers.some((callback) => callback.callable instanceof RoMessagePort) ||
+            this.unscopedObservers.some(
+                (callback) =>
+                    callback.callable instanceof RoMessagePort &&
+                    callback.hostNode instanceof Task &&
+                    callback.hostNode.id === hostNode.id
+            ) ||
             this.scopedObservers
                 .get(hostNode)
                 ?.some((callback) => callback.callable instanceof RoMessagePort) ||

--- a/src/core/brsTypes/nodes/Font.ts
+++ b/src/core/brsTypes/nodes/Font.ts
@@ -1,8 +1,8 @@
-import { rootObjects, RoSGNode } from "../components/RoSGNode";
+import { RoSGNode } from "../components/RoSGNode";
 import { FieldKind, FieldModel } from "./Field";
 import {
     BrsBoolean,
-    BrsInvalid,
+    rootObjects,
     BrsString,
     BrsType,
     getFontRegistry,

--- a/src/core/brsTypes/nodes/Global.ts
+++ b/src/core/brsTypes/nodes/Global.ts
@@ -1,30 +1,53 @@
 import { RoSGNode } from "../components/RoSGNode";
 import { FieldKind } from "./Field";
-import { AAMember, BrsType, isBrsString, fromSGNode } from "..";
+import { AAMember, BrsType, isBrsString, fromSGNode, brsValueOf, BrsString } from "..";
 import SharedObject from "../../SharedObject";
 
 export class Global extends RoSGNode {
+    private dataVersion: number;
     sharedObject: SharedObject;
 
     constructor(members: AAMember[] = [], readonly name: string = "Node") {
         super([], name);
-        this.sharedObject = new SharedObject();
-
         this.registerInitializedFields(members);
+
+        this.sharedObject = new SharedObject();
+        this.sharedObject.store(fromSGNode(this));
+        this.dataVersion = this.sharedObject.getVersion();
     }
 
     set(index: BrsType, value: BrsType, alwaysNotify: boolean = false, kind?: FieldKind) {
         if (!isBrsString(index)) {
             throw new Error("RoSGNode indexes must be strings");
         }
-
-        const mapKey = index.getValue().toLowerCase();
-
+        const fieldName = index.getValue().toLowerCase();
         const retValue = super.set(index, value, alwaysNotify, kind);
         // Refresh SharedObject with latest Node state
         if (this.changed) {
-            this.sharedObject.store(fromSGNode(this));
+            const data = fromSGNode(this);
+            data["_updated_"] = fieldName;
+            this.sharedObject.store(data);
+            this.dataVersion = this.sharedObject.getVersion();
         }
         return retValue;
+    }
+
+    refresh() {
+        const currVersion = this.sharedObject.getVersion();
+        if (this.dataVersion !== currVersion) {
+            const global = this.sharedObject.load();
+            const updated = global["_updated_"] as string;
+            for (let [key, value] of Object.entries(global)) {
+                if (key.startsWith("_") && key.endsWith("_") && key.length > 2) {
+                    // Ignore other transfer metadata fields
+                    continue;
+                } else if (key === updated) {
+                    super.set(new BrsString(key), brsValueOf(value));
+                } else {
+                    this.setFieldValue(key, brsValueOf(value));
+                }
+            }
+            this.dataVersion = currVersion;
+        }
     }
 }

--- a/src/core/brsTypes/nodes/Global.ts
+++ b/src/core/brsTypes/nodes/Global.ts
@@ -1,0 +1,30 @@
+import { RoSGNode } from "../components/RoSGNode";
+import { FieldKind } from "./Field";
+import { AAMember, BrsType, isBrsString, fromSGNode } from "..";
+import SharedObject from "../../SharedObject";
+
+export class Global extends RoSGNode {
+    sharedObject: SharedObject;
+
+    constructor(members: AAMember[] = [], readonly name: string = "Node") {
+        super([], name);
+        this.sharedObject = new SharedObject();
+
+        this.registerInitializedFields(members);
+    }
+
+    set(index: BrsType, value: BrsType, alwaysNotify: boolean = false, kind?: FieldKind) {
+        if (!isBrsString(index)) {
+            throw new Error("RoSGNode indexes must be strings");
+        }
+
+        const mapKey = index.getValue().toLowerCase();
+
+        const retValue = super.set(index, value, alwaysNotify, kind);
+        // Refresh SharedObject with latest Node state
+        if (this.changed) {
+            this.sharedObject.store(fromSGNode(this));
+        }
+        return retValue;
+    }
+}

--- a/src/core/brsTypes/nodes/Group.ts
+++ b/src/core/brsTypes/nodes/Group.ts
@@ -1,4 +1,4 @@
-import { rootObjects, RoSGNode } from "../components/RoSGNode";
+import { RoSGNode } from "../components/RoSGNode";
 import { FieldKind, FieldModel } from "./Field";
 import {
     Int32,
@@ -16,6 +16,7 @@ import {
     jsValueOf,
     isBrsString,
     BrsBoolean,
+    rootObjects,
 } from "..";
 import { Interpreter } from "../../interpreter";
 import { IfDraw2D, MeasuredText, Rect } from "../interfaces/IfDraw2D";

--- a/src/core/brsTypes/nodes/Task.ts
+++ b/src/core/brsTypes/nodes/Task.ts
@@ -9,6 +9,7 @@ import {
     BrsEvent,
     brsValueOf,
     isBrsString,
+    rootObjects,
 } from "..";
 import { Field, FieldKind, FieldModel } from "./Field";
 import { isTaskUpdate, TaskData, TaskState, TaskUpdate } from "../../common";
@@ -104,6 +105,7 @@ export class Task extends RoSGNode {
     /** Message callback to handle observed fields with message port */
     protected getNewEvents() {
         const events: BrsEvent[] = [];
+        rootObjects.mGlobal.refresh();
         this.updateTask();
         return events;
     }

--- a/src/core/scenegraph/SGNodeFactory.ts
+++ b/src/core/scenegraph/SGNodeFactory.ts
@@ -416,7 +416,12 @@ export function initializeTask(interpreter: Interpreter, taskData: TaskData) {
             }
         }
         if (taskData.m?.global) {
-            for (let [key, value] of Object.entries(taskData.m.global)) {
+            let global = taskData.m.global;
+            if (global["_buffer_"] instanceof SharedArrayBuffer) {
+                rootObjects.mGlobal.sharedObject.setBuffer(global["_buffer_"]);
+                global = rootObjects.mGlobal.sharedObject.load();
+            }
+            for (let [key, value] of Object.entries(global)) {
                 if (key.startsWith("_") && key.endsWith("_") && key.length > 2) {
                     // Ignore transfer metadata fields
                     continue;


### PR DESCRIPTION
A new `Global` special node was created to handle the shared `m.global` among the threads (main and tasks) and allowed also the observability in the task with a message port.