### PR TITLE
Fixed `roUtils.deepCopy` to properly copy `boxed` objects

### DIFF
--- a/src/core/brsTypes/Boxing.ts
+++ b/src/core/brsTypes/Boxing.ts
@@ -7,6 +7,7 @@ export interface Boxable {
 
 export interface Unboxable {
     unbox(): BrsType;
+    copy(): BrsType;
 }
 
 export function isBoxable(value: BrsType): value is BrsType & Boxable {
@@ -14,5 +15,5 @@ export function isBoxable(value: BrsType): value is BrsType & Boxable {
 }
 
 export function isUnboxable(value: BrsType): value is BrsType & Unboxable {
-    return "unbox" in value;
+    return "unbox" in value && "copy" in value;
 }

--- a/src/core/brsTypes/components/RoArray.ts
+++ b/src/core/brsTypes/components/RoArray.ts
@@ -4,6 +4,7 @@ import { BrsComponent } from "./BrsComponent";
 import { Callable, StdlibArgument } from "../Callable";
 import { Interpreter } from "../../interpreter";
 import { RoAssociativeArray } from "./RoAssociativeArray";
+import { RoFunction } from "./RoFunction";
 import { BrsArray, IfArray, IfArrayGet, IfArraySet } from "../interfaces/IfArray";
 import { IfEnum } from "../interfaces/IfEnum";
 import { BrsDevice } from "../../device/BrsDevice";
@@ -134,8 +135,10 @@ export class RoArray extends BrsComponent implements BrsValue, BrsArray {
                 if (value instanceof RoArray || value instanceof RoAssociativeArray) {
                     copiedElements.push(value.deepCopy());
                 }
-            } else if (isBoxable(value) || isUnboxable(value)) {
+            } else if (isBoxable(value) && !(value instanceof Callable)) {
                 copiedElements.push(value);
+            } else if (isUnboxable(value) && !(value instanceof RoFunction)) {
+                copiedElements.push(value.copy());
             }
         }
         return new RoArray(copiedElements);

--- a/src/core/brsTypes/components/RoAssociativeArray.ts
+++ b/src/core/brsTypes/components/RoAssociativeArray.ts
@@ -1,6 +1,6 @@
 import { BrsValue, ValueKind, BrsString, BrsBoolean, BrsInvalid } from "../BrsType";
 import { BrsComponent, BrsIterable } from "./BrsComponent";
-import { BrsType, isBoxable, isIterable, isUnboxable } from "..";
+import { BrsType, isBoxable, isIterable, isUnboxable, RoFunction } from "..";
 import { Callable, StdlibArgument } from "../Callable";
 import { Interpreter } from "../../interpreter";
 import { Int32 } from "../Int32";
@@ -88,7 +88,7 @@ export class RoAssociativeArray extends BrsComponent implements BrsValue, BrsIte
             .map((value: BrsType) => value);
     }
 
-    deepCopy(): RoAssociativeArray {
+    deepCopy() {
         const copiedElements: AAMember[] = [];
         for (const [key, value] of this.elements) {
             if (isIterable(value)) {
@@ -97,8 +97,10 @@ export class RoAssociativeArray extends BrsComponent implements BrsValue, BrsIte
                 if (value instanceof RoArray || value instanceof RoAssociativeArray) {
                     copiedElements.push({ name: new BrsString(key), value: value.deepCopy() });
                 }
-            } else if (isBoxable(value) || isUnboxable(value)) {
+            } else if (isBoxable(value) && !(value instanceof Callable)) {
                 copiedElements.push({ name: new BrsString(key), value: value });
+            } else if (isUnboxable(value) && !(value instanceof RoFunction)) {
+                copiedElements.push({ name: new BrsString(key), value: value.copy() });
             }
         }
         return new RoAssociativeArray(copiedElements, this.modeCaseSensitive);

--- a/src/core/brsTypes/components/RoBoolean.ts
+++ b/src/core/brsTypes/components/RoBoolean.ts
@@ -30,6 +30,10 @@ export class RoBoolean extends BrsComponent implements BrsValue, Unboxable {
         return this.intrinsic;
     }
 
+    copy() {
+        return new RoBoolean(this.intrinsic);
+    }
+
     equalTo(other: BrsType): BrsBoolean {
         if (other instanceof RoBoolean) {
             return BrsBoolean.from(other.getValue() === this.getValue());

--- a/src/core/brsTypes/components/RoDouble.ts
+++ b/src/core/brsTypes/components/RoDouble.ts
@@ -28,6 +28,10 @@ export class RoDouble extends BrsComponent implements BrsValue, Unboxable {
         return this.intrinsic;
     }
 
+    copy() {
+        return new RoDouble(this.intrinsic);
+    }
+
     equalTo(other: BrsType): BrsBoolean {
         if (other instanceof RoDouble) {
             return BrsBoolean.from(other.intrinsic.getValue() === this.intrinsic.getValue());

--- a/src/core/brsTypes/components/RoFloat.ts
+++ b/src/core/brsTypes/components/RoFloat.ts
@@ -28,6 +28,10 @@ export class RoFloat extends BrsComponent implements BrsValue, Unboxable {
         return this.intrinsic;
     }
 
+    copy() {
+        return new RoFloat(this.intrinsic);
+    }
+
     equalTo(other: BrsType): BrsBoolean {
         if (other instanceof RoFloat) {
             return BrsBoolean.from(other.intrinsic.getValue() === this.intrinsic.getValue());

--- a/src/core/brsTypes/components/RoFunction.ts
+++ b/src/core/brsTypes/components/RoFunction.ts
@@ -28,6 +28,10 @@ export class RoFunction extends BrsComponent implements BrsValue, Unboxable {
         return this.intrinsic;
     }
 
+    copy() {
+        return new RoFunction(this.intrinsic);
+    }
+
     equalTo(other: BrsType): BrsBoolean {
         return BrsBoolean.False;
     }

--- a/src/core/brsTypes/components/RoInt.ts
+++ b/src/core/brsTypes/components/RoInt.ts
@@ -31,6 +31,10 @@ export class RoInt extends BrsComponent implements BrsValue, Unboxable {
         return this.intrinsic;
     }
 
+    copy() {
+        return new RoInt(this.intrinsic);
+    }
+
     equalTo(other: BrsType): BrsBoolean {
         if (other instanceof RoInt) {
             return BrsBoolean.from(other.intrinsic.getValue() === this.intrinsic.getValue());

--- a/src/core/brsTypes/components/RoInvalid.ts
+++ b/src/core/brsTypes/components/RoInvalid.ts
@@ -25,6 +25,10 @@ export class RoInvalid extends BrsComponent implements BrsValue, Unboxable {
         return this.intrinsic;
     }
 
+    copy() {
+        return new RoInvalid();
+    }
+
     equalTo(other: BrsType): BrsBoolean {
         if (other instanceof BrsInvalid) {
             return BrsBoolean.True;

--- a/src/core/brsTypes/components/RoLongInteger.ts
+++ b/src/core/brsTypes/components/RoLongInteger.ts
@@ -28,6 +28,10 @@ export class RoLongInteger extends BrsComponent implements BrsValue, Unboxable {
         return this.intrinsic;
     }
 
+    copy() {
+        return new RoLongInteger(this.intrinsic);
+    }
+
     equalTo(other: BrsType): BrsBoolean {
         if (other instanceof RoLongInteger) {
             return BrsBoolean.from(other.intrinsic.getValue().low === this.intrinsic.getValue().low);

--- a/src/core/brsTypes/components/RoString.ts
+++ b/src/core/brsTypes/components/RoString.ts
@@ -92,6 +92,10 @@ export class RoString extends BrsComponent implements BrsValue, Comparable, Unbo
         return this.intrinsic;
     }
 
+    copy() {
+        return new RoString(this.intrinsic);
+    }
+
     toString(parent?: BrsType): string {
         return this.intrinsic.toString(parent);
     }

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -748,6 +748,10 @@ describe("end to end brightscript functions", () => {
             "new_aa.d[2].x   y",
             "new_aa.list.count               invalid",
             "new_aa.byteArray.toAsciiString  invalid",
+            "arr[0]:  1      roInt",
+            "arrCopy[0]:  10 roInt",
+            "arr[2]:  30     roInt",
+            "arrCopy[2]:  3  roInt",
         ]);
     });
 });

--- a/test/e2e/resources/components/roUtils.brs
+++ b/test/e2e/resources/components/roUtils.brs
@@ -27,4 +27,13 @@ sub main()
     ? "new_aa.d[2].x", new_aa.d[2].x
     ? "new_aa.list.count", new_aa.list?.count?()
     ? "new_aa.byteArray.toAsciiString", new_aa.byteArray?.toAsciiString?()
+    ' Array of boxed objects test
+    arr = [box(1), box(2), box(3)]
+    arrCopy = utils.deepCopy(arr)
+    arrCopy[0].setInt(10)
+    arr[2].setInt(30)
+    print "arr[0]: "; arr[0], type(arr[0], 3)
+    print "arrCopy[0]: "; arrCopy[0], type(arrCopy[0], 3)
+    print "arr[2]: "; arr[2], type(arr[2], 3)
+    print "arrCopy[2]: "; arrCopy[2], type(arrCopy[2], 3)
 end sub


### PR DESCRIPTION
Added a `copy` method to all `Unboxable` components, so the `deepCopy` utility could properly copy the boxed values.