### PR TITLE
Implemented `ifStringOps.Arg()` new method

### DIFF
--- a/test/brsTypes/components/RoString.test.js
+++ b/test/brsTypes/components/RoString.test.js
@@ -77,6 +77,82 @@ describe("RoString", () => {
             interpreter = new Interpreter();
         });
 
+        describe("arg", () => {
+            let s, argMethod;
+
+            beforeEach(() => {
+                s = new RoString(new BrsString("Hello %1, you have %2 new messages and %3 notifications!"));
+                argMethod = s.getMethod("arg");
+                expect(argMethod).toBeInstanceOf(Callable);
+            });
+
+            it("replaces all %n placeholders with corresponding arguments", () => {
+                const result = argMethod.call(
+                    interpreter,
+                    new BrsString("Alice"),
+                    new BrsString("5"),
+                    new BrsString("2")
+                );
+                expect(result).toEqual(new BrsString("Hello Alice, you have 5 new messages and 2 notifications!"));
+            });
+
+            it("leaves unmatched placeholders unchanged if not enough arguments", () => {
+                const result = argMethod.call(interpreter, new BrsString("Bob"));
+                expect(result).toEqual(new BrsString("Hello Bob, you have %2 new messages and %3 notifications!"));
+            });
+
+            it("handles repeated placeholders", () => {
+                let s2 = new RoString(new BrsString("%1-%1-%2-%2"));
+                let argMethod2 = s2.getMethod("arg");
+                const result = argMethod2.call(interpreter, new BrsString("A"), new BrsString("B"));
+                expect(result).toEqual(new BrsString("A-A-B-B"));
+            });
+
+            it("handles placeholders out of order", () => {
+                let s3 = new RoString(new BrsString("%3 %1 %2"));
+                let argMethod3 = s3.getMethod("arg");
+                const result = argMethod3.call(interpreter, new BrsString("X"), new BrsString("Y"), new BrsString("Z"));
+                expect(result).toEqual(new BrsString("Z X Y"));
+            });
+
+            it("replace placeholders above %6", () => {
+                let s4 = new RoString(new BrsString("%7 %1 %6"));
+                let argMethod4 = s4.getMethod("arg");
+                const result = argMethod4.call(
+                    interpreter,
+                    new BrsString("A"),
+                    new BrsString("B"),
+                    new BrsString("C"),
+                    new BrsString("D"),
+                    new BrsString("E"),
+                    new BrsString("F")
+                );
+                expect(result).toEqual(new BrsString("C A B"));
+            });
+
+            it("does not replace placeholder %0", () => {
+                let s4 = new RoString(new BrsString("%0 %1 %2"));
+                let argMethod4 = s4.getMethod("arg");
+                const result = argMethod4.call(
+                    interpreter,
+                    new BrsString("A"),
+                    new BrsString("B"),
+                    new BrsString("C"),
+                    new BrsString("D"),
+                    new BrsString("E"),
+                    new BrsString("F")
+                );
+                expect(result).toEqual(new BrsString("%0 A B"));
+            });
+
+            it("does not replace if no placeholders", () => {
+                let s5 = new RoString(new BrsString("No placeholders here"));
+                let argMethod5 = s5.getMethod("arg");
+                const result = argMethod5.call(interpreter, new BrsString("A"));
+                expect(result).toEqual(new BrsString("No placeholders here"));
+            });
+        });
+
         describe("appendString", () => {
             let s, appendString;
 

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -339,7 +339,9 @@ describe("end to end brightscript functions", () => {
             "true", // startsWith no position
             "true", // startsWith with position
             "true", // endsWith no position
-            "true", // endsWith with position
+            "true", // endsWith with position,
+            "%0 %9 %8 %7 %6 %5 d c b a",
+            "%0 a b c d e f %7 %8 %9",
         ]);
     });
 

--- a/test/e2e/TypeChecking.test.js
+++ b/test/e2e/TypeChecking.test.js
@@ -18,13 +18,13 @@ describe("function argument type checking", () => {
     it("errors when too few args are passed", async () => {
         await execute([resourceFile("type-checking", "too-few-args.brs")], outputStreams);
         const output = allArgs(outputStreams.stderr.write);
-        expect(output[0]).toMatch(/UCase requires at least 1 arguments, but received 0\./);
+        expect(output[0]).toMatch(/UCase requires at least 1 argument\(s\), but received 0\./);
     });
 
     it("errors when too many args are passed", async () => {
         await execute([resourceFile("type-checking", "too-many-args.brs")], outputStreams);
         const output = allArgs(outputStreams.stderr.write);
-        expect(output[0] ?? "").toMatch(/RebootSystem accepts at most 0 arguments, but received 1\./);
+        expect(output[0] ?? "").toMatch(/RebootSystem accepts at most 0 argument\(s\), but received 1\./);
     });
 
     it("errors when mismatched types are provided as arguments", async () => {

--- a/test/e2e/resources/components/roString.brs
+++ b/test/e2e/resources/components/roString.brs
@@ -37,4 +37,8 @@ sub main()
     print "1234567890".endsWith("890") ' => true
     print "1234567890".startsWith("567", 4) ' => true
     print "1234567890".endsWith("567", 7) ' => true
+
+    ' arg method
+    ? "%0 %9 %8 %7 %6 %5 %4 %3 %2 %1".arg("a", "b", "c", "d") ' => "%0 %9 %8 %7 %6 %5 d c b a"
+    ? "%0 %1 %2 %3 %4 %5 %6 %7 %8 %9".arg("a", "b", "c", "d", "e", "f") ' => "%0 a b c d e f %7 %8 %9"
 end sub

--- a/test/interpreter/Call.test.js
+++ b/test/interpreter/Call.test.js
@@ -135,11 +135,11 @@ describe("interpreter calls", () => {
             new Expr.Call(
                 new Expr.Variable(identifier("UCase")),
                 token(Lexeme.RightParen, ")"),
-                [] // no arugments
+                [] // no arguments
             )
         );
 
-        expect(() => interpreter.exec([call])).toThrow(/UCase.*arguments/);
+        expect(() => interpreter.exec([call])).toThrow(/UCase.*argument/);
     });
 
     it("errors when too many arguments are provided", () => {
@@ -150,7 +150,7 @@ describe("interpreter calls", () => {
             ])
         );
 
-        expect(() => interpreter.exec([call])).toThrow(/UCase.*arguments/);
+        expect(() => interpreter.exec([call])).toThrow(/UCase.*argument/);
     });
 
     it("errors when argument types are incorrect", () => {


### PR DESCRIPTION
Documentation is [here](https://developer.roku.com/en-gb/docs/references/brightscript/language/global-string-functions.md#argarg1-as-string-arg2-as-string-arg3-as-stringstr-as-string--arg1-as-string--) but has incomplete data and wrong example. 

The actual implementation was based on discussions on Roku Community Slack and testing on device.