### PR TITLE
fix(draw2d): parse 9-patch corner insets from marker start and end

### DIFF
--- a/src/core/brsTypes/components/RoBitmap.ts
+++ b/src/core/brsTypes/components/RoBitmap.ts
@@ -27,6 +27,17 @@ import BMP from "decode-bmp";
 import { WebPRiffParser, WebPDecoder } from "@lvcabral/libwebp";
 import { BrsDevice } from "../../device/BrsDevice";
 
+/** Parsed 9-patch (`.9.png`) layout, in source-pixel units (excluding the 1px marker border). */
+export interface NinePatch {
+    /** Fixed corner insets, derived from the TOP row + LEFT column stretch markers. */
+    left: number;
+    right: number;
+    top: number;
+    bottom: number;
+    /** Content padding, derived from the RIGHT column + BOTTOM row markers. */
+    margins: { left: number; right: number; top: number; bottom: number };
+}
+
 export class RoBitmap extends BrsComponent implements BrsValue, BrsDraw2D {
     readonly kind = ValueKind.Object;
     readonly x: number = 0;
@@ -38,7 +49,7 @@ export class RoBitmap extends BrsComponent implements BrsValue, BrsDraw2D {
     private readonly context: BrsCanvasContext2D;
     private readonly name: string;
     private readonly valid: boolean;
-    private readonly patchSizes?: { horizontal: number; vertical: number };
+    private readonly patchSizes?: NinePatch;
     private alphaEnable: boolean;
     private rgbaCanvas?: BrsCanvas;
     private rgbaLast: number;
@@ -188,8 +199,8 @@ export class RoBitmap extends BrsComponent implements BrsValue, BrsDraw2D {
             ifBitmap: [this.getName],
         });
         if (this.valid && this.name.toLowerCase().endsWith(".9.png")) {
-            const sizes = this.getPatchSizes();
-            if (sizes.horizontal >= 0 && sizes.vertical >= 0) {
+            const sizes = this.parsePatchSizes();
+            if (sizes) {
                 this.ninePatch = true;
                 this.patchSizes = sizes;
             }
@@ -296,49 +307,81 @@ export class RoBitmap extends BrsComponent implements BrsValue, BrsDraw2D {
         }
     }
 
-    getPatchSizes(): { horizontal: number; vertical: number } {
-        if (this.patchSizes) {
-            return this.patchSizes;
-        }
+    /** Returns the parsed 9-patch layout, or `undefined` for non 9-patch bitmaps. */
+    getPatchSizes(): NinePatch | undefined {
+        return this.patchSizes ?? this.parsePatchSizes();
+    }
+
+    /**
+     * Parses the 1px marker border of a `.9.png` image into fixed corner insets and content
+     * margins. The TOP row and LEFT column markers define the stretchable region (and thus the
+     * fixed corner insets); the RIGHT column and BOTTOM row markers define the content padding.
+     * Returns `undefined` when the image is not a valid 9-patch (no top/left stretch markers).
+     */
+    private parsePatchSizes(): NinePatch | undefined {
         const image = this.getCanvas();
         const ctx = this.getContext();
+        const width = image.width;
+        const height = image.height;
+        const data = ctx.getImageData(0, 0, width, height).data;
 
-        const imageData = ctx.getImageData(0, 0, image.width, image.height);
-        const data = imageData.data;
+        const isBlack = (x: number, y: number) => {
+            const i = (x + y * width) * 4;
+            // Marker pixels are opaque black (0, 0, 0, 255)
+            return data[i] === 0 && data[i + 1] === 0 && data[i + 2] === 0 && data[i + 3] === 255;
+        };
 
-        let horizPatchSize = -1;
-        let vertPatchSize = -1;
-
-        // Check the top row for the first black pixel (horizontal patch size)
-        for (let i = 0; i < image.width; i++) {
-            const index = (i + 0 * image.width) * 4;
-            const r = data[index];
-            const g = data[index + 1];
-            const b = data[index + 2];
-            const a = data[index + 3];
-
-            // Assuming black pixel (0, 0, 0, 255)
-            if (r === 0 && g === 0 && b === 0 && a === 255) {
-                horizPatchSize = i;
-                break;
+        // Scans an edge line and returns the [first, last] indices of its contiguous marker, or
+        // undefined when no marker pixel is found.
+        const scanMarker = (length: number, sample: (i: number) => boolean) => {
+            let first = -1;
+            let last = -1;
+            for (let i = 0; i < length; i++) {
+                if (sample(i)) {
+                    if (first < 0) {
+                        first = i;
+                    }
+                    last = i;
+                }
             }
+            return first < 0 ? undefined : { first, last };
+        };
+
+        // Content spans indices 1..length-2 (the marker border is excluded).
+        const inset = (marker: { first: number; last: number }, length: number) => ({
+            before: marker.first - 1,
+            after: length - 2 - marker.last,
+        });
+
+        const topMarker = scanMarker(width, (x) => isBlack(x, 0));
+        const leftMarker = scanMarker(height, (y) => isBlack(0, y));
+        if (!topMarker || !leftMarker) {
+            return undefined;
+        }
+        const horiz = inset(topMarker, width);
+        const vert = inset(leftMarker, height);
+
+        const bottomMarker = scanMarker(width, (x) => isBlack(x, height - 1));
+        const rightMarker = scanMarker(height, (y) => isBlack(width - 1, y));
+        let margins = { left: 0, right: 0, top: 0, bottom: 0 };
+        if (bottomMarker && rightMarker) {
+            const horizMargin = inset(bottomMarker, width);
+            const vertMargin = inset(rightMarker, height);
+            margins = {
+                left: horizMargin.before,
+                right: horizMargin.after,
+                top: vertMargin.before,
+                bottom: vertMargin.after,
+            };
         }
 
-        // Check the left column for the first black pixel (vertical patch size)
-        for (let i = 0; i < image.height; i++) {
-            const index = (0 + i * image.width) * 4;
-            const r = data[index];
-            const g = data[index + 1];
-            const b = data[index + 2];
-            const a = data[index + 3];
-
-            // Assuming black pixel (0, 0, 0, 255)
-            if (r === 0 && g === 0 && b === 0 && a === 255) {
-                vertPatchSize = i;
-                break;
-            }
-        }
-        return { horizontal: horizPatchSize, vertical: vertPatchSize };
+        return {
+            left: horiz.before,
+            right: horiz.after,
+            top: vert.before,
+            bottom: vert.after,
+            margins,
+        };
     }
 
     // ifBitmap  -----------------------------------------------------------------------------------

--- a/src/core/brsTypes/interfaces/IfDraw2D.ts
+++ b/src/core/brsTypes/interfaces/IfDraw2D.ts
@@ -221,6 +221,9 @@ export class IfDraw2D {
         rgba = combineRgbaOpacity(rgba, opacity);
         const image = getCanvasFromDraw2d(bitmap, rgba);
         const patchSizes = bitmap.getPatchSizes();
+        if (!patchSizes) {
+            return;
+        }
         const x = rect.x;
         const y = rect.y;
         const width = rect.width;
@@ -228,10 +231,10 @@ export class IfDraw2D {
         const sw = image.width;
         const sh = image.height;
 
-        const lw = patchSizes.horizontal; // Left Width
-        const rw = patchSizes.horizontal; // Right Width (assuming symmetric)
-        const th = patchSizes.vertical; // Top Height
-        const bh = patchSizes.vertical; // Bottom Height (assuming symmetric)
+        const lw = patchSizes.left; // Left fixed-corner width
+        const rw = patchSizes.right; // Right fixed-corner width
+        const th = patchSizes.top; // Top fixed-corner height
+        const bh = patchSizes.bottom; // Bottom fixed-corner height
 
         const cw = Math.max(0, sw - 2 - lw - rw); // Center source width (drawable area)
         const ch = Math.max(0, sh - 2 - th - bh); // Center source height (drawable area)

--- a/src/extensions/scenegraph/nodes/Poster.ts
+++ b/src/extensions/scenegraph/nodes/Poster.ts
@@ -135,12 +135,12 @@ export class Poster extends Group {
         this.bitmap = this.loadBitmap(uri);
         if (this.bitmap?.isValid()) {
             const margins = { left: 0, right: 0, top: 0, bottom: 0 };
-            if (this.bitmap.ninePatch) {
-                const sizes = this.bitmap.getPatchSizes();
-                margins.left = sizes.horizontal;
-                margins.right = sizes.horizontal;
-                margins.top = sizes.vertical;
-                margins.bottom = sizes.vertical;
+            const sizes = this.bitmap.ninePatch ? this.bitmap.getPatchSizes() : undefined;
+            if (sizes) {
+                margins.left = sizes.margins.left;
+                margins.right = sizes.margins.right;
+                margins.top = sizes.margins.top;
+                margins.bottom = sizes.margins.bottom;
             } else {
                 const loadWidth = this.getValueJS("loadWidth") as number;
                 const loadHeight = this.getValueJS("loadHeight") as number;

--- a/test/brsTypes/components/RoBitmap.test.js
+++ b/test/brsTypes/components/RoBitmap.test.js
@@ -14,10 +14,7 @@ describe("RoBitmap 9-patch parsing", () => {
     });
 
     it("parses asymmetric stretch markers and content margins (inputField.9.png)", () => {
-        const fixture = path.join(
-            __dirname,
-            "../../../src/extensions/scenegraph/common/images/inputField.9.png"
-        );
+        const fixture = path.join(__dirname, "../../../src/extensions/scenegraph/common/images/inputField.9.png");
         const bitmap = new RoBitmap(fs.readFileSync(fixture), "pkg:/images/inputField.9.png");
 
         expect(bitmap.ninePatch).toBe(true);

--- a/test/brsTypes/components/RoBitmap.test.js
+++ b/test/brsTypes/components/RoBitmap.test.js
@@ -1,0 +1,60 @@
+const fs = require("fs");
+const path = require("path");
+const { createCanvas } = require("canvas");
+const brs = require("../../../packages/node/bin/brs.node");
+const { RoBitmap } = brs.types;
+
+describe("RoBitmap 9-patch parsing", () => {
+    it("flags non 9-patch bitmaps and returns no patch sizes", () => {
+        const canvas = createCanvas(4, 4);
+        const bitmap = new RoBitmap(canvas.toBuffer("image/png"), "pkg:/images/plain.png");
+
+        expect(bitmap.ninePatch).toBe(false);
+        expect(bitmap.getPatchSizes()).toBeUndefined();
+    });
+
+    it("parses asymmetric stretch markers and content margins (inputField.9.png)", () => {
+        const fixture = path.join(
+            __dirname,
+            "../../../src/extensions/scenegraph/common/images/inputField.9.png"
+        );
+        const bitmap = new RoBitmap(fs.readFileSync(fixture), "pkg:/images/inputField.9.png");
+
+        expect(bitmap.ninePatch).toBe(true);
+        // 75x75 image; top marker x:[12,63], left marker y:[13,61] => asymmetric left(11) != right(10)
+        // bottom/right padding markers span 25..49 => margins of 24 on every side.
+        expect(bitmap.getPatchSizes()).toEqual({
+            left: 11,
+            right: 10,
+            top: 12,
+            bottom: 12,
+            margins: { left: 24, right: 24, top: 24, bottom: 24 },
+        });
+    });
+
+    it("parses a single-pixel center marker (pill-style) keeping the caps fixed", () => {
+        // 11x11 image: stretch marker is a single pixel at the center of the top row / left column,
+        // padding markers span the full content edge (margins of 0) - the pill_button layout.
+        const size = 11;
+        const canvas = createCanvas(size, size);
+        const ctx = canvas.getContext("2d");
+        ctx.fillStyle = "rgba(0, 0, 0, 1)";
+        const center = (size - 1) / 2; // 5
+        ctx.fillRect(center, 0, 1, 1); // top stretch marker (single pixel)
+        ctx.fillRect(0, center, 1, 1); // left stretch marker (single pixel)
+        ctx.fillRect(1, size - 1, size - 2, 1); // bottom padding marker (full content)
+        ctx.fillRect(size - 1, 1, 1, size - 2); // right padding marker (full content)
+
+        const bitmap = new RoBitmap(canvas.toBuffer("image/png"), "pkg:/images/pill.9.png");
+
+        expect(bitmap.ninePatch).toBe(true);
+        // content length = 9; marker at index 5 => fixed inset 4 on each side, center stretch = 1.
+        expect(bitmap.getPatchSizes()).toEqual({
+            left: 4,
+            right: 4,
+            top: 4,
+            bottom: 4,
+            margins: { left: 0, right: 0, top: 0, bottom: 0 },
+        });
+    });
+});


### PR DESCRIPTION
## Problem

A pill-style button background (a `.9.png` whose horizontal/vertical stretch marker is a single center pixel) rendered as two detached semicircles with an empty gap, instead of a solid rounded pill.

## Root cause

`RoBitmap.getPatchSizes()` scanned for only the **first** black marker pixel in the top row and left column, and `IfDraw2D.drawNinePatch()` assumed symmetric corners equal to that position (`lw = rw = horizontal`, `th = bh = vertical`).

For the pill asset (`pill_button_fhd.9.png`, 105×105), the stretch marker is a single pixel at x=52 / y=52, so the code computed `lw = rw = 52` → center width `105 − 2 − 52 − 52 = −1`, clamped to `0`. The stretchable region vanished and only the four 52×52 corner quadrants got drawn (each half a rounded cap), leaving a gap in the middle.

## Fix

- **`RoBitmap.ts`** — New `parsePatchSizes()` finds the **start and end** of each edge marker to derive *independent* corner insets (`left`/`right`/`top`/`bottom`) from the top/left stretch markers, plus content `margins` from the right/bottom padding markers. `getPatchSizes()` now returns a `NinePatch | undefined`.
- **`IfDraw2D.ts`** — `drawNinePatch()` uses the independent insets; the nine `drawPart` calls were already generic and become correct automatically.
- **`Poster.ts`** — `bitmapMargins` is now sourced from the right/bottom padding markers, matching the [Roku spec](https://developer.roku.com/) (previously it incorrectly used the top/left stretch markers).
- **Tests** — New `test/brsTypes/components/RoBitmap.test.js` covering a non-9-patch bitmap, the bundled asymmetric `inputField.9.png` (`left=11` ≠ `right=10`, margins=24 — which the old code got wrong), and a synthetic single-center-pixel pill case.

## Verification

- `npm run lint` ✅
- `npm test` — 1660 passed, 2 todo, 0 failed ✅
- `npm run build` — all packages compile ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)