### PR TITLE
Support extended Unicode in `chr()` and `asc()`

### DIFF
--- a/src/core/stdlib/String.ts
+++ b/src/core/stdlib/String.ts
@@ -33,7 +33,7 @@ export const Asc = new Callable("Asc", {
         if (str.value.length === 0) {
             return new Int32(0); // Return 0 for empty strings
         }
-        return new Int32(str.value.codePointAt(0) || 0); // Use codePointAt for full Unicode support
+        return new Int32(str.value.codePointAt(0) ?? 0); // Use codePointAt for full Unicode support
     },
 });
 

--- a/src/core/stdlib/String.ts
+++ b/src/core/stdlib/String.ts
@@ -27,9 +27,14 @@ export const LCase = new Callable("LCase", {
 export const Asc = new Callable("Asc", {
     signature: {
         args: [new StdlibArgument("letter", ValueKind.String)],
-        returns: ValueKind.String,
+        returns: ValueKind.Int32,
     },
-    impl: (_: Interpreter, str: BrsString) => new Int32(str.value.charCodeAt(0) || 0),
+    impl: (_: Interpreter, str: BrsString) => {
+        if (str.value.length === 0) {
+            return new Int32(0); // Return 0 for empty strings
+        }
+        return new Int32(str.value.codePointAt(0) || 0); // Use codePointAt for full Unicode support
+    },
 });
 
 /**
@@ -45,8 +50,8 @@ export const Chr = new Callable("Chr", {
     },
     impl: (_: Interpreter, ch: Int32) => {
         const num = ch.getValue();
-        if (num <= 0) return new BrsString("");
-        else return new BrsString(String.fromCharCode(num));
+        const chr = num <= 0 || num > 0x10ffff ? "" : String.fromCodePoint(num);
+        return new BrsString(chr);
     },
 });
 

--- a/test/e2e/StdLib.test.js
+++ b/test/e2e/StdLib.test.js
@@ -44,6 +44,8 @@ describe("end to end standard libary", () => {
             "mixed case",
             " 12359",
             "ぇ",
+            " 128516",
+            "😄",
             "Mixed",
             "Case",
             "",

--- a/test/e2e/resources/stdlib/strings.brs
+++ b/test/e2e/resources/stdlib/strings.brs
@@ -7,6 +7,8 @@ sub main()
 
     print Asc("ぇ")
     print Chr(12359) ' UTF-16 decimal for "ぇ"
+    print Asc("😄")
+    print chr(128516)
 
     print Left(mixedCase, 5)
     print Right(mixedCase, 4) ' "Case"


### PR DESCRIPTION
This PR fix #540 