### PR TITLE
fix(scenegraph): apply uri_resolution_autosub manifest config more robustly

### DIFF
--- a/src/extensions/scenegraph/SGRoot.ts
+++ b/src/extensions/scenegraph/SGRoot.ts
@@ -157,16 +157,21 @@ export class SGRoot {
                 this._resolution = "SD";
             }
         }
-        const autoSub = interpreter.manifest.get("uri_resolution_autosub") ?? "";
-        if (autoSub.split(",").length === 4) {
-            const subs = autoSub.split(",");
-            this._autoSub.search = subs[0];
-            if (this._resolution === "SD") {
-                this._autoSub.replace = subs[1];
-            } else if (this._resolution === "HD") {
-                this._autoSub.replace = subs[2];
-            } else {
-                this._autoSub.replace = subs[3];
+        // Format: uri_resolution_autosub=<search>,<replace...>
+        // The full form lists replacements for SD, HD and FHD, but channels often omit the
+        // resolutions they don't ship (most commonly SD), e.g. "$$RES$$,hd,fhd". The replacements
+        // are an ascending-resolution suffix of [SD, HD, FHD] (FHD is always the last one), so map
+        // the current resolution from the end of the list. Roku trims surrounding whitespace.
+        const autoSub = (interpreter.manifest.get("uri_resolution_autosub") ?? "").trim();
+        if (autoSub) {
+            const subs = autoSub.split(",").map((sub) => sub.trim());
+            const replacements = subs.slice(1);
+            if (replacements.length && subs[0] !== "") {
+                this._autoSub.search = subs[0];
+                // Offset from the end: FHD = last, HD = second-to-last, SD = third-to-last.
+                const offset = this._resolution === "FHD" ? 1 : this._resolution === "HD" ? 2 : 3;
+                const index = Math.min(Math.max(replacements.length - offset, 0), replacements.length - 1);
+                this._autoSub.replace = replacements[index];
             }
         }
     }

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -1063,10 +1063,12 @@ export class Node extends RoSGNode implements BrsValue {
         if (!uri?.trim()) {
             return undefined;
         }
-        if (sgRoot.autoSub.search && sgRoot.autoSub.replace) {
+        if (sgRoot.autoSub.search) {
+            // Replace the configured token with the resolution-specific string. An empty replacement
+            // is valid (it removes the token), so only the search string needs to be configured.
             const escapedSearch = sgRoot.autoSub.search.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
-            const searchPattern = new RegExp(escapedSearch, "i");
-            uri = uri.replace(searchPattern, sgRoot.autoSub.replace);
+            const searchPattern = new RegExp(escapedSearch, "gi");
+            uri = uri.replaceAll(searchPattern, () => sgRoot.autoSub.replace);
         }
         return getTextureManager().loadTexture(uri, this.httpAgent.customHeaders);
     }


### PR DESCRIPTION
## Summary

Resolution autosub (`uri_resolution_autosub`) was silently dropped for several valid manifest configurations, so Posters (and other nodes) loaded the literal URI with an unresolved token instead of the resolution-specific asset — e.g. `pkg:/images/pill_button_$$RES$$.9.png` → `ENOENT`.

## Root causes

1. **No trimming** of the comma-separated parts — a readable entry like `uri_resolution_autosub=$$RES$$, SD, HD, FHD` left a leading space on each replacement, producing a bad asset path (`pkg:/images/ FHD/...`).
2. **Fixed "exactly 4 fields"** parse — it rejected the common 3-field form `$$RES$$,hd,fhd` (channels omit the SD replacement, which Roku does not target), and any trailing comma / extra field discarded the entire config.
3. **Empty-replacement guard** in `loadBitmap` — substitution was skipped when the resolution-specific replacement was empty, even though an empty replacement validly removes the token.

## Fix

- Trim the whole value and each comma-separated part.
- Treat the replacements as an ascending-resolution **suffix of `[SD, HD, FHD]`** (FHD is always the last one) and map the current resolution from the end of the list, so both `$$RES$$,SD,HD,FHD` and `$$RES$$,hd,fhd` resolve correctly.
- Substitute whenever the search token is configured (empty replacement = token removal), using a global, `$`-safe `replaceAll` so a token appearing more than once is fully replaced.

## Testing

- `npm run lint`, `build:sg`, `build:cli` clean; SceneGraph e2e + scenegraph unit suites pass (102 tests).
- Reproduced via a live channel with HD (30px) and FHD (45px) 9-patch assets. Before the fix the spaced / 3-field / extra-field configs failed to load; after, all resolve `ready` and load the correct-resolution asset:

| `ui_resolutions` | `uri_resolution_autosub` | loaded asset |
|---|---|---|
| `fhd,hd` | `$$RES$$,hd,fhd` | `fhd` (45px) |
| `hd,fhd` | `$$RES$$,hd,fhd` | `hd` (30px) |
| `fhd` | `$$RES$$,sd,hd,fhd` | `fhd` (45px) |
| `hd` | `$$RES$$,sd,hd,fhd` | `hd` (30px) |

> Note: the e2e harness only packages `.brs` files (no images on `pkg:`), so image-loading substitution is verified via a live channel rather than an automated test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)