### PR TITLE
Implemented support for flag to disable string escape of Unicode characters

### DIFF
--- a/src/core/stdlib/Json.ts
+++ b/src/core/stdlib/Json.ts
@@ -31,7 +31,7 @@ function jsonOf(x: BrsType, flags: number = 0, key: string = ""): string {
         case ValueKind.Invalid:
             return "null";
         case ValueKind.String:
-            return `"${x.toString()}"`;
+            return jsonString(x.toString(), (flags & 1) === 0);
         case ValueKind.Boolean:
         case ValueKind.Double:
         case ValueKind.Float:
@@ -83,6 +83,15 @@ function jsonOf(x: BrsType, flags: number = 0, key: string = ""): string {
         errMessage = `${key}: ${errMessage}`;
     }
     throw new Error(errMessage);
+}
+
+function jsonString(x: string, escape: boolean): string {
+    if (escape) {
+        return `"${x.replace(/[\u007F-\uFFFF]/g, (char) => {
+            return `\\u${char.charCodeAt(0).toString(16).padStart(4, "0").toUpperCase()}`;
+        })}"`;
+    }
+    return `"${x}"`;
 }
 
 function logBrsErr(interpreter: Interpreter, functionName: string, err: Error): void {

--- a/test/e2e/StdLib.test.js
+++ b/test/e2e/StdLib.test.js
@@ -137,6 +137,8 @@ describe("end to end standard libary", () => {
             "",
             `{"ar":[1,2,3],"di":null,"nx":123,"sa":"abc"}`,
             `{"ar":[1,2,3],"di":"<roDeviceInfo>","nx":123,"sa":"abc"}`,
+            `"\\u20AC"`,
+            `"€"`,
             " 123",
             "ABC",
             ["<Component: roAssociativeArray> =", "{", "    X: 456", "}"].join("\n"),

--- a/test/e2e/resources/stdlib/json.brs
+++ b/test/e2e/resources/stdlib/json.brs
@@ -17,6 +17,7 @@ sub main()
         float: pi,
         boolean: false
     }))
+    ' Test parseJson with invalid input
     a = {
         nx: 123
         sa: "abc"
@@ -24,12 +25,16 @@ sub main()
         ar: [1, 2, 3]
     }
     print formatJson(a)
-    print formatJson(a, 257)
-    print formatJson(a, 513)
-    ' Test case sensitivity
-    print ParseJSON("123")
-	print ParseJSON("""ABC""")
+    print formatJson(a, &h0100)
+    print formatJson(a, &h0200)
+    ' Test UNICODE conversion on FormatJson
+	euroStr = Chr(&h20AC)
+	? FormatJSON(euroStr)
+	? FormatJSON(euroStr, &h0001)
+    ' Test case sensitivity on ParseJSON
+    print parseJSON("123")
+	print parseJSON("""ABC""")
 	json = "{""x"": 123, ""X"": 456}"
-    print ParseJSON(json, "i")
-	print ParseJSON("{""root"": " + json + "}").root
+    print parseJSON(json, "i")
+	print parseJSON("{""root"": " + json + "}").root
 end sub

--- a/test/e2e/resources/stdlib/json.brs
+++ b/test/e2e/resources/stdlib/json.brs
@@ -28,13 +28,13 @@ sub main()
     print formatJson(a, &h0100)
     print formatJson(a, &h0200)
     ' Test UNICODE conversion on FormatJson
-	euroStr = Chr(&h20AC)
-	? FormatJSON(euroStr)
-	? FormatJSON(euroStr, &h0001)
+    euroStr = Chr(&h20AC)
+    ? FormatJSON(euroStr)
+    ? FormatJSON(euroStr, &h0001)
     ' Test case sensitivity on ParseJSON
     print parseJSON("123")
-	print parseJSON("""ABC""")
-	json = "{""x"": 123, ""X"": 456}"
+    print parseJSON("""ABC""")
+    json = "{""x"": 123, ""X"": 456}"
     print parseJSON(json, "i")
-	print parseJSON("{""root"": " + json + "}").root
+    print parseJSON("{""root"": " + json + "}").root
 end sub


### PR DESCRIPTION
By default `FormatJSON` was supposed to escape non-ASCII characters in JSON Unicode escape format with `\u` prefix.
This PR implements this change and support to the flag `&h0001` to disable the escape behavior.