### PR TITLE
Fix key handling on extended nodes

### DIFF
--- a/src/core/brsTypes/nodes/ArrayGrid.ts
+++ b/src/core/brsTypes/nodes/ArrayGrid.ts
@@ -366,11 +366,14 @@ export class ArrayGrid extends Group {
     }
 
     protected refreshContent() {
-        const content = this.getFieldValue("content") as ContentNode;
         const numCols = (this.getFieldValueJS("numColumns") as number) || 1;
-        const sections = content.getNodeChildren();
         this.content.length = 0;
         this.metadata.length = 0;
+        const content = this.getFieldValue("content");
+        if (!(content instanceof ContentNode)) {
+            return;
+        }
+        const sections = content.getNodeChildren();
         let itemIndex = 0;
         for (const section of sections) {
             if (section.getFieldValueJS("ContentType")?.toLowerCase() === "section") {

--- a/src/core/brsTypes/nodes/ArrayGrid.ts
+++ b/src/core/brsTypes/nodes/ArrayGrid.ts
@@ -377,35 +377,40 @@ export class ArrayGrid extends Group {
         let itemIndex = 0;
         for (const section of sections) {
             if (section.getFieldValueJS("ContentType")?.toLowerCase() === "section") {
-                const content = section.getNodeChildren();
-                if (content.length === 0) {
-                    continue;
-                }
-                content.forEach((_item, index) => {
-                    const metadata = { index: itemIndex, divider: false, sectionTitle: "" };
-                    if (index === 0) {
-                        metadata.divider = true;
-                        metadata.sectionTitle = section.getFieldValueJS("title") ?? "";
-                    }
-                    this.metadata.push(metadata);
-                    itemIndex++;
-                });
-                this.content.push(...content);
-                // check if the items count is multiple of numCols, otherwise fill with empty nodes
-                const remainder = content.length % numCols;
-                if (remainder > 0) {
-                    const emptyContent = new ContentNode("_placeholder_");
-                    const emptyMetadata = { index: -1, divider: false, sectionTitle: "" };
-                    for (let i = 0; i < numCols - remainder; i++) {
-                        this.content.push(emptyContent);
-                        this.metadata.push(emptyMetadata);
-                    }
-                }
+                itemIndex = this.processSection(section, itemIndex, numCols);
             }
         }
         if (this.content.length === 0 && sections.length > 0) {
             this.content.push(...sections);
         }
+    }
+
+    private processSection(section: RoSGNode, itemIndex: number, numCols: number) {
+        const content = section.getNodeChildren();
+        if (content.length === 0) {
+            return itemIndex;
+        }
+        content.forEach((_item, index) => {
+            const metadata = { index: itemIndex, divider: false, sectionTitle: "" };
+            if (index === 0) {
+                metadata.divider = true;
+                metadata.sectionTitle = section.getFieldValueJS("title") ?? "";
+            }
+            this.metadata.push(metadata);
+            itemIndex++;
+        });
+        this.content.push(...content);
+        // check if the items count is multiple of numCols, otherwise fill with empty nodes
+        const remainder = content.length % numCols;
+        if (remainder > 0) {
+            const emptyContent = new ContentNode("_placeholder_");
+            const emptyMetadata = { index: -1, divider: false, sectionTitle: "" };
+            for (let i = 0; i < numCols - remainder; i++) {
+                this.content.push(emptyContent);
+                this.metadata.push(emptyMetadata);
+            }
+        }
+        return itemIndex;
     }
 
     protected createItemComponent(interpreter: Interpreter, itemRect: Rect, content: ContentNode) {

--- a/src/core/brsTypes/nodes/CheckList.ts
+++ b/src/core/brsTypes/nodes/CheckList.ts
@@ -146,5 +146,5 @@ export class CheckList extends LabelList {
         const result = brsValueOf(states);
         this.setFieldValue("checkedState", result);
         return result;
-}
+    }
 }

--- a/src/core/brsTypes/nodes/CheckList.ts
+++ b/src/core/brsTypes/nodes/CheckList.ts
@@ -134,15 +134,17 @@ export class CheckList extends LabelList {
         if (checkedState instanceof RoArray) {
             states = jsValueOf(checkedState);
         }
-        const content = this.getFieldValue("content") as ContentNode;
-        const contentCount = content.getNodeChildren().length;
-        if (states.length < contentCount) {
-            states.length = contentCount;
-        } else if (states.length > contentCount) {
-            states.splice(contentCount);
+        const content = this.getFieldValue("content");
+        if (content instanceof ContentNode) {
+            const contentCount = content.getNodeChildren().length;
+            if (states.length < contentCount) {
+                states.length = contentCount;
+            } else if (states.length > contentCount) {
+                states.splice(contentCount);
+            }
         }
         const result = brsValueOf(states);
         this.setFieldValue("checkedState", result);
         return result;
-    }
+}
 }

--- a/src/core/brsTypes/nodes/Scene.ts
+++ b/src/core/brsTypes/nodes/Scene.ts
@@ -194,6 +194,10 @@ export class Scene extends Group {
             }
             return BrsBoolean.False;
         }, nodeEnv);
-        return handled instanceof BrsBoolean && handled.toBoolean();
+        const keyHandled = handled instanceof BrsBoolean && handled.toBoolean();
+        if (!keyHandled && hostNode instanceof Group) {
+            return hostNode.handleKey(key.value, press.toBoolean());
+        }
+        return keyHandled;
     }
 }


### PR DESCRIPTION
When the native node had default key handling (e.g. `LabelList`) the engine was not calling the key handler method when the node was extended in BrightScript.