### PR TITLE
fix(scenegraph): update global focus pointer before clearing old focus chain

### DIFF
--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -901,11 +901,21 @@ export class Node extends RoSGNode implements BrsValue {
             // Get the focus chain, with lowest ancestor first.
             let newFocusChain = this.createPath();
 
-            // If there's already a focused node somewhere, we need to remove focus
+            // Capture the previously focused node, then update the global focus
+            // reference up front so any observers fired while we rewrite the
+            // focusedChild fields below already see the new focus state
+            // (hasFocus() === sgRoot.focused === this). Otherwise, clearing the old
+            // focus chain flushes its observers synchronously while sgRoot.focused
+            // still points at the node losing focus, making it (incorrectly) report
+            // hasFocus() === true alongside the node gaining focus.
+            const prevFocused = sgRoot.focused;
+            sgRoot.setFocused(this);
+
+            // If there was already a focused node somewhere, we need to remove focus
             // from it and its ancestors.
-            if (sgRoot.focused instanceof Node) {
+            if (prevFocused instanceof Node) {
                 // Get the focus chain, with root-most ancestor first.
-                let currFocusChain = this.createPath(sgRoot.focused);
+                let currFocusChain = this.createPath(prevFocused);
 
                 // Find the lowest common ancestor (LCA) between the newly focused node
                 // and the current focused node.
@@ -920,8 +930,6 @@ export class Node extends RoSGNode implements BrsValue {
                     currFocusChain[i].setValue(focusedChild, BrsInvalid.Instance, false);
                 }
             }
-            // Set the global focused node reference to this node.
-            sgRoot.setFocused(this);
 
             // Set the focusedChild for each ancestor to the next node in the chain,
             // which is the current node's child.

--- a/test/extensions/scenegraph/Focus.test.js
+++ b/test/extensions/scenegraph/Focus.test.js
@@ -1,0 +1,68 @@
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { Node, sgRoot } = scenegraph;
+const { BrsBoolean, RoMessagePort } = core;
+
+/**
+ * Builds a focusable Group node.
+ */
+function focusableNode() {
+    const node = new Node([], "Group");
+    node.setValue("focusable", BrsBoolean.True, false);
+    return node;
+}
+
+/**
+ * Minimal fake interpreter accepted by Field.addObserver for a port observer.
+ * Port observers never enter inSubEnv (they just pushMessage), so the body is
+ * never invoked, but the shape needs to exist.
+ */
+const fakeInterpreter = { environment: {}, inSubEnv: () => {} };
+
+/**
+ * Field name passed to addObserver; only getValue/toString are exercised.
+ */
+const focusedChildFieldArg = { getValue: () => "focusedChild", toString: () => "focusedChild" };
+
+describe("SceneGraph focus management", () => {
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    test("setFocus moves the global focus pointer before clearing the old focus chain", () => {
+        // Two sibling buttons under a common parent.
+        const parent = focusableNode();
+        const buttonA = focusableNode();
+        const buttonB = focusableNode();
+        parent.appendChildToParent(buttonA);
+        parent.appendChildToParent(buttonB);
+
+        // Button A starts focused.
+        buttonA.setNodeFocus(true);
+        expect(sgRoot.focused).toBe(buttonA);
+
+        // Observe button A's focusedChild with a port so the observer fires
+        // synchronously when A loses focus. Capture which node the engine
+        // considers focused *during* that notification.
+        const port = new RoMessagePort();
+        let focusedDuringALosingFocus;
+        const originalPush = port.pushMessage.bind(port);
+        port.pushMessage = (event) => {
+            focusedDuringALosingFocus = sgRoot.focused;
+            originalPush(event);
+        };
+        buttonA.fields
+            .get("focusedchild")
+            .addObserver("permanent", fakeInterpreter, port, buttonA, focusedChildFieldArg);
+
+        // Move focus to button B. Clearing A's focusedChild fires the observer above.
+        buttonB.setNodeFocus(true);
+
+        // Regression: while A is losing focus, the global focus pointer must
+        // already be B, so A.hasFocus() (=== sgRoot.focused === A) returns false.
+        // Previously the pointer was still A here, making both buttons report focus.
+        expect(focusedDuringALosingFocus).toBe(buttonB);
+        expect(sgRoot.focused).toBe(buttonB);
+    });
+});


### PR DESCRIPTION
## Problem

When navigating a row of buttons, BrightScript calls `setFocus(true)` on the button receiving focus. During the transition **both** the button losing focus and the button gaining focus momentarily returned `true` from `hasFocus()` inside field-observer callbacks. On a real Roku, exactly one node is ever the tip of the focus chain.

## Root cause

`hasFocus()` is `sgRoot.focused === this`. In `Node.setNodeFocus` the old order was:

1. Clear the previously focused node's `focusedChild` (`setValue`)
2. `sgRoot.setFocused(this)`
3. Set the new focus chain's `focusedChild` fields

Field writes flush observers **synchronously** (`Field.setValue` → `notifyObservers` → `flushNotificationQueue`). So step 1 dispatched the old node's `focusedChild` observers **before** step 2 moved `sgRoot.focused`. Inside those callbacks `sgRoot.focused` still pointed at the node losing focus, so its `hasFocus()` returned `true`. The new node's observers fired after step 2 and also returned `true` — both buttons appeared focused.

## Fix

Capture the previously focused node, then call `sgRoot.setFocused(this)` **before** mutating any `focusedChild` field. Every observer fired during the transition now sees the final focus state. The early-return guards (initial-focus delegation, `!isFocusable() && isChildrenFocused()`) still run before the pointer moves, so a rejected focus request never updates `sgRoot.focused`. The `focusOn === false` branches are unchanged.

## Test

Adds `test/extensions/scenegraph/Focus.test.js`: focuses button A, observes A's `focusedChild` with a port (synchronous dispatch), moves focus to B, and asserts the global focus pointer already equals B while A is losing focus. Fails on the pre-fix code (pointer is still A), passes after.

- `npx jest test/e2e/SceneGraph.test.js test/extensions/` → 103 passed
- `npm run lint` clean, `npm run prettier:write` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)