### PR TITLE
Added support for `ifHttpAgent` headers configuration

### DIFF
--- a/src/core/brsTypes/components/RoSGNode.ts
+++ b/src/core/brsTypes/components/RoSGNode.ts
@@ -486,7 +486,9 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
     /** Load a bitmap based on one of the fields of the node */
     getBitmap(fieldName: string) {
         const uri = this.getFieldValueJS(fieldName) as string;
-        return uri?.trim() ? getTextureManager().loadTexture(uri) : undefined;
+        return uri?.trim()
+            ? getTextureManager().loadTexture(uri, this.httpAgent.customHeaders)
+            : undefined;
     }
 
     /** Returns the largest dimensions of the icons from the passed fields */

--- a/src/core/brsTypes/components/RoTextureManager.ts
+++ b/src/core/brsTypes/components/RoTextureManager.ts
@@ -119,14 +119,14 @@ export class RoTextureManager extends BrsComponent implements BrsValue, BrsHttpA
         return new RoTextureRequestEvent(request, bitmap);
     }
 
-    loadTexture(uri: string): RoBitmap | undefined {
+    loadTexture(uri: string, headers?: Map<string, string>): RoBitmap | undefined {
         const bitmap = this.textures.get(uri);
         if (bitmap) {
             return bitmap;
         }
         let data: ArrayBuffer | undefined;
         if (uri.startsWith("http")) {
-            data = download(uri, "arraybuffer", this.customHeaders, this.cookiesEnabled);
+            data = download(uri, "arraybuffer", headers ?? this.customHeaders, this.cookiesEnabled);
         } else {
             try {
                 const fsys = BrsDevice.fileSystem;

--- a/src/core/brsTypes/components/RoTextureManager.ts
+++ b/src/core/brsTypes/components/RoTextureManager.ts
@@ -128,28 +128,7 @@ export class RoTextureManager extends BrsComponent implements BrsValue, BrsHttpA
         if (uri.startsWith("http")) {
             data = download(uri, "arraybuffer", headers ?? this.customHeaders, this.cookiesEnabled);
         } else {
-            try {
-                const fsys = BrsDevice.fileSystem;
-                let assetPath = uri;
-                if (uri.startsWith("pkg:/locale/images/") && !fsys.existsSync(uri)) {
-                    const locale = BrsDevice.deviceInfo.locale;
-                    const filePath = uri.substring("pkg:/locale/images/".length);
-                    if (fsys.existsSync(`pkg:/locale/${locale}/images/${filePath}`)) {
-                        assetPath = `pkg:/locale/${locale}/images/${filePath}`;
-                    } else if (fsys.existsSync(`pkg:/locale/default/images/${filePath}`)) {
-                        assetPath = `pkg:/locale/default/images/${filePath}`;
-                    } else if (fsys.existsSync(`pkg:/locale/en_US/images/${filePath}`)) {
-                        assetPath = `pkg:/locale/en_US/images/${filePath}`;
-                    }
-                }
-                data = fsys.readFileSync(assetPath);
-            } catch (err: any) {
-                if (BrsDevice.isDevMode) {
-                    BrsDevice.stderr.write(
-                        `warning,[roTextureManager] Error requesting texture ${uri}: ${err.message}`
-                    );
-                }
-            }
+            data = this.loadLocalFile(uri);
         }
         if (data) {
             const bitmap = new RoBitmap(data, uri.toLowerCase().endsWith(".9.png"));
@@ -159,6 +138,31 @@ export class RoTextureManager extends BrsComponent implements BrsValue, BrsHttpA
             }
         }
         return undefined;
+    }
+
+    private loadLocalFile(uri: string) {
+        try {
+            const fsys = BrsDevice.fileSystem;
+            let assetPath = uri;
+            if (uri.startsWith("pkg:/locale/images/") && !fsys.existsSync(uri)) {
+                const locale = BrsDevice.deviceInfo.locale;
+                const filePath = uri.substring("pkg:/locale/images/".length);
+                if (fsys.existsSync(`pkg:/locale/${locale}/images/${filePath}`)) {
+                    assetPath = `pkg:/locale/${locale}/images/${filePath}`;
+                } else if (fsys.existsSync(`pkg:/locale/default/images/${filePath}`)) {
+                    assetPath = `pkg:/locale/default/images/${filePath}`;
+                } else if (fsys.existsSync(`pkg:/locale/en_US/images/${filePath}`)) {
+                    assetPath = `pkg:/locale/en_US/images/${filePath}`;
+                }
+            }
+            return fsys.readFileSync(assetPath);
+        } catch (err: any) {
+            if (BrsDevice.isDevMode) {
+                BrsDevice.stderr.write(
+                    `warning,[roTextureManager] Error requesting texture ${uri}: ${err.message}`
+                );
+            }
+        }
     }
 
     /** Makes a request for an roBitmap with the attributes specified by the roTextureRequest. */

--- a/src/core/brsTypes/nodes/Button.ts
+++ b/src/core/brsTypes/nodes/Button.ts
@@ -167,7 +167,7 @@ export class Button extends Group {
         let width = 0;
         let height = 0;
         if (uri) {
-            const bmp = getTextureManager().loadTexture(uri);
+            const bmp = getTextureManager().loadTexture(uri, this.httpAgent.customHeaders);
             if (bmp) {
                 width = bmp.width;
                 height = bmp.height;

--- a/src/core/brsTypes/nodes/Poster.ts
+++ b/src/core/brsTypes/nodes/Poster.ts
@@ -119,7 +119,7 @@ export class Poster extends Group {
 
     private loadUri(uri: string): string {
         let loadStatus = "failed";
-        this.bitmap = getTextureManager().loadTexture(uri);
+        this.bitmap = getTextureManager().loadTexture(uri, this.httpAgent.customHeaders);
         if (this.bitmap?.isValid()) {
             this.setFieldValue("bitmapWidth", new Float(this.bitmap.width));
             this.setFieldValue("bitmapHeight", new Float(this.bitmap.height));

--- a/src/core/brsTypes/nodes/Scene.ts
+++ b/src/core/brsTypes/nodes/Scene.ts
@@ -121,7 +121,7 @@ export class Scene extends Group {
         const backURI = this.getFieldValueJS("backgroundUri") as string;
         if (draw2D && backURI.trim() !== "") {
             const textureManager = getTextureManager();
-            const bitmap = textureManager.loadTexture(backURI);
+            const bitmap = textureManager.loadTexture(backURI, this.httpAgent.customHeaders);
             if (bitmap instanceof RoBitmap && bitmap.isValid()) {
                 const scaleX = this.ui.width / bitmap.width;
                 const scaleY = this.ui.height / bitmap.height;


### PR DESCRIPTION
Updated `roTextureManager.loadTexture()` to get an optional parameter with the headers map, that is now sent by SceneGraph nodes.