### PR TITLE
Removed redundant `platform` reference

### DIFF
--- a/src/core/brsTypes/components/RoDeviceInfo.ts
+++ b/src/core/brsTypes/components/RoDeviceInfo.ts
@@ -6,7 +6,7 @@ import { Interpreter } from "../../interpreter";
 import { RoDeviceInfoEvent } from "../events/RoDeviceInfoEvent";
 import { RoAssociativeArray } from "./RoAssociativeArray";
 import { RoArray } from "./RoArray";
-import { ConnectionInfo, getRokuOSVersion, isPlatform } from "../../common";
+import { ConnectionInfo, getRokuOSVersion, platform } from "../../common";
 import { IfSetMessagePort, IfGetMessagePort } from "../interfaces/IfMessagePort";
 import { getExternalIp } from "../../interpreter/Network";
 import { v4 as uuidv4 } from "uuid";
@@ -612,12 +612,9 @@ export class RoDeviceInfo extends BrsComponent implements BrsValue {
             if (custom instanceof Array && custom.length > 0) {
                 features.push(...custom);
             }
-            const platform = BrsDevice.deviceInfo.platform;
-            if (isPlatform(platform)) {
-                for (const [key, value] of Object.entries(platform)) {
-                    if (value) {
-                        features.push(`platform_${key.slice(2).toLowerCase()}`);
-                    }
+            for (const [key, value] of Object.entries(platform)) {
+                if (value) {
+                    features.push(`platform_${key.slice(2).toLowerCase()}`);
                 }
             }
             return BrsBoolean.from(features.includes(feature.value.toLowerCase()));

--- a/src/core/common.ts
+++ b/src/core/common.ts
@@ -44,7 +44,6 @@ export interface DeviceInfo {
     appList?: AppData[];
     entryPoint?: boolean;
     stopOnCrash?: boolean;
-    platform?: Platform;
     corsProxy?: string;
 }
 
@@ -81,7 +80,6 @@ export const defaultDeviceInfo: DeviceInfo = {
     audioVolume: 50, // Defines the default volume level for system sounds - valid: (0-100)
     registry: new Map(),
     maxFps: 60,
-    platform: platform,
 };
 
 /* Execution Payload Interface
@@ -243,24 +241,6 @@ export type Platform = {
     inLinux: boolean;
     inChromeOS: boolean;
 };
-
-// Function to check if a value is a Platform object
-export function isPlatform(value: any): value is Platform {
-    return (
-        value &&
-        typeof value.inBrowser === "boolean" &&
-        typeof value.inChromium === "boolean" &&
-        typeof value.inFirefox === "boolean" &&
-        typeof value.inSafari === "boolean" &&
-        typeof value.inElectron === "boolean" &&
-        typeof value.inAndroid === "boolean" &&
-        typeof value.inIOS === "boolean" &&
-        typeof value.inMacOS === "boolean" &&
-        typeof value.inWindows === "boolean" &&
-        typeof value.inLinux === "boolean" &&
-        typeof value.inChromeOS === "boolean"
-    );
-}
 
 /* Connection Information Interface
  *


### PR DESCRIPTION
No need to have a reference to `platform` in DeviceInfo as `common` is accessible everywhere.