### PR TITLE
Add width/height fields to Video node and suppress UI when windowed (#926)

### DIFF
--- a/src/extensions/scenegraph/nodes/Video.ts
+++ b/src/extensions/scenegraph/nodes/Video.ts
@@ -41,6 +41,8 @@ import { TrickPlayBar } from "./TrickPlayBar";
 
 export class Video extends Group {
     readonly defaultFields: FieldModel[] = [
+        { name: "width", type: "float", value: "0.0" },
+        { name: "height", type: "float", value: "0.0" },
         { name: "content", type: "node" },
         { name: "playStartInfo", type: "assocarray" },
         { name: "licenseStatus", type: "assocarray" },
@@ -309,7 +311,7 @@ export class Video extends Group {
                 this.showUI(false);
                 this.resetSeeking();
                 this.showHeader = now + 5000;
-                this.spinner.setValueSilent("visible", BrsBoolean.from(this.enableUI));
+                this.spinner.setValueSilent("visible", BrsBoolean.from(this.uiVisible()));
                 this.setBufferingStatus(eventIndex);
                 return;
             case MediaEvent.StartStream:
@@ -528,6 +530,20 @@ export class Video extends Group {
         }
     }
 
+    private isFullscreen(): boolean {
+        const size = this.getDimensions();
+        const width = size.width || this.sceneRect.width;
+        const height = size.height || this.sceneRect.height;
+        const [x, y] = this.getTranslation();
+        return x <= 0 && y <= 0 && width >= this.sceneRect.width && height >= this.sceneRect.height;
+    }
+
+    private uiVisible(): boolean {
+        // On Roku, a windowed (non-fullscreen) Video plane shows no overlay UI; the
+        // control commands still work, there is just no on-screen feedback.
+        return this.enableUI && this.isFullscreen();
+    }
+
     showUI(show: boolean) {
         if (sgRoot.inTaskThread()) return;
         if (!show) {
@@ -556,7 +572,7 @@ export class Video extends Group {
                 if (this.trickPlayPos >= 0) {
                     postMessage(`video,seek,${this.trickPlayPos * 1000}`);
                     this.trickPlayPos = -1;
-                    this.spinner.setValueSilent("visible", BrsBoolean.from(this.enableUI));
+                    this.spinner.setValueSilent("visible", BrsBoolean.from(this.uiVisible()));
                     this.seeking = true;
                     this.showUI(false);
                 } else {
@@ -576,7 +592,7 @@ export class Video extends Group {
             if (this.trickPlayPos >= 0) {
                 postMessage(`video,seek,${this.trickPlayPos * 1000}`);
                 this.trickPlayPos = -1;
-                this.spinner.setValueSilent("visible", BrsBoolean.from(this.enableUI));
+                this.spinner.setValueSilent("visible", BrsBoolean.from(this.uiVisible()));
                 this.showUI(false);
                 this.seeking = true;
                 handled = true;
@@ -704,7 +720,7 @@ export class Video extends Group {
                 const duration = this.getValueJS("duration") as number;
                 this.updateSeekStep(this.seekMode === "ff", duration, Math.trunc(1000 / this.seekLevel));
             }
-            this.showUI(this.enableUI);
+            this.showUI(this.uiVisible());
         }
         this.updateBoundingRects(rect, origin, rotation);
         this.renderChildren(interpreter, drawTrans, rotation, opacity, draw2D);


### PR DESCRIPTION
## Summary

Fixes #926. The SceneGraph `Video` node never registered `width`/`height` fields, so setting them in XML (`<Video width="1472" height="828" .../>`) or BrightScript was silently dropped, reads returned `<invalid>`, and the video plane always rendered fullscreen.

- Register `width`/`height` as `float` fields (default `0.0` = fullscreen), matching `Poster`/`Rectangle`. The existing `renderNode`/`getDimensions` path picks them up with no further changes — a non-zero value now sizes/positions the video plane.
- Match Roku behavior for a windowed (non-fullscreen) plane: overlay UI (header, clock, pause icon, TrickPlayBar, background overlay, buffering/seek spinner) is suppressed, while remote-control commands keep working without on-screen feedback. The UI-display paths are routed through a new `uiVisible()` helper gated on `isFullscreen()`.

## Verification

- `npm run lint` — clean
- `npm run prettier` — clean on the edited file
- `npm run build:sg` — compiles
- `npm test` — 1656 passed / 177 snapshots, no regressions

Manual repro from the issue:
```xml
<Video id="videoPlayer" width="1472" height="828" translation="[0, 126]" enableUI="false" />
```
```brightscript
vp = m.top.findNode("videoPlayer")
print vp.width; "x"; vp.height   ' -> 1472 x 828 (was: invalid x invalid)
```
Video renders within the 1472×828 window at offset [0,126]; omitting `width`/`height` still renders fullscreen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)