### PR TITLE
Added support for default sound effect volume level

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -23,7 +23,7 @@ const deviceInfo = {
   customFeatures: [], // String array with custom features (see below)
   localIps: ["eth1,127.0.0.1"], // In a Browser isn't possible to get a real IP, populate it on NodeJS or Electron
   startTime: Date.now(),
-  audioVolume: 40,
+  audioVolume: 50, // Defines the default volume level for system sounds - valid: (0-100)
   maxFps: 60,
   corsProxy: "https://your-cors-proxy-instance.yourdomain.com/", // (optional) Add your CORS-Anywhere URL here
 };

--- a/src/core/brsTypes/components/RoAudioResource.ts
+++ b/src/core/brsTypes/components/RoAudioResource.ts
@@ -69,10 +69,14 @@ export class RoAudioResource extends BrsComponent implements BrsValue {
             returns: ValueKind.Void,
         },
         impl: (_: Interpreter, volume: Int32, index: Int32) => {
-            // TODO: Check behavior when index > maxSimulStreams
-            postMessage(`audio,trigger,${this.audioName},${volume.toString()},${index.toString()}`);
-            this.currentIndex = index.getValue();
-            this.playing = true;
+            const stream = index.getValue();
+            if (stream >= 0 && stream < this.maxStreams) {
+                const sysIndex = DefaultSounds.findIndex((wav) => wav === this.audioName.toLowerCase());
+                const playVolume = sysIndex > -1 ? BrsDevice.deviceInfo.audioVolume : volume.getValue();
+                postMessage(`audio,trigger,${this.audioName},${playVolume},${stream}`);
+                this.currentIndex = stream;
+                this.playing = true;
+            }
             return BrsInvalid.Instance;
         },
     });

--- a/src/core/common.ts
+++ b/src/core/common.ts
@@ -80,7 +80,7 @@ export const defaultDeviceInfo: DeviceInfo = {
     },
     localIps: ["eth1,127.0.0.1"], // In a Browser is not possible to get a real IP, populate it on NodeJS or Electron.
     startTime: Date.now(),
-    audioVolume: 40,
+    audioVolume: 50, // Defines the default volume level for system sounds - valid: (0-100)
     registry: new Map(),
     maxFps: 60,
     platform: platform,

--- a/test/brsTypes/components/RoDeviceInfo.test.js
+++ b/test/brsTypes/components/RoDeviceInfo.test.js
@@ -575,7 +575,7 @@ describe("RoDeviceInfo", () => {
                 let method = deviceInfo.getMethod("getSoundEffectsVolume");
 
                 expect(method).toBeTruthy();
-                expect(method.call(interpreter)).toEqual(new Int32(40));
+                expect(method.call(interpreter)).toEqual(new Int32(50));
             });
         });
         describe("isAudioGuideEnabled", () => {

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -501,7 +501,7 @@ describe("end to end brightscript functions", () => {
             "Stereo",
             " 0",
             "true",
-            " 40",
+            " 50",
             "false",
             "false",
             "false",


### PR DESCRIPTION
The `roAudioResource` documentation states that:

> system sound effects are played at the volume selected in the user's settings, or not played at all if the user has turned sound effects off, regardless of the volume value passed to Trigger.