### PR TITLE
Fixed `roSGNode.get()` and `roSGNode.deepCopy()` to properly handle nested nodes

### DIFF
--- a/src/core/brsTypes/components/BrsComponent.ts
+++ b/src/core/brsTypes/components/BrsComponent.ts
@@ -141,6 +141,7 @@ export interface BrsIterable {
 
     /**
      * Creates a deep copy of this object.
+     * @param interpreter The interpreter instance to use for creating the deep copy (only for RoSGNode).
      * @returns a deep copy of this object.
      */
     deepCopy(interpreter?: Interpreter): BrsType;

--- a/src/core/brsTypes/components/RoSGNode.ts
+++ b/src/core/brsTypes/components/RoSGNode.ts
@@ -224,7 +224,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
 
     deepCopy(interpreter?: Interpreter): BrsType {
         if (!interpreter) {
-            return new RoInvalid();
+            return this;
         }
         const copiedNode = createNodeByType(interpreter, new BrsString(this.nodeSubtype));
         if (!(copiedNode instanceof RoSGNode)) {
@@ -510,7 +510,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
     /* searches the node tree for a node with the given id */
     findNodeById(node: RoSGNode, id: BrsString): RoSGNode | BrsInvalid {
         // test current node in tree
-        let currentId = node.get(new BrsString("id"));
+        let currentId = node.getFieldValue("id");
         if (currentId.toString().toLowerCase() === id.value.toLowerCase()) {
             return node;
         }
@@ -864,7 +864,7 @@ export class RoSGNode extends BrsComponent implements BrsValue, BrsIterable {
             returns: ValueKind.Boolean,
         },
         impl: (_: Interpreter, str: BrsString) => {
-            return this.get(str) !== BrsInvalid.Instance ? BrsBoolean.True : BrsBoolean.False;
+            return BrsBoolean.from(this.fields.has(str.value.toLowerCase()));
         },
     });
 

--- a/src/core/brsTypes/events/RoSGNodeEvent.ts
+++ b/src/core/brsTypes/events/RoSGNodeEvent.ts
@@ -67,7 +67,7 @@ export class RoSGNodeEvent extends BrsComponent implements BrsValue {
             returns: ValueKind.Dynamic,
         },
         impl: (_: Interpreter) => {
-            return this.node.get(new BrsString("id"));
+            return this.node.getFieldValue("id");
         },
     });
 

--- a/src/core/brsTypes/index.ts
+++ b/src/core/brsTypes/index.ts
@@ -394,9 +394,9 @@ export type BrsConvertible = boolean | number | string | BrsType | null | undefi
 export function toAssociativeArray(input: Map<string, any> | FlexObject, cs?: boolean): RoAssociativeArray {
     const associativeArray = new RoAssociativeArray([], cs);
     if (input instanceof Map) {
-        input.forEach((value, key) => {
+        for (const [key, value] of input) {
             associativeArray.set(new BrsString(key), brsValueOf(value, cs), true);
-        });
+        }
     } else if (typeof input === "object" && input !== null) {
         for (const key in input) {
             if (input.hasOwnProperty(key)) {

--- a/src/core/brsTypes/nodes/Field.ts
+++ b/src/core/brsTypes/nodes/Field.ts
@@ -407,7 +407,8 @@ export class Field {
             eventParams.infoFields.elements?.forEach((element) => {
                 if (isBrsString(element)) {
                     // TODO: Check how to handle object values (by reference or by value)
-                    fieldsMap.set(element.getValue(), hostNode.get(element));
+                    const key = element.getValue();
+                    fieldsMap.set(key, hostNode.getFieldValue(key));
                 }
             });
             infoFields = toAssociativeArray(fieldsMap);


### PR DESCRIPTION
When using `deepCopy` from a `get` the interpreter instance is not available, for nested nodes return the current instance.