### PR TITLE
Refactored `video` media tracks handling

### DIFF
--- a/src/core/brsTypes/components/RoVideoPlayer.ts
+++ b/src/core/brsTypes/components/RoVideoPlayer.ts
@@ -13,7 +13,7 @@ import {
 import { Callable, StdlibArgument } from "../Callable";
 import { Interpreter } from "../../interpreter";
 import { Int32 } from "../Int32";
-import { BufferType, DataType, isAudioTrack, MediaEvent } from "../../common";
+import { BufferType, DataType, isMediaTrack, MediaEvent } from "../../common";
 import { BrsHttpAgent, IfHttpAgent } from "../interfaces/IfHttpAgent";
 import { IfSetMessagePort, IfGetMessagePort } from "../interfaces/IfMessagePort";
 import { BrsDevice } from "../../device/BrsDevice";
@@ -138,10 +138,10 @@ export class RoVideoPlayer extends BrsComponent implements BrsValue, BrsHttpAgen
             Atomics.store(BrsDevice.sharedArray, DataType.VSE, -1);
         }
         const bufferFlag = Atomics.load(BrsDevice.sharedArray, DataType.BUF);
-        if (bufferFlag === BufferType.AUDIO_TRACKS) {
+        if (bufferFlag === BufferType.MEDIA_TRACKS) {
             const strTracks = BrsDevice.readDataBuffer();
             try {
-                this.audioTracks = JSON.parse(strTracks);
+                this.audioTracks = JSON.parse(strTracks)?.audio ?? [];
             } catch (e) {
                 this.audioTracks = [];
             }
@@ -433,9 +433,9 @@ export class RoVideoPlayer extends BrsComponent implements BrsValue, BrsHttpAgen
             const result: BrsType[] = [];
             if (this.audioTracks.length) {
                 this.audioTracks.forEach((track) => {
-                    if (isAudioTrack(track)) {
+                    if (isMediaTrack(track)) {
                         const item = {
-                            Track: track.id.toString(),
+                            Track: track.id,
                             Language: track.lang,
                             Name: track.name,
                         };

--- a/src/core/common.ts
+++ b/src/core/common.ts
@@ -59,7 +59,7 @@ export const defaultDeviceInfo: DeviceInfo = {
     countryCode: "US", // App Store Country
     timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     locale: "en_US", // Used if app supports localization
-    captionLanguage: "eng",
+    captionLanguage: "en",
     clockFormat: "12h",
     displayMode: "720p",
     captionsMode: "Off",
@@ -270,6 +270,7 @@ export enum DataType {
     VPS, // Video Position
     VDR, // Video Duration
     VAT, // Video Audio Track
+    VTT, // Video Text Track
     SND, // Sound Event
     SDX, // Sound Event Index
     WAV, // Wave Audio
@@ -358,28 +359,28 @@ export enum MediaErrorCode {
     DRM = -6,
 }
 
-// Audio Track Interface
-export interface AudioTrack {
-    id: number;
+// Media Track Interface
+export interface MediaTrack {
+    id: string;
     name: string;
     lang: string;
-    codec: string;
+    codec?: string;
 }
 
-export function isAudioTrack(value: any): value is AudioTrack {
+export function isMediaTrack(value: any): value is MediaTrack {
     return (
         value &&
-        typeof value.id === "number" &&
+        typeof value.id === "string" &&
         typeof value.name === "string" &&
         typeof value.lang === "string" &&
-        typeof value.codec === "string"
+        (typeof value.codec === "string" || value.codec === undefined)
     );
 }
 
 // Buffer Data Types enumerator
 export enum BufferType {
     DEBUG_EXPR,
-    AUDIO_TRACKS,
+    MEDIA_TRACKS,
     SYS_LOG,
     INPUT,
 }

--- a/test/brsTypes/components/RoDeviceInfo.test.js
+++ b/test/brsTypes/components/RoDeviceInfo.test.js
@@ -219,7 +219,7 @@ describe("RoDeviceInfo", () => {
                 let method = deviceInfo.getMethod("getPreferredCaptionLanguage");
 
                 expect(method).toBeTruthy();
-                expect(method.call(interpreter)).toEqual(new BrsString("eng"));
+                expect(method.call(interpreter)).toEqual(new BrsString("en"));
             });
         });
         describe("timeSinceLastKeyPress", () => {

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -469,7 +469,7 @@ describe("end to end brightscript functions", () => {
             "en_US",
             "US",
             "US",
-            "eng",
+            "en",
             " 0",
             " 1",
             " 0",


### PR DESCRIPTION
In order to allow both audio and subtitle tracks to be handled by the `SceneGraph` implementation, it was necessary to refactor the Audio tracks feature.