### PR TITLE
Add Roku reference docs (dev-doc submodule) and brs-reference skill

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -77,6 +77,12 @@ The Node CLI runs the interpreter on a **single thread**; remote control there r
 - `src/core/brsTypes/` — BrightScript values: primitives (`Int32`, `Float`, `Double`, `BrsString`, `Boolean`), `Callable`, plus `Coercion.ts`/`Boxing.ts` rules.
 - `src/core/brsTypes/components/` — the `roXxx` component objects (`RoArray`, `RoAssociativeArray`, `RoBitmap`, `RoAudioPlayer`, `RoDeviceInfo`, `RoMessagePort`, …); `BrsObjects.ts` is the `CreateObject` registry.
 
+#### Interfaces are method grouping, not separate types
+
+Roku documents a component's methods under `ifXxx` interfaces, but **we do not implement each `ifXxx` as its own type/contract**. A component implements all its methods and registers them via `registerMethods({ ifXxx: [...callables] })`, where the `ifXxx` key is just **metadata grouping** that mirrors the docs. Most methods are defined inline on the component class itself (e.g. `RoArray`'s `join`/`sort`, all of `RoVideoPlayer`'s `ifVideoPlayer` methods).
+
+`src/core/brsTypes/interfaces/` (`IfArray`, `IfEnum`, `IfHttpAgent`, `IfList`, `IfMessagePort`, `IfSocket`, `IfToStr`, `IfDraw2D`, …) holds a **small, deliberate set** of helper classes — effectively abstract/shared method bundles to **reduce duplication** across components that expose the same interface (e.g. `ifHttpAgent` is shared by many `roXxx`). They are instantiated with the owning component (`new IfArray(this)`) and their callables are spread into `registerMethods`. This is **not** a complete mirror of Roku's interface list — only the interfaces worth sharing live here; everything else is inline.
+
 ### Device, filesystem, stdlib, errors
 
 - `src/core/device/BrsDevice.ts` — simulated device state, the shared control array (`BrsDevice.sharedArray`, an `Int32Array`), registry, current `threadId`, stdout/stderr.
@@ -180,7 +186,7 @@ Layout and how it maps to the source tree:
 | Reference path | Documents | Implement / verify in |
 | --- | --- | --- |
 | `brightscript/components/roXxx.md` | `roXxx` component: how it's created, which interfaces/events it supports | `src/core/brsTypes/components/RoXxx.ts` (registered in `BrsObjects.ts`) |
-| `brightscript/interfaces/ifXxx.md` | An interface's method signatures, args, return types, defaults | the methods that component class exposes |
+| `brightscript/interfaces/ifXxx.md` | An interface's method signatures, args, return types, defaults | methods on the component, grouped under the `ifXxx` key in `registerMethods` (see "Interfaces are method grouping" above) — **not** a standalone type |
 | `brightscript/events/roXxxEvent.md` | Event objects returned via `roMessagePort` | the matching event component |
 | `brightscript/language/*.md` | Language spec: statements, expressions/types, error handling, conditional compilation, format strings, reserved words, and the global Math/String/Utility/Runtime functions | `src/core/lexer/`, `src/core/parser/`, `src/core/preprocessor/`, `src/core/stdlib/` |
 | `scenegraph/**/<node>.md` | SceneGraph node fields (name/type/default/access) and behavior, grouped by category (renderable, layout, list-and-grid, dialog, animation, media, …) | `src/extensions/scenegraph/nodes/<Node>.ts` (see "Creating a new Node type") |

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -168,3 +168,23 @@ See `docs/extensions.md` and `packages/scenegraph/README.md` for the consumer-fa
 ## Documentation
 
 `docs/` is the source of truth for usage: `build-from-source.md`, `integrating.md`, `engine-api.md`, `customization.md`, `run-as-cli.md`, `using-node-library.md`, `extensions.md`, `remote-control.md`, `limitations.md`, `contributing.md`.
+
+## Roku reference documentation (`out/references/`)
+
+A local mirror of Roku's official BrightScript + SceneGraph reference lives in `out/references/` (HTML-flavored Markdown). **This is the authoritative spec** for what each component, interface, event, node, and global function should do — consult it whenever implementing, fixing, or verifying a missing/incomplete feature so the simulated behavior matches a real Roku device.
+
+> Note: `out/` is **gitignored**, so this folder is a local-only convenience and is not available to all contributors or CI. Treat it as a research aid, never as a build/runtime dependency.
+
+Layout and how it maps to the source tree:
+
+| Reference path | Documents | Implement / verify in |
+| --- | --- | --- |
+| `brightscript/components/roXxx.md` | `roXxx` component: how it's created, which interfaces/events it supports | `src/core/brsTypes/components/RoXxx.ts` (registered in `BrsObjects.ts`) |
+| `brightscript/interfaces/ifXxx.md` | An interface's method signatures, args, return types, defaults | the methods that component class exposes |
+| `brightscript/events/roXxxEvent.md` | Event objects returned via `roMessagePort` | the matching event component |
+| `brightscript/language/*.md` | Language spec: statements, expressions/types, error handling, conditional compilation, format strings, reserved words, and the global Math/String/Utility/Runtime functions | `src/core/lexer/`, `src/core/parser/`, `src/core/preprocessor/`, `src/core/stdlib/` |
+| `scenegraph/**/<node>.md` | SceneGraph node fields (name/type/default/access) and behavior, grouped by category (renderable, layout, list-and-grid, dialog, animation, media, …) | `src/extensions/scenegraph/nodes/<Node>.ts` (see "Creating a new Node type") |
+| `scenegraph/xml-elements/*.md`, `scenegraph/component-functions/*.md` | Component XML (`<component>`/`<interface>`/`<children>`/`<script>`) and `init`/`onKeyEvent` | `src/extensions/scenegraph/parser/`, `factory/` |
+| `deprecated-apis.md` | APIs Roku has deprecated — check before adding/relying on one | n/a (informational) |
+
+When implementing a node or component, match the documented **field names, types, defaults, and access permissions** exactly (e.g. a node's `defaultFields` should mirror the reference's Fields table). Use the `brs-reference` skill to look things up.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -175,13 +175,13 @@ See `docs/extensions.md` and `packages/scenegraph/README.md` for the consumer-fa
 
 `docs/` is the source of truth for usage: `build-from-source.md`, `integrating.md`, `engine-api.md`, `customization.md`, `run-as-cli.md`, `using-node-library.md`, `extensions.md`, `remote-control.md`, `limitations.md`, `contributing.md`.
 
-## Roku reference documentation (`out/references/`)
+## Roku reference documentation (`external/dev-doc` submodule)
 
-A local mirror of Roku's official BrightScript + SceneGraph reference lives in `out/references/` (HTML-flavored Markdown). **This is the authoritative spec** for what each component, interface, event, node, and global function should do — consult it whenever implementing, fixing, or verifying a missing/incomplete feature so the simulated behavior matches a real Roku device.
+Roku's official, open-sourced developer docs ([rokudev/dev-doc](https://github.com/rokudev/dev-doc), branch `v2.0`) are vendored as a **git submodule** at `external/dev-doc`. The BrightScript + SceneGraph reference lives under **`external/dev-doc/docs/REFERENCES/`** (Markdown with YAML frontmatter). **This is the authoritative spec** for what each component, interface, event, node, and global function should do — consult it whenever implementing, fixing, or verifying a missing/incomplete feature so the simulated behavior matches a real Roku device.
 
-> Note: `out/` is **gitignored**, so this folder is a local-only convenience and is not available to all contributors or CI. Treat it as a research aid, never as a build/runtime dependency.
+> The submodule is pinned to a specific commit and only populated after `git submodule update --init external/dev-doc` (a plain checkout leaves the folder empty). It is **reference only** — never make build/runtime code depend on it. Update it with `git -C external/dev-doc pull origin v2.0`, then commit the new pointer.
 
-Layout and how it maps to the source tree:
+Layout under `external/dev-doc/docs/REFERENCES/` and how it maps to the source tree:
 
 | Reference path | Documents | Implement / verify in |
 | --- | --- | --- |

--- a/.claude/skills/brs-reference/SKILL.md
+++ b/.claude/skills/brs-reference/SKILL.md
@@ -1,19 +1,23 @@
 ---
 name: brs-reference
-description: Look up Roku's official BrightScript/SceneGraph spec in out/references/ when implementing, fixing, or verifying an interpreter feature — components (roXxx), interfaces (ifXxx), events, SceneGraph nodes, global functions, or language behavior. Use it to confirm exact method signatures, node field names/types/defaults/access, and event semantics so simulated behavior matches a real Roku device.
+description: Look up Roku's official BrightScript/SceneGraph spec in the external/dev-doc submodule (docs/REFERENCES/) when implementing, fixing, or verifying an interpreter feature — components (roXxx), interfaces (ifXxx), events, SceneGraph nodes, global functions, or language behavior. Use it to confirm exact method signatures, node field names/types/defaults/access, and event semantics so simulated behavior matches a real Roku device.
 ---
 
 # brs-reference
 
-`out/references/` is a local mirror of Roku's **official** BrightScript + SceneGraph
-reference docs (HTML-flavored Markdown). It is the authoritative spec for *what the
-behavior should be* — the brs-engine code is *how we simulate it*. Reach for this skill
-whenever a task involves a missing, incomplete, or wrong-looking BrightScript/SceneGraph
-feature, and before claiming a feature "matches Roku."
+Roku's **official**, open-sourced BrightScript + SceneGraph reference docs are vendored as
+a git submodule ([rokudev/dev-doc](https://github.com/rokudev/dev-doc), branch `v2.0`) at
+`external/dev-doc`. The reference pages live under **`external/dev-doc/docs/REFERENCES/`**
+(Markdown with YAML frontmatter). They are the authoritative spec for *what the behavior
+should be* — the brs-engine code is *how we simulate it*. Reach for this skill whenever a
+task involves a missing, incomplete, or wrong-looking BrightScript/SceneGraph feature, and
+before claiming a feature "matches Roku."
 
-> `out/` is **gitignored** — this folder is a local convenience, not guaranteed present
-> for every contributor or in CI. Use it for research only; never make build/runtime
-> code depend on it. If the folder is absent, say so and fall back to
+In this skill `$REF` means `external/dev-doc/docs/REFERENCES`.
+
+> The submodule must be initialized: if `$REF` is empty/missing, run
+> `git submodule update --init external/dev-doc`. It is **reference only** — never make
+> build/runtime code depend on it. If it still can't be fetched, say so and fall back to
 > <https://developer.roku.com/docs/references/> (or skip the lookup).
 
 ## When to use
@@ -26,37 +30,42 @@ feature, and before claiming a feature "matches Roku."
 
 ## Where things live (and where to implement them)
 
+All paths below are relative to `$REF` (= `external/dev-doc/docs/REFERENCES`).
+
 | Reference glob | Topic | Source to edit |
 | --- | --- | --- |
-| `out/references/brightscript/components/roXxx.md` | Component overview + supported interfaces/events | `src/core/brsTypes/components/RoXxx.ts` (register in `BrsObjects.ts`) |
-| `out/references/brightscript/interfaces/ifXxx.md` | Method signatures, args, returns, defaults | methods on the component, grouped under the `ifXxx` key in `registerMethods` — **not** a standalone type (see "Interfaces are method grouping" below) |
-| `out/references/brightscript/events/roXxxEvent.md` | Event objects from `roMessagePort` | the matching event component |
-| `out/references/brightscript/language/*.md` | Statements, types, errors, `#if`, format strings, reserved words, global functions | `src/core/lexer/`, `parser/`, `preprocessor/`, `stdlib/` |
-| `out/references/scenegraph/**/<node>.md` | SceneGraph node fields + behavior (by category) | `src/extensions/scenegraph/nodes/<Node>.ts` |
-| `out/references/scenegraph/xml-elements/*.md`, `component-functions/*.md` | Component XML + `init`/`onKeyEvent` | `src/extensions/scenegraph/parser/`, `factory/` |
-| `out/references/deprecated-apis.md` | Deprecated APIs — check before relying on one | n/a |
+| `$REF/brightscript/components/roXxx.md` | Component overview + supported interfaces/events | `src/core/brsTypes/components/RoXxx.ts` (register in `BrsObjects.ts`) |
+| `$REF/brightscript/interfaces/ifXxx.md` | Method signatures, args, returns, defaults | methods on the component, grouped under the `ifXxx` key in `registerMethods` — **not** a standalone type (see "Interfaces are method grouping" below) |
+| `$REF/brightscript/events/roXxxEvent.md` | Event objects from `roMessagePort` | the matching event component |
+| `$REF/brightscript/language/*.md` | Statements, types, errors, `#if`, format strings, reserved words, global functions | `src/core/lexer/`, `parser/`, `preprocessor/`, `stdlib/` |
+| `$REF/scenegraph/**/<node>.md` | SceneGraph node fields + behavior (by category) | `src/extensions/scenegraph/nodes/<Node>.ts` |
+| `$REF/scenegraph/xml-elements/*.md`, `component-functions/*.md` | Component XML + `init`/`onKeyEvent` | `src/extensions/scenegraph/parser/`, `factory/` |
+| `$REF/deprecated-apis.md` | Deprecated APIs — check before relying on one | n/a |
 
 Filenames are lowercase, no spaces (e.g. `rovideoplayer.md`, `ifsgnodefield.md`,
-`renderable-nodes/rectangle.md`). Files are HTML fragments: headings as `<h1..h3>`,
-field/method tables as `<table>`, and code samples inside `<pre><code>`.
+`renderable-nodes/rectangle.md`). Files are Markdown: a YAML frontmatter block
+(`title`, `excerpt`, …) at the top, `##` headings, GitHub-style pipe tables for fields/
+methods, fenced or double-backtick code samples, and cross-links written as
+`[label](doc:slug)` (the slug is the target file's basename without `.md`).
 
 ## How to look up
 
 1. **Find the file.** Map the BrightScript name to a path with the table above. If unsure
    of the category for a SceneGraph node, search by filename:
    ```bash
-   ls out/references/scenegraph/**/ | grep -i <node>
-   find out/references -iname '*<name>*'
+   REF=external/dev-doc/docs/REFERENCES
+   find "$REF/scenegraph" -iname '*<node>*'
+   find "$REF" -iname '*<name>*'
    ```
-2. **Read it.** A component file lists its supported `ifXxx` interfaces — follow those to
-   the `interfaces/` files for the actual method signatures. A node file's **Fields**
-   table (Field / Type / Default / Access Permission / Description) is the spec for the
-   node's fields; note that base-class fields are inherited and documented separately
-   (the file says "Fields derived from the … base class can also be used").
+2. **Read it.** A component file lists its supported `ifXxx` interfaces (as `[ifXxx](doc:ifxxx)`
+   links) — follow those to the `interfaces/` files for the actual method signatures. A node
+   file's **Fields** table (Field / Type / Default / Access Permission / Description) is the
+   spec for the node's fields; note that base-class fields are inherited and documented
+   separately (the file says "Fields derived from the … base class can also be used").
 3. **Grep across the corpus** when you don't know where a method/field is defined:
    ```bash
-   grep -rin "getmessageport" out/references/brightscript/interfaces/
-   grep -rl "itemComponentName" out/references/scenegraph/
+   grep -rin "getmessageport" "$REF/brightscript/interfaces/"
+   grep -rl "itemComponentName" "$REF/scenegraph/"
    ```
 
 ## Applying it to the code

--- a/.claude/skills/brs-reference/SKILL.md
+++ b/.claude/skills/brs-reference/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: brs-reference
+description: Look up Roku's official BrightScript/SceneGraph spec in out/references/ when implementing, fixing, or verifying an interpreter feature — components (roXxx), interfaces (ifXxx), events, SceneGraph nodes, global functions, or language behavior. Use it to confirm exact method signatures, node field names/types/defaults/access, and event semantics so simulated behavior matches a real Roku device.
+---
+
+# brs-reference
+
+`out/references/` is a local mirror of Roku's **official** BrightScript + SceneGraph
+reference docs (HTML-flavored Markdown). It is the authoritative spec for *what the
+behavior should be* — the brs-engine code is *how we simulate it*. Reach for this skill
+whenever a task involves a missing, incomplete, or wrong-looking BrightScript/SceneGraph
+feature, and before claiming a feature "matches Roku."
+
+> `out/` is **gitignored** — this folder is a local convenience, not guaranteed present
+> for every contributor or in CI. Use it for research only; never make build/runtime
+> code depend on it. If the folder is absent, say so and fall back to
+> <https://developer.roku.com/docs/references/> (or skip the lookup).
+
+## When to use
+
+- Implementing or fixing a `roXxx` component / `ifXxx` interface method.
+- Adding or correcting a SceneGraph node (fields, defaults, behavior).
+- Implementing a global function (Math/String/Utility/Runtime) or language feature.
+- Verifying argument counts, types, return values, defaults, or event semantics.
+- Checking whether an API is deprecated.
+
+## Where things live (and where to implement them)
+
+| Reference glob | Topic | Source to edit |
+| --- | --- | --- |
+| `out/references/brightscript/components/roXxx.md` | Component overview + supported interfaces/events | `src/core/brsTypes/components/RoXxx.ts` (register in `BrsObjects.ts`) |
+| `out/references/brightscript/interfaces/ifXxx.md` | Method signatures, args, returns, defaults | the methods on that component |
+| `out/references/brightscript/events/roXxxEvent.md` | Event objects from `roMessagePort` | the matching event component |
+| `out/references/brightscript/language/*.md` | Statements, types, errors, `#if`, format strings, reserved words, global functions | `src/core/lexer/`, `parser/`, `preprocessor/`, `stdlib/` |
+| `out/references/scenegraph/**/<node>.md` | SceneGraph node fields + behavior (by category) | `src/extensions/scenegraph/nodes/<Node>.ts` |
+| `out/references/scenegraph/xml-elements/*.md`, `component-functions/*.md` | Component XML + `init`/`onKeyEvent` | `src/extensions/scenegraph/parser/`, `factory/` |
+| `out/references/deprecated-apis.md` | Deprecated APIs — check before relying on one | n/a |
+
+Filenames are lowercase, no spaces (e.g. `rovideoplayer.md`, `ifsgnodefield.md`,
+`renderable-nodes/rectangle.md`). Files are HTML fragments: headings as `<h1..h3>`,
+field/method tables as `<table>`, and code samples inside `<pre><code>`.
+
+## How to look up
+
+1. **Find the file.** Map the BrightScript name to a path with the table above. If unsure
+   of the category for a SceneGraph node, search by filename:
+   ```bash
+   ls out/references/scenegraph/**/ | grep -i <node>
+   find out/references -iname '*<name>*'
+   ```
+2. **Read it.** A component file lists its supported `ifXxx` interfaces — follow those to
+   the `interfaces/` files for the actual method signatures. A node file's **Fields**
+   table (Field / Type / Default / Access Permission / Description) is the spec for the
+   node's fields; note that base-class fields are inherited and documented separately
+   (the file says "Fields derived from the … base class can also be used").
+3. **Grep across the corpus** when you don't know where a method/field is defined:
+   ```bash
+   grep -rin "getmessageport" out/references/brightscript/interfaces/
+   grep -rl "itemComponentName" out/references/scenegraph/
+   ```
+
+## Applying it to the code
+
+- **Match names/types/defaults/access exactly.** A node's `defaultFields` entries should
+  mirror the reference Fields table (e.g. Rectangle's `width`/`height` are `float`
+  default `0.0`, `color` is `color` default `0xFFFFFFFF`). Field `type` strings and
+  default values in code should equal the doc's Type/Default columns.
+- **Respect inheritance.** If the doc says a node `Extends Group`, the TS class should
+  extend the matching base and `setExtendsType(name, SGNodeType.Group)` — only declare
+  fields the doc adds beyond the base.
+- **Interfaces drive method surfaces.** Implement the methods (with correct arg order,
+  optional args, and return type) listed in the `ifXxx.md` the component supports.
+- **Cross-check before saying "done."** When verifying a fix, re-read the relevant
+  reference and confirm signatures, defaults, and edge cases (and that the API isn't in
+  `deprecated-apis.md`) actually agree with the implementation.
+
+## Wiring reminders (see CLAUDE.md for full detail)
+
+- New component: implement `RoXxx.ts`, register it in
+  `src/core/brsTypes/components/BrsObjects.ts`.
+- New SceneGraph node: add to the `SGNodeType` enum in
+  `src/extensions/scenegraph/nodes/index.ts`, create `nodes/<Node>.ts`, and wire it into
+  `SGNodeFactory.createNode`'s switch in `factory/NodeFactory.ts`.

--- a/.claude/skills/brs-reference/SKILL.md
+++ b/.claude/skills/brs-reference/SKILL.md
@@ -29,7 +29,7 @@ feature, and before claiming a feature "matches Roku."
 | Reference glob | Topic | Source to edit |
 | --- | --- | --- |
 | `out/references/brightscript/components/roXxx.md` | Component overview + supported interfaces/events | `src/core/brsTypes/components/RoXxx.ts` (register in `BrsObjects.ts`) |
-| `out/references/brightscript/interfaces/ifXxx.md` | Method signatures, args, returns, defaults | the methods on that component |
+| `out/references/brightscript/interfaces/ifXxx.md` | Method signatures, args, returns, defaults | methods on the component, grouped under the `ifXxx` key in `registerMethods` — **not** a standalone type (see "Interfaces are method grouping" below) |
 | `out/references/brightscript/events/roXxxEvent.md` | Event objects from `roMessagePort` | the matching event component |
 | `out/references/brightscript/language/*.md` | Statements, types, errors, `#if`, format strings, reserved words, global functions | `src/core/lexer/`, `parser/`, `preprocessor/`, `stdlib/` |
 | `out/references/scenegraph/**/<node>.md` | SceneGraph node fields + behavior (by category) | `src/extensions/scenegraph/nodes/<Node>.ts` |
@@ -68,11 +68,44 @@ field/method tables as `<table>`, and code samples inside `<pre><code>`.
 - **Respect inheritance.** If the doc says a node `Extends Group`, the TS class should
   extend the matching base and `setExtendsType(name, SGNodeType.Group)` — only declare
   fields the doc adds beyond the base.
-- **Interfaces drive method surfaces.** Implement the methods (with correct arg order,
-  optional args, and return type) listed in the `ifXxx.md` the component supports.
+- **Interfaces drive method surfaces, but don't become types.** Use `ifXxx.md` to get the
+  correct method names, arg order, optional args, and return types — then implement those
+  methods on the **component** and register them under the `ifXxx` key in
+  `registerMethods({ ifXxx: [...] })`. Do **not** create a new `ifXxx` class just because
+  the docs list one. See "Interfaces are method grouping" below.
 - **Cross-check before saying "done."** When verifying a fix, re-read the relevant
   reference and confirm signatures, defaults, and edge cases (and that the API isn't in
   `deprecated-apis.md`) actually agree with the implementation.
+
+## Interfaces are method grouping, not separate types
+
+The reference's `ifXxx` files describe Roku's interfaces, but this codebase does **not**
+implement one type per interface. Follow the existing pattern:
+
+- A component implements its methods (mostly **inline** on the class) and registers them
+  with `registerMethods({ ifXxx: [callable, ...] })`. The `ifXxx` key is just a label that
+  mirrors the docs — there is no `ifXxx` contract being satisfied.
+  ```ts
+  // RoVideoPlayer.ts — methods defined inline, grouped under interface-name keys
+  this.registerMethods({
+      ifVideoPlayer: [this.play, this.stop, this.setContentList, /* ... */],
+      ifHttpAgent: [ifHttpAgent.addHeader, ifHttpAgent.setHeaders, /* ... */],
+  });
+  ```
+- `src/core/brsTypes/interfaces/` holds only a **small, deliberate set** of shared helper
+  classes (`IfArray`, `IfEnum`, `IfHttpAgent`, `IfList`, `IfMessagePort`, `IfSocket`,
+  `IfToStr`, `IfDraw2D`, …) — abstract/shared method bundles that exist purely to **reduce
+  duplication** when several components expose the same interface. Instantiate one with the
+  owning component and spread its callables into `registerMethods`:
+  ```ts
+  const ifArray = new IfArray(this);
+  this.registerMethods({ ifArray: [ifArray.peek, ifArray.pop, /* ... */] });
+  ```
+- **Decision rule when adding a method/interface to a component:**
+  - Shared by multiple components → add it to (or reuse) a helper in `interfaces/`.
+  - Specific to one component → define it inline on that component class.
+  - Either way, register it under the matching `ifXxx` key. **Do not** add a new file in
+    `interfaces/` just to mirror a documented interface that only one component uses.
 
 ## Wiring reminders (see CLAUDE.md for full detail)
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "external/dev-doc"]
+	path = external/dev-doc
+	url = https://github.com/rokudev/dev-doc.git
+	branch = v2.0


### PR DESCRIPTION
## Summary

Wires Roku's official, open-sourced developer documentation into the repo as a reference for implementing/verifying interpreter features, and adds Claude Code guidance + a skill for using it.

- **Vendors `rokudev/dev-doc` as a git submodule** at `external/dev-doc` (branch `v2.0`), whose `docs/REFERENCES/` tree is the authoritative BrightScript + SceneGraph spec. Reference-only — no build/runtime dependency.
- **CLAUDE.md**: new "Roku reference documentation" section mapping each reference path (`components/`, `interfaces/`, `events/`, `language/`, `scenegraph/**`) to the source it implements/verifies, plus submodule init/update instructions.
- **`.claude/skills/brs-reference/`**: a skill for looking up component/interface/event/node/global-function specs when implementing or verifying features.
- **Documents the interface architecture**: `ifXxx` interfaces are *method-grouping metadata* in `registerMethods`, not standalone types — methods are mostly inline on the `roXxx` component, and `src/core/brsTypes/interfaces/` holds only a small set of shared helper classes to reduce duplication. The skill tells contributors to follow this pattern rather than mirroring the documented interface list.

## Notes

- After checkout, run `git submodule update --init external/dev-doc` (or clone with `--recurse-submodules`) to populate the docs. Update later with `git -C external/dev-doc pull origin v2.0` and commit the new pointer.
- Docs-only / tooling change — no source or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)