### PR TITLE
Use CORS proxy (if configured) by default

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -31,7 +31,6 @@ const deviceInfo = {
 
 ### CORS Proxy Configuration
 
-* Make sure it has the trailing slash
 * See `App Manifest` below to enable CORS proxy for your app
 * CORS-Anywhere repository: <https://github.com/Rob--W/cors-anywhere>
 
@@ -77,7 +76,7 @@ For example, if you want to define that your application is running on a device 
 There is also a way BrightScript apps can change the behavior of the simulation engine, by using special `manifest` entries. The valid options are:
 
 * `multi_key_events=1`: If this flag is defined, will inform the simulator to handle multiple key events in parallel, instead of the default Roku behavior, that is handling one key at a time.
-* `cors_proxy=1`: If this flag is defined, the engine will prepend to the network requests, the `corsProxy` URL configured in the `DeviceInfo` object.
+* `cors_proxy=0`: If this flag is defined with `zero`, the engine will disable the `corsProxy` URL for the app, if configured in the `DeviceInfo` object.
 
 **Note:** these special `manifest` entries are ignored by Roku Devices.
 

--- a/src/core/device/BrsDevice.ts
+++ b/src/core/device/BrsDevice.ts
@@ -14,7 +14,7 @@ export class BrsDevice {
     static sharedArray: Int32Array = new Int32Array(0);
     static displayEnabled: boolean = true;
     static singleKeyEvents: boolean = true; // Default Roku behavior is `true`
-    static useCORSProxy: boolean = false;
+    static useCORSProxy: boolean = true; // If CORS proxy is configured, use it by default
     static lastRemote: number = 0;
     static lastKeyTime: number = Date.now();
     static currKeyTime: number = Date.now();
@@ -47,6 +47,13 @@ export class BrsDevice {
                 if (key === "developerId") {
                     // Prevent developerId from having "." to avoid issues on registry persistence
                     value = value.replace(".", ":");
+                } else if (key === "corsProxy") {
+                    // make sure the CORS proxy is valid URL and ends with "/"
+                    if (value.length > 0 && !value.startsWith("http")) {
+                        value = "";
+                    } else if (value.length > 0 && !value.endsWith("/")) {
+                        value += "/";
+                    }
                 }
                 this.deviceInfo[key] = value;
             }
@@ -58,10 +65,8 @@ export class BrsDevice {
      * @returns the URL or empty string
      */
     static getCORSProxy() {
-        if (this.useCORSProxy) {
-            return this.deviceInfo.corsProxy ?? "";
-        }
-        return "";
+        const corsProxy = this.deviceInfo.corsProxy ?? "";
+        return this.useCORSProxy ? corsProxy : "";
     }
 
     /**

--- a/src/core/interpreter/index.ts
+++ b/src/core/interpreter/index.ts
@@ -153,7 +153,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
     public setManifest(manifest: Map<string, string>) {
         // Reset custom manifest flags to default
         BrsDevice.singleKeyEvents = true;
-        BrsDevice.useCORSProxy = false;
+        BrsDevice.useCORSProxy = true;
         // Load manifest entries
         manifest.forEach((value: string, key: string) => {
             this.manifest.set(key, value);
@@ -161,7 +161,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
             if (key.toLowerCase() === "multi_key_events") {
                 BrsDevice.singleKeyEvents = value.trim() !== "1";
             } else if (key.toLowerCase() === "cors_proxy") {
-                BrsDevice.useCORSProxy = value.trim() === "1";
+                BrsDevice.useCORSProxy = value.trim() !== "0";
             }
         });
     }


### PR DESCRIPTION
Reverted the custom manifest flag `cors_proxy` to be enabled by default, this way Roku samples and other apps would run without modifications when the `brs-engine` is configured with CORS proxy URL.