### PR TITLE
Fixed `Poster` and `BusySpinner` nodes

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -156,7 +156,7 @@ export function initialize(customDeviceInfo?: Partial<DeviceInfo>, options: any 
         sharedBuffer = new ArrayBuffer(Int32Array.BYTES_PER_ELEMENT * length);
         apiException(
             "warning",
-            `[api] Remote control simulation will not work as SharedArrayBuffer is not enabled, ` +
+            `[api] Tasks threads and remote control simulation will not work as SharedArrayBuffer is not enabled, ` +
                 `to know more visit https://developer.chrome.com/blog/enabling-shared-array-buffer/`
         );
     }

--- a/src/core/brsTypes/nodes/BusySpinner.ts
+++ b/src/core/brsTypes/nodes/BusySpinner.ts
@@ -14,7 +14,7 @@ export class BusySpinner extends Group {
         { name: "spinInterval", type: "float", value: "2.0" }, // seconds
     ];
     private poster: Poster;
-    private active: boolean = false;
+    private active: boolean = true;
     private lastRenderTime: number = 0;
     private currentRotation: number = 0;
 
@@ -39,7 +39,7 @@ export class BusySpinner extends Group {
             let control = value.toString();
             if (control === "start") {
                 this.active = true;
-                this.lastRenderTime = performance.now();
+                this.lastRenderTime = Date.now();
             } else if (control === "stop") {
                 this.active = false;
             } else {
@@ -94,7 +94,10 @@ export class BusySpinner extends Group {
                 this.setFieldValue("height", new Float(bmp.height));
             }
             if (this.active) {
-                const now = performance.now();
+                if (this.lastRenderTime === 0) {
+                    this.lastRenderTime = Date.now();
+                }
+                const now = Date.now();
                 const spinInterval = this.getFieldValueJS("spinInterval") as number;
                 const clockwise = this.getFieldValueJS("clockwise") as boolean;
                 const direction = clockwise ? -1 : 1;

--- a/src/core/brsTypes/nodes/Poster.ts
+++ b/src/core/brsTypes/nodes/Poster.ts
@@ -60,15 +60,15 @@ export class Poster extends Group {
                 if (loadStatus !== "ready" && this.getFieldValueJS("failedBitmapUri") !== "") {
                     this.loadUri(this.getFieldValueJS("failedBitmapUri"));
                 }
-                this.setFieldValue("loadStatus", new BrsString(loadStatus));
+                super.set(new BrsString("loadStatus"), new BrsString(loadStatus));
             } else if (typeof uri !== "string" || uri.trim() === "") {
                 this.uri = "";
                 this.bitmap = undefined;
-                this.setFieldValue("loadStatus", new BrsString("none"));
-                this.setFieldValue("bitmapWidth", new Float(0));
-                this.setFieldValue("bitmapHeight", new Float(0));
+                super.set(new BrsString("loadStatus"), new BrsString("none"));
+                super.set(new BrsString("bitmapWidth"), new Float(0));
+                super.set(new BrsString("bitmapHeight"), new Float(0));
                 const margins = { left: 0, right: 0, top: 0, bottom: 0 };
-                this.setFieldValue("bitmapMargins", brsValueOf(margins));
+                super.set(new BrsString("bitmapMargins"), brsValueOf(margins));
             }
         } else if (readonlyFields.includes(fieldName)) {
             return BrsInvalid.Instance;
@@ -115,8 +115,8 @@ export class Poster extends Group {
         let loadStatus = "failed";
         this.bitmap = getTextureManager().loadTexture(uri, this.httpAgent.customHeaders);
         if (this.bitmap?.isValid()) {
-            this.setFieldValue("bitmapWidth", new Float(this.bitmap.width));
-            this.setFieldValue("bitmapHeight", new Float(this.bitmap.height));
+            super.set(new BrsString("bitmapWidth"), new Float(this.bitmap.width));
+            super.set(new BrsString("bitmapHeight"), new Float(this.bitmap.height));
             const margins = { left: 0, right: 0, top: 0, bottom: 0 };
             if (this.bitmap.ninePatch) {
                 const sizes = this.bitmap.getPatchSizes();
@@ -125,7 +125,7 @@ export class Poster extends Group {
                 margins.top = sizes.vertical;
                 margins.bottom = sizes.vertical;
             }
-            this.setFieldValue("bitmapMargins", brsValueOf(margins));
+            super.set(new BrsString("bitmapMargins"), brsValueOf(margins));
             loadStatus = "ready";
         }
         return loadStatus;


### PR DESCRIPTION
The `BusySpinner` was not starting by default and `Poster` was not triggering observer callbacks for read-only fields.