### PR TITLE
Changed `Task` threads to use `Atomics.wait()` and sleep until data arrives.

### DIFF
--- a/src/core/SharedObject.ts
+++ b/src/core/SharedObject.ts
@@ -46,6 +46,10 @@ class SharedObject {
         this.processQueue();
     }
 
+    waitVersion(version: number, timeout?: number) {
+        return Atomics.wait(this.atomicView, this.versionIdx, version, timeout);
+    }
+
     private processQueue(): void {
         if (this.isProcessing || this.queue.length === 0) {
             return;

--- a/src/core/brsTypes/components/RoMessagePort.ts
+++ b/src/core/brsTypes/components/RoMessagePort.ts
@@ -55,14 +55,14 @@ export class RoMessagePort extends BrsComponent implements BrsValue {
 
     wait(interpreter: Interpreter, ms: number) {
         const loop = ms === 0;
-        ms += performance.now();
+        const timeout = ms + performance.now();
 
-        while (loop || performance.now() < ms) {
-            this.updateMessageQueue();
+        while (loop || performance.now() < timeout) {
             const msg = this.getNextMessage();
-            if (msg !== BrsInvalid.Instance) {
+            if (isBrsEvent(msg)) {
                 return msg;
             }
+            this.updateMessageQueue(ms);
             const cmd = BrsDevice.checkBreakCommand(interpreter.debugMode);
             if (cmd === DebugCommand.BREAK || cmd === DebugCommand.EXIT) {
                 interpreter.debugMode = cmd === DebugCommand.BREAK;
@@ -72,10 +72,10 @@ export class RoMessagePort extends BrsComponent implements BrsValue {
         return BrsInvalid.Instance;
     }
 
-    private updateMessageQueue() {
+    private updateMessageQueue(wait?: number) {
         if (this.callbackMap.size > 0) {
             for (const [_, callback] of this.callbackMap.entries()) {
-                const events = callback();
+                const events = callback(wait);
                 this.messageQueue.push(...events.filter(isBrsEvent));
             }
         }
@@ -85,12 +85,9 @@ export class RoMessagePort extends BrsComponent implements BrsValue {
         if (this.messageQueue.length > 0) {
             return this.messageQueue.shift();
         } else if (this.callbackQueue.length > 0) {
-            let callback = this.callbackQueue.shift();
+            const callback = this.callbackQueue.shift();
             if (typeof callback === "function") {
-                const event = callback();
-                if (event !== BrsInvalid.Instance) {
-                    return event;
-                }
+                return callback();
             }
         }
         return BrsInvalid.Instance;

--- a/src/core/brsTypes/components/RoSGNode.ts
+++ b/src/core/brsTypes/components/RoSGNode.ts
@@ -522,10 +522,9 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
     }
 
     /** Message callback to handle observed fields with message port */
-    protected getNewEvents() {
-        const events: BrsEvent[] = [];
+    protected getNewEvents(_wait: number) {
         // To be overridden by the Task class
-        return events;
+        return new Array<BrsEvent>();
     }
 
     private registerHttpAgent(agent: RoHttpAgent) {

--- a/src/core/brsTypes/nodes/Task.ts
+++ b/src/core/brsTypes/nodes/Task.ts
@@ -114,10 +114,14 @@ export class Task extends RoSGNode {
     }
 
     /** Message callback to handle observed fields with message port */
-    protected getNewEvents() {
-        const events: BrsEvent[] = [];
-        this.updateTask();
-        return events;
+    protected getNewEvents(wait: number) {
+        if (this.taskBuffer && this.thread) {
+            const timeout = wait === 0 ? undefined : wait;
+            const result = this.taskBuffer.waitVersion(0, timeout);
+            console.debug(`The thread ${this.id} was awaken with "${result}"`);
+            this.updateTask();
+        }
+        return new Array<BrsEvent>();
     }
 
     checkTask() {


### PR DESCRIPTION
This change prevents the task worker threads to be continuously running on the while loop, instead it sleeps with `Atomics.wait()` until any data arrives from the main thread.