### PR TITLE
Fixed `Keyboard` to enable cursor on `TextEditBox` with focus and calculate the bounding box correctly

### DIFF
--- a/src/core/brsTypes/nodes/Keyboard.ts
+++ b/src/core/brsTypes/nodes/Keyboard.ts
@@ -53,6 +53,8 @@ export class Keyboard extends Group {
     private readonly keyWidth: number;
     private readonly keyHeight: number;
     private readonly keyFocusDelta: number;
+    private readonly widthOver: number;
+    private readonly heightOver: number;
     private readonly offsetX: number;
     private readonly offsetY: number;
     private readonly font: Font;
@@ -103,6 +105,8 @@ export class Keyboard extends Group {
             this.keyFocusDelta = 15;
             this.offsetX = 90;
             this.offsetY = 84;
+            this.widthOver = 21;
+            this.heightOver = 90;
         } else {
             this.textEditBox.setFieldValue("width", new Float(914));
             this.textEditX = 8;
@@ -118,10 +122,15 @@ export class Keyboard extends Group {
             this.keyFocusDelta = 10;
             this.offsetX = 60;
             this.offsetY = 56;
+            this.widthOver = 12;
+            this.heightOver = 60;
         }
         this.textEditBox.setTranslation([this.textEditX, 0]);
         this.textEditBox.setFieldValue("maxTextLength", new Int32(75));
         this.bmpBack = getTextureManager().loadTexture(`common:/images/keyboard_full_${this.resolution}.png`);
+        this.setFieldValue("width", new Float(this.bmpBack!.width + this.widthOver));
+        this.setFieldValue("height", new Float(this.bmpBack!.height + this.heightOver));
+
         this.bmpFocus = getTextureManager().loadTexture("common:/images/focus_keyboard.9.png");
         this.icons.forEach((icon) => {
             const uri = `common:/images/icon_${icon}_${this.resolution}.png`;
@@ -245,6 +254,7 @@ export class Keyboard extends Group {
             return;
         }
         const isFocused = rootObjects.focused === this;
+        this.textEditBox.setActive(isFocused);
         const nodeTrans = this.getTranslation();
         const drawTrans = nodeTrans.slice();
         drawTrans[0] += origin[0];
@@ -258,8 +268,8 @@ export class Keyboard extends Group {
             this.keyColor = this.getFieldValueJS("keyColor") as number;
             this.focusedKeyColor = this.getFieldValueJS("focusedKeyColor") as number;
         }
-
-        this.drawImage(this.bmpBack!, { ...rect, y: rect.y + this.iconLeftY }, 0, opacity, draw2D);
+        const backRect = { x: rect.x, y: rect.y + this.iconLeftY, width: 0, height: 0 };
+        this.drawImage(this.bmpBack!, backRect, 0, opacity, draw2D);
         this.renderLeftIcons(rect, opacity, isFocused, draw2D);
         this.keyFocus.key = "";
         const keysY = rect.y + this.keyBaseY;

--- a/src/core/brsTypes/nodes/KeyboardDialog.ts
+++ b/src/core/brsTypes/nodes/KeyboardDialog.ts
@@ -90,8 +90,8 @@ export class KeyboardDialog extends Dialog {
         if (press && (key === "back" || (key === "options" && optionsDialog))) {
             this.set(new BrsString("close"), BrsBoolean.True);
             this.focus = "";
-            this.keyboard.textEditBox.setFieldValue("active", BrsBoolean.False);
-            this.keyboard.textEditBox.setFieldValue("cursorPosition", new Int32(0));
+            this.keyboard.textEditBox.setActive(false);
+            this.keyboard.textEditBox.moveCursor(0);
             handled = true;
         } else if (this.hasButtons && this.focus === "buttons") {
             handled = this.buttonGroup.handleKey(key, press);
@@ -104,13 +104,11 @@ export class KeyboardDialog extends Dialog {
         if (press && key === "up" && this.focus === "buttons") {
             rootObjects.focused = this.keyboard;
             this.focus = "keyboard";
-            this.keyboard.textEditBox.set(new BrsString("active"), BrsBoolean.True);
             this.isDirty = true;
             handled = true;
         } else if (press && key === "down" && this.focus === "keyboard") {
             rootObjects.focused = this.buttonGroup;
             this.focus = "buttons";
-            this.keyboard.textEditBox.set(new BrsString("active"), BrsBoolean.False);
             this.isDirty = true;
             handled = true;
         }
@@ -160,7 +158,6 @@ export class KeyboardDialog extends Dialog {
         }
         if (this.focus === "") {
             this.focus = this.hasButtons ? "buttons" : "keyboard";
-            this.keyboard.textEditBox.set(new BrsString("active"), BrsBoolean.from(!this.hasButtons));
         }
 
         // Set new Dialog height and reposition elements

--- a/src/core/brsTypes/nodes/TextEditBox.ts
+++ b/src/core/brsTypes/nodes/TextEditBox.ts
@@ -136,14 +136,25 @@ export class TextEditBox extends Group {
         return handled;
     }
 
+    /** Set the active state of the node */
+    setActive(active: boolean) {
+        this.set(new BrsString("active"), BrsBoolean.from(active));
+    }
+
+    /** Move the cursor a delta or if delta is zero, reset to first position */
     moveCursor(delta: number) {
         let position = this.getFieldValueJS("cursorPosition") as number;
         const text = this.getFieldValueJS("text") as string;
-        position += delta;
-        if (position < 0) {
+
+        if (delta === 0) {
             position = 0;
-        } else if (position > text.length) {
-            position = text.length;
+        } else {
+            position += delta;
+            if (position < 0) {
+                position = 0;
+            } else if (position > text.length) {
+                position = text.length;
+            }
         }
         this.set(new BrsString("cursorPosition"), new Float(position));
         // Reset cursor blink on move


### PR DESCRIPTION
The focus for the text edit box was incorrectly being handled in the Dialog also the Keyboard bounding box was not being calculated correctly