### PR TITLE
Refactoring to move `nodeDefMap` to `rootObjects` and other improvements

### DIFF
--- a/src/core/brsTypes/components/BrsObjects.ts
+++ b/src/core/brsTypes/components/BrsObjects.ts
@@ -182,5 +182,5 @@ export const BrsObjects = new BrsObjectsMap([
     ["roSocketAddress", (_?: Interpreter) => new RoSocketAddress()],
     ["roStreamSocket", (_?: Interpreter) => new RoStreamSocket()],
     ["roSGNode", (interpreter: Interpreter, nodeType: BrsString) => createNodeByType(interpreter, nodeType), 1],
-    ["roSGScreen", (interpreter: Interpreter) => new RoSGScreen(interpreter)],
+    ["roSGScreen", (_?: Interpreter) => new RoSGScreen()],
 ]);

--- a/src/core/brsTypes/components/RoMessagePort.ts
+++ b/src/core/brsTypes/components/RoMessagePort.ts
@@ -62,7 +62,7 @@ export class RoMessagePort extends BrsComponent implements BrsValue {
             if (isBrsEvent(msg)) {
                 return msg;
             }
-            this.updateMessageQueue(ms);
+            this.updateMessageQueue(interpreter, ms);
             const cmd = BrsDevice.checkBreakCommand(interpreter.debugMode);
             if (cmd === DebugCommand.BREAK || cmd === DebugCommand.EXIT) {
                 interpreter.debugMode = cmd === DebugCommand.BREAK;
@@ -72,10 +72,10 @@ export class RoMessagePort extends BrsComponent implements BrsValue {
         return BrsInvalid.Instance;
     }
 
-    private updateMessageQueue(wait?: number) {
+    private updateMessageQueue(interpreter?: Interpreter, wait?: number) {
         if (this.callbackMap.size > 0) {
             for (const [_, callback] of this.callbackMap.entries()) {
-                const events = callback(wait);
+                const events = callback(interpreter, wait);
                 this.messageQueue.push(...events.filter(isBrsEvent));
             }
         }

--- a/src/core/brsTypes/components/RoSGNode.ts
+++ b/src/core/brsTypes/components/RoSGNode.ts
@@ -382,7 +382,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             if (!this.triedInitFocus) {
                 // Only try initial focus once
                 this.triedInitFocus = true;
-                const typeDef = interpreter.environment.nodeDefMap.get(this.nodeSubtype.toLowerCase());
+                const typeDef = rootObjects.nodeDefMap.get(this.nodeSubtype.toLowerCase());
                 if (typeDef?.initialFocus) {
                     const initialFocus = new BrsString(typeDef.initialFocus);
                     const childToFocus = this.findNodeById(this, initialFocus);
@@ -501,7 +501,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
     }
 
     /** Message callback to handle observed fields with message port */
-    protected getNewEvents(_wait: number) {
+    protected getNewEvents(_interpreter: Interpreter, _wait: number) {
         // To be overridden by the Task class
         return new Array<BrsEvent>();
     }
@@ -669,7 +669,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             },
             impl: (interpreter: Interpreter, functionName: BrsString, ...functionArgs: BrsType[]) => {
                 // We need to search the callee's environment for this function rather than the caller's.
-                let componentDef = interpreter.environment.nodeDefMap.get(this.nodeSubtype.toLowerCase());
+                let componentDef = rootObjects.nodeDefMap.get(this.nodeSubtype.toLowerCase());
 
                 // Only allow public functions (defined in the interface) to be called.
                 if (componentDef && functionName.value in componentDef.functions) {

--- a/src/core/brsTypes/index.ts
+++ b/src/core/brsTypes/index.ts
@@ -40,6 +40,7 @@ import { Task } from "./nodes/Task";
 import { Timer } from "./nodes/Timer";
 import { Audio } from "./nodes/Audio";
 import { Field } from "./nodes/Field";
+import { ComponentDefinition } from "../scenegraph";
 import { getNodeType, SGNodeFactory } from "../scenegraph/SGNodeFactory";
 import { BrsObjects } from "./components/BrsObjects";
 
@@ -614,10 +615,11 @@ export function fromSGNode(node: RoSGNode): FlexObject {
  * */
 interface RootObjects {
     mGlobal: Global;
+    nodeDefMap: Map<string, ComponentDefinition>;
     rootScene?: Scene;
     focused?: RoSGNode;
     audio?: Audio;
     tasks: Task[];
     timers: Timer[];
 }
-export const rootObjects: RootObjects = { mGlobal: new Global([]), tasks: [], timers: [] };
+export const rootObjects: RootObjects = { mGlobal: new Global([]), nodeDefMap: new Map(), tasks: [], timers: [] };

--- a/src/core/brsTypes/nodes/MarkupGrid.ts
+++ b/src/core/brsTypes/nodes/MarkupGrid.ts
@@ -112,7 +112,7 @@ export class MarkupGrid extends ArrayGrid {
         }
         const hasSections = this.metadata.length > 0;
         const itemCompName = this.getFieldValueJS("itemComponentName") as string;
-        if (!customNodeExists(interpreter, new BrsString(itemCompName))) {
+        if (!customNodeExists(new BrsString(itemCompName))) {
             BrsDevice.stderr.write(`warning,[sg.markupgrid.create.fail] Failed to create markup item ${itemCompName}`);
             return;
         }

--- a/src/core/brsTypes/nodes/MarkupList.ts
+++ b/src/core/brsTypes/nodes/MarkupList.ts
@@ -96,7 +96,7 @@ export class MarkupList extends ArrayGrid {
         }
         const hasSections = this.metadata.length > 0;
         const itemCompName = this.getFieldValueJS("itemComponentName") as string;
-        if (!customNodeExists(interpreter, new BrsString(itemCompName))) {
+        if (!customNodeExists(new BrsString(itemCompName))) {
             BrsDevice.stderr.write(`warning,[sg.markuplist.create.fail] Failed to create markup item ${itemCompName}`);
             return;
         }

--- a/src/core/brsTypes/nodes/Scene.ts
+++ b/src/core/brsTypes/nodes/Scene.ts
@@ -141,7 +141,7 @@ export class Scene extends Group {
     }
 
     private handleKeyByNode(interpreter: Interpreter, hostNode: RoSGNode, key: BrsString, press: BrsBoolean): boolean {
-        const typeDef = interpreter.environment.nodeDefMap.get(hostNode.nodeSubtype.toLowerCase());
+        const typeDef = rootObjects.nodeDefMap.get(hostNode.nodeSubtype.toLowerCase());
         if (typeDef?.environment === undefined) {
             if (hostNode instanceof Group) {
                 return hostNode.handleKey(key.value, press.toBoolean());

--- a/src/core/brsTypes/nodes/Task.ts
+++ b/src/core/brsTypes/nodes/Task.ts
@@ -15,6 +15,7 @@ import { Field, FieldKind, FieldModel } from "./Field";
 import { isThreadUpdate, TaskData, TaskState, ThreadUpdate } from "../../common";
 import SharedObject from "../../SharedObject";
 import { Global } from "./Global";
+import { Interpreter } from "../../interpreter";
 
 export class Task extends RoSGNode {
     readonly defaultFields: FieldModel[] = [
@@ -108,7 +109,7 @@ export class Task extends RoSGNode {
     }
 
     /** Message callback to handle observed fields with message port */
-    protected getNewEvents(wait: number) {
+    protected getNewEvents(_: Interpreter, wait: number) {
         if (this.taskBuffer && this.thread) {
             const timeout = wait === 0 ? undefined : wait;
             const result = this.taskBuffer.waitVersion(0, timeout);

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -307,6 +307,7 @@ export async function executeFile(payload: AppPayload, customOptions?: Partial<E
     let interpreter: Interpreter;
     if (components.size > 0) {
         interpreter = await getInterpreterWithSubEnvs(components, payload.manifest, options);
+        BrsTypes.rootObjects.nodeDefMap = components;
     } else {
         interpreter = new Interpreter(options);
     }
@@ -357,6 +358,7 @@ export async function executeTask(payload: TaskPayload, customOptions?: Partial<
     let interpreter: Interpreter;
     if (components.size > 0) {
         interpreter = await getInterpreterWithSubEnvs(components, payload.manifest, options);
+        BrsTypes.rootObjects.nodeDefMap = components;
     } else {
         postMessage(`warning,No SceneGraph components found!`);
         return;
@@ -546,8 +548,8 @@ async function runSource(
             return { exitReason: AppExitReason.PACKAGED, cipherText: cipherText, iv: iv };
         }
         // Update Source Map with the SceneGraph components (if exists)
-        if (interpreter.environment.nodeDefMap?.size) {
-            const components = interpreter.environment.nodeDefMap;
+        if (BrsTypes.rootObjects.nodeDefMap?.size) {
+            const components = BrsTypes.rootObjects.nodeDefMap;
             Array.from(components.values()).forEach((component: ComponentDefinition) => {
                 component.scripts.forEach((script) => {
                     const sourcePath = script.uri ?? script.xmlPath;

--- a/src/core/interpreter/Environment.ts
+++ b/src/core/interpreter/Environment.ts
@@ -53,9 +53,6 @@ export class Environment {
     private mPointer: RoAssociativeArray;
     private rootM: RoAssociativeArray;
 
-    /** Map holding component definitions of all parsed xml component files */
-    public nodeDefMap = new Map<string, ComponentDefinition>();
-
     /** The node in which field-change observers are registered. */
     public hostNode: RoSGNode | undefined;
 
@@ -268,7 +265,6 @@ export class Environment {
     public createSubEnvironment(includeModuleScope: boolean = true): Environment {
         let newEnvironment = new Environment(this.mPointer, this.rootM);
         newEnvironment.global = this.global;
-        newEnvironment.nodeDefMap = this.nodeDefMap;
         newEnvironment.hostNode = this.hostNode;
         if (includeModuleScope) {
             newEnvironment.module = this.module;

--- a/src/core/interpreter/index.ts
+++ b/src/core/interpreter/index.ts
@@ -343,7 +343,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
             if (taskData.buffer) {
                 taskNode.setTaskBuffer(taskData.buffer);
             }
-            const typeDef = this.environment.nodeDefMap.get(taskNode.nodeSubtype.toLowerCase());
+            const typeDef = rootObjects.nodeDefMap.get(taskNode.nodeSubtype.toLowerCase());
             const taskEnv = typeDef?.environment;
             if (taskEnv) {
                 const mPointer = taskNode.m;

--- a/src/core/scenegraph/SGNodeFactory.ts
+++ b/src/core/scenegraph/SGNodeFactory.ts
@@ -231,7 +231,7 @@ export function createNodeByType(interpreter: Interpreter, type: BrsString): RoS
     // If this is a built-in node component, then return it.
     let node = SGNodeFactory.createNode(type.value) ?? BrsInvalid.Instance;
     if (node instanceof BrsInvalid) {
-        let typeDef = interpreter.environment.nodeDefMap.get(type.value.toLowerCase());
+        let typeDef = rootObjects.nodeDefMap.get(type.value.toLowerCase());
         if (typeDef) {
             if (typeDef.extends === SGNodeType.Scene) {
                 node = new Scene([], type.value);
@@ -260,8 +260,8 @@ export function createNodeByType(interpreter: Interpreter, type: BrsString): RoS
     return node;
 }
 
-export function customNodeExists(interpreter: Interpreter, node: BrsString) {
-    return interpreter.environment.nodeDefMap.has(node.value.toLowerCase());
+export function customNodeExists(node: BrsString) {
+    return rootObjects.nodeDefMap.has(node.value.toLowerCase());
 }
 
 /** Function to initialize Nodes with its Fields, Children and Environment */
@@ -283,7 +283,7 @@ export function initializeNode(
             // Add the current typedef to the subtypeHierarchy
             subtypeHierarchy.set(typeDef.name!.toLowerCase(), typeDef.extends || SGNodeType.Node);
 
-            typeDef = interpreter.environment.nodeDefMap.get(typeDef.extends.toLowerCase());
+            typeDef = rootObjects.nodeDefMap.get(typeDef.extends.toLowerCase());
             if (typeDef) typeDefStack.push(typeDef);
         }
 
@@ -353,7 +353,7 @@ export function initializeNode(
 /** Function to Initialize a Task on its own Worker thread */
 export function initializeTask(interpreter: Interpreter, taskData: TaskData) {
     const type = taskData.name;
-    let typeDef = interpreter.environment.nodeDefMap.get(type.toLowerCase());
+    let typeDef = rootObjects.nodeDefMap.get(type.toLowerCase());
     if (typeDef) {
         //use typeDef object to tack on all the bells & whistles of a custom node
         let typeDefStack: ComponentDefinition[] = [];
@@ -366,7 +366,7 @@ export function initializeTask(interpreter: Interpreter, taskData: TaskData) {
             // Add the current typedef to the subtypeHierarchy
             subtypeHierarchy.set(typeDef.name!.toLowerCase(), typeDef.extends || SGNodeType.Task);
 
-            typeDef = interpreter.environment.nodeDefMap.get(typeDef.extends.toLowerCase());
+            typeDef = rootObjects.nodeDefMap.get(typeDef.extends.toLowerCase());
             if (typeDef) typeDefStack.push(typeDef);
         }
 

--- a/src/core/scenegraph/index.ts
+++ b/src/core/scenegraph/index.ts
@@ -206,8 +206,6 @@ export async function getInterpreterWithSubEnvs(
     const lexerParserFn = getLexerParserFn(fs, manifest, options);
     let entryPoint = options.entryPoint ?? false;
 
-    interpreter.environment.nodeDefMap = componentMap;
-
     let componentScopeResolver = new ComponentScopeResolver(componentMap, lexerParserFn);
     await pSettle(
         Array.from(componentMap).map(async (componentKV) => {


### PR DESCRIPTION
Also changed:

- Removed dependency of `Interpreter` in `roSGScreen` constructor 
- Added `Interpreter` as parameter of the `roMessagePort` registered callback
