### PR TITLE
Field assignments to convert `string` values and improved `array` parsing

### DIFF
--- a/src/core/brsTypes/components/RoSGNode.ts
+++ b/src/core/brsTypes/components/RoSGNode.ts
@@ -225,7 +225,10 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
         const fieldType = kind ?? FieldKind.fromBrsType(value);
         const alias = this.aliases.get(mapKey);
         let field = this.fields.get(mapKey);
-
+        if (field && field.getType() !== FieldKind.String && isBrsString(value)) {
+            // If the field is not a string, but the value is a string, convert it.
+            value = getBrsValueFromFieldType(field.getType(), value.getValue());
+        }
         if (!field) {
             // RBI does not create a new field if the value isn't valid.
             if (fieldType && alwaysNotify !== undefined) {

--- a/src/core/brsTypes/nodes/Group.ts
+++ b/src/core/brsTypes/nodes/Group.ts
@@ -294,7 +294,7 @@ export class Group extends RoSGNode {
         ellipsis: string = "...",
         index: number = 0
     ) {
-        const drawFont = font.createDrawFont(); // TODO: Cache this font
+        const drawFont = font.createDrawFont();
         let text: string;
         let measured: MeasuredText;
 

--- a/src/core/brsTypes/nodes/Overhang.ts
+++ b/src/core/brsTypes/nodes/Overhang.ts
@@ -15,7 +15,7 @@ import {
 import { Group } from "./Group";
 import { Interpreter } from "../../interpreter";
 import { IfDraw2D } from "../interfaces/IfDraw2D";
-import { BrsDevice } from "../..";
+import { BrsDevice } from "../../device/BrsDevice";
 
 export class Overhang extends Group {
     readonly defaultFields: FieldModel[] = [


### PR DESCRIPTION
Roku SceneGraph nodes accept string values for any field, converting based on the field type, just like the XML files definition. Also added support to convert multi-dimensional arrays, and non-numeric arrays.