### PR TITLE
feat(scenegraph): implement MaskGroup alpha-mask compositing

### DIFF
--- a/src/core/brsTypes/interfaces/IfDraw2D.ts
+++ b/src/core/brsTypes/interfaces/IfDraw2D.ts
@@ -1071,6 +1071,26 @@ export function CircleCircle(circle1: Circle, circle2: Circle): boolean {
     return dist <= circle1.r + circle2.r;
 }
 
+/**
+ * Blits a scaled sub-region of a source canvas onto a destination context, handling the
+ * OffscreenCanvas (browser) vs node `Canvas` type guards in one place so callers in other
+ * bundles don't have to duplicate them.
+ */
+export function drawCanvasRegion(
+    ctx: BrsCanvasContext2D,
+    image: BrsCanvas,
+    sx: number,
+    sy: number,
+    sw: number,
+    sh: number,
+    dx: number,
+    dy: number,
+    dw: number,
+    dh: number
+) {
+    drawChunk(ctx, image, { sx, sy, sw, sh, dx, dy, dw, dh });
+}
+
 function drawChunk(ctx: BrsCanvasContext2D, image: BrsCanvas, chunk: DrawChunk) {
     if (image.width === 0 || image.height === 0) {
         return;

--- a/src/extensions/scenegraph/nodes/MaskGroup.ts
+++ b/src/extensions/scenegraph/nodes/MaskGroup.ts
@@ -1,7 +1,18 @@
-import { AAMember } from "brs-engine";
+import {
+    AAMember,
+    Interpreter,
+    Float,
+    RoBitmap,
+    IfDraw2D,
+    BrsCanvasContext2D,
+    createNewCanvas,
+    releaseCanvas,
+    drawCanvasRegion,
+} from "brs-engine";
 import { FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";
 import { Group } from "./Group";
+import { brsValueOf } from "../factory/Serializer";
 
 export class MaskGroup extends Group {
     readonly defaultFields: FieldModel[] = [
@@ -17,5 +28,123 @@ export class MaskGroup extends Group {
 
         this.registerDefaultFields(this.defaultFields);
         this.registerInitializedFields(initializedFields);
+    }
+
+    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+        if (!this.isVisible()) {
+            this.updateRenderTracking(true);
+            return;
+        }
+        const maskUri = this.getValueJS("maskUri") as string;
+        const maskBitmap = maskUri ? this.loadBitmap(maskUri) : undefined;
+        this.updateMaskBitmapFields(maskBitmap);
+
+        // Fallback path: with no draw target, no/invalid mask, or an empty scene, behave like a
+        // plain Group. This mirrors the documented behavior on Roku players without OpenGL, where
+        // a MaskGroup just renders its children without applying the alpha mask.
+        if (!draw2D || !maskBitmap?.isValid() || this.sceneRect.width <= 0 || this.sceneRect.height <= 0) {
+            super.renderNode(interpreter, origin, angle, opacity, draw2D);
+            return;
+        }
+
+        // Render children into a scene-sized offscreen bitmap so their pixel coordinates line up
+        // 1:1 with the screen, then knock out alpha with the mask and composite the result back.
+        const offscreen = new RoBitmap(
+            brsValueOf({ width: this.sceneRect.width, height: this.sceneRect.height, alphaEnable: true })
+        );
+        const offDraw = new IfDraw2D(offscreen);
+        // Group.renderNode handles transforms, child rendering, bounding rects, and render tracking.
+        super.renderNode(interpreter, origin, angle, opacity, offDraw);
+
+        // The mask coordinate system origin is the group origin in scene space (translation applied).
+        // Note: any rotation on the MaskGroup itself rotates the children (handled above) but the mask
+        // is applied in axis-aligned scene space, which is an accepted limitation of the simulation.
+        const nodeTrans = this.getTranslation();
+        this.applyMask(offscreen, maskBitmap, origin[0] + nodeTrans[0], origin[1] + nodeTrans[1]);
+
+        // Children were already drawn at the group opacity, so composite the masked result as-is.
+        draw2D.doDrawScaledObject(0, 0, 1, 1, offscreen);
+        releaseCanvas(offscreen.getCanvas());
+    }
+
+    /** Reports the loaded mask bitmap's actual dimensions through the read-only fields. */
+    private updateMaskBitmapFields(maskBitmap?: RoBitmap) {
+        const width = maskBitmap?.isValid() ? maskBitmap.width : 0;
+        const height = maskBitmap?.isValid() ? maskBitmap.height : 0;
+        if ((this.getValueJS("maskBitmapWidth") as number) !== width) {
+            super.setValue("maskBitmapWidth", new Float(width));
+        }
+        if ((this.getValueJS("maskBitmapHeight") as number) !== height) {
+            super.setValue("maskBitmapHeight", new Float(height));
+        }
+    }
+
+    /**
+     * Multiplies the alpha of the already-rendered offscreen bitmap by the alpha of the mask bitmap.
+     * The mask is scaled by maskSize (a 0 element means "use the bitmap's actual size in that
+     * dimension") and offset by maskOffset relative to the group origin. Where the transformed mask
+     * does not cover the group, the nearest edge row/column of the mask is repeated (edge-clamp).
+     */
+    private applyMask(offscreen: RoBitmap, maskBitmap: RoBitmap, originX: number, originY: number) {
+        const maskSize = this.getValueJS("maskSize") as number[];
+        const maskOffset = this.getValueJS("maskOffset") as number[];
+        const bw = maskBitmap.width;
+        const bh = maskBitmap.height;
+        if (bw <= 0 || bh <= 0) {
+            return;
+        }
+        const mw = maskSize[0] > 0 ? maskSize[0] : bw;
+        const mh = maskSize[1] > 0 ? maskSize[1] : bh;
+        const mx = originX + maskOffset[0];
+        const my = originY + maskOffset[1];
+        const sceneW = offscreen.width;
+        const sceneH = offscreen.height;
+
+        // Build the mask alpha layer, filling the whole scene with edge-clamping outside the mask rect.
+        const maskLayer = createNewCanvas(sceneW, sceneH);
+        const mctx = maskLayer.getContext("2d") as BrsCanvasContext2D;
+        mctx.imageSmoothingEnabled = true;
+        const src = maskBitmap.getCanvas();
+
+        const blit = (
+            sx: number,
+            sy: number,
+            sw: number,
+            sh: number,
+            dx: number,
+            dy: number,
+            dw: number,
+            dh: number
+        ) => {
+            if (dw > 0 && dh > 0) {
+                drawCanvasRegion(mctx, src, sx, sy, sw, sh, dx, dy, dw, dh);
+            }
+        };
+        const rightX = mx + mw;
+        const bottomY = my + mh;
+        const rightW = sceneW - rightX;
+        const bottomH = sceneH - bottomY;
+        // Center (the transformed mask itself).
+        blit(0, 0, bw, bh, mx, my, mw, mh);
+        // Edge strips (1px source slices stretched to the gap).
+        blit(0, 0, 1, bh, 0, my, mx, mh); // left
+        blit(bw - 1, 0, 1, bh, rightX, my, rightW, mh); // right
+        blit(0, 0, bw, 1, mx, 0, mw, my); // top
+        blit(0, bh - 1, bw, 1, mx, bottomY, mw, bottomH); // bottom
+        // Corners (1px source slices stretched to fill).
+        blit(0, 0, 1, 1, 0, 0, mx, my); // top-left
+        blit(bw - 1, 0, 1, 1, rightX, 0, rightW, my); // top-right
+        blit(0, bh - 1, 1, 1, 0, bottomY, mx, bottomH); // bottom-left
+        blit(bw - 1, bh - 1, 1, 1, rightX, bottomY, rightW, bottomH); // bottom-right
+
+        // Multiply the offscreen alpha by the mask alpha.
+        const octx = offscreen.getContext();
+        octx.save();
+        octx.globalCompositeOperation = "destination-in";
+        drawCanvasRegion(octx, maskLayer, 0, 0, sceneW, sceneH, 0, 0, sceneW, sceneH);
+        octx.restore();
+        offscreen.makeDirty();
+
+        releaseCanvas(maskLayer);
     }
 }

--- a/test/e2e/SceneGraph.test.js
+++ b/test/e2e/SceneGraph.test.js
@@ -234,6 +234,24 @@ describe("SceneGraph node tests", () => {
         ]);
     });
 
+    test("maskgroup.brs", async () => {
+        await execute([resourceFile("scenegraph", "maskgroup.brs")], outputStreams);
+
+        expect(allArgs(outputStreams.stdout.write).map((arg) => arg.trimEnd())).toEqual([
+            "subtype: MaskGroup",
+            "isSubtype Node: true",
+            "maskUri: []",
+            "maskSize: 0,0",
+            "maskOffset: 0,0",
+            "maskBitmapWidth: 0",
+            "maskBitmapHeight: 0",
+            "set maskSize: 100,50",
+            "set maskOffset: 50,30",
+            "set maskUri: [pkg:/images/mask.png]",
+            "Test completed successfully!",
+        ]);
+    });
+
     test("update-fields.brs", async () => {
         await execute([resourceFile("scenegraph", "update-fields.brs")], outputStreams);
 

--- a/test/e2e/resources/scenegraph/maskgroup.brs
+++ b/test/e2e/resources/scenegraph/maskgroup.brs
@@ -1,0 +1,24 @@
+sub Main()
+    mask = CreateObject("roSGNode", "MaskGroup")
+    print "subtype: " + mask.subtype()
+    print "isSubtype Node: " ; mask.isSubtype("Node")
+
+    print "maskUri: [" + mask.maskUri + "]"
+    sz = mask.maskSize
+    print "maskSize: " + Str(sz[0]).Trim() + "," + Str(sz[1]).Trim()
+    off = mask.maskOffset
+    print "maskOffset: " + Str(off[0]).Trim() + "," + Str(off[1]).Trim()
+    print "maskBitmapWidth: " + Str(mask.maskBitmapWidth).Trim()
+    print "maskBitmapHeight: " + Str(mask.maskBitmapHeight).Trim()
+
+    mask.maskSize = [100, 50]
+    mask.maskOffset = [50, 30]
+    mask.maskUri = "pkg:/images/mask.png"
+    nsz = mask.maskSize
+    noff = mask.maskOffset
+    print "set maskSize: " + Str(nsz[0]).Trim() + "," + Str(nsz[1]).Trim()
+    print "set maskOffset: " + Str(noff[0]).Trim() + "," + Str(noff[1]).Trim()
+    print "set maskUri: [" + mask.maskUri + "]"
+
+    print "Test completed successfully!"
+end sub


### PR DESCRIPTION
## Summary

`MaskGroup` previously inherited `Group.renderNode`, so its `maskUri` / `maskSize` / `maskOffset` fields were ignored and the read-only `maskBitmapWidth` / `maskBitmapHeight` were never populated. This implements the actual alpha mask described in the [Roku MaskGroup spec](https://developer.roku.com/docs/references/scenegraph/control-nodes/maskgroup.md).

## What it does

- Renders children into an offscreen `RoBitmap`, then multiplies their alpha by the mask bitmap via canvas `destination-in` compositing:
  - `maskSize` scales the mask (a `0` element = bitmap's actual size in that dimension),
  - `maskOffset` offsets the mask relative to the group origin,
  - pixels outside the transformed mask are **edge-clamped** (nearest edge row/column repeated).
- Populates the read-only `maskBitmapWidth` / `maskBitmapHeight` from the loaded bitmap.
- Falls back to plain `Group` rendering when there is no valid mask — matching the documented non-OpenGL-player behavior.
- Exports a small `drawCanvasRegion` helper from `IfDraw2D` so the scenegraph bundle reuses the existing browser/node canvas guards instead of duplicating them.

## Testing

- `npm run lint`, `build:api`, `build:sg`, `build:cli` all clean.
- Added `test/e2e/resources/scenegraph/maskgroup.brs` + a case in `SceneGraph.test.js` asserting subtype, default fields (per the Roku spec table), and read/write of `maskSize`/`maskOffset`/`maskUri`. Full SceneGraph suite passes.
- Verified the rendering end-to-end with a live channel (CLI ASCII render): with an alpha-gradient mask the child fades left→right and `maskBitmapWidth` reports the bitmap size; with an empty `maskUri` the child renders fully (fallback). No runtime errors in the compositing path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)