### PR TITLE
fix(draw2d): apply blendColor RGB tint at full strength regardless of alpha

### DIFF
--- a/src/core/brsTypes/components/RoBitmap.ts
+++ b/src/core/brsTypes/components/RoBitmap.ts
@@ -261,7 +261,11 @@ export class RoBitmap extends BrsComponent implements BrsValue, BrsDraw2D {
         }) as BrsCanvasContext2D;
         drawImageAtPos(this.canvas, ctx, 0, 0);
         ctx.globalCompositeOperation = "multiply";
-        ctx.fillStyle = rgbaIntToHex(rgba);
+        // Apply the RGB tint at full strength: blendColor's alpha controls the resulting
+        // transparency (handled separately via globalAlpha when blitting), not the tint
+        // strength. Using the color's alpha here would weaken the multiply and lighten the
+        // result, diverging from Roku (e.g. 0x0B001980 must render dark, not near-white).
+        ctx.fillStyle = rgbaIntToHex(rgba, false);
         ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
         ctx.globalCompositeOperation = "destination-in";
         drawImageAtPos(this.canvas, ctx, 0, 0);


### PR DESCRIPTION
## Problem

A `blendColor` with a translucent alpha applied to a Poster (notably 9-patch images) rendered **lighter / closer to white** than on a real Roku. For example `0x0B001980` should produce a dark tint but came out near-white.

## Root cause

`blendColor` is a component-wise multiply tint. In `RoBitmap.getRgbaCanvas` the tint was filled with the **full RGBA** color under `globalCompositeOperation = "multiply"`. Because the fill was semi-transparent (`0x0B001980` → alpha `0x80` ≈ 0.5), canvas compositing weakened the multiply to ~50%, blending the dark result halfway back toward the original.

The blend color's **alpha** is meant to control the resulting **transparency**, not the tint strength — and that transparency is already applied separately via `setContextAlpha`/`globalAlpha` when the tinted canvas is blitted (in both `drawNinePatch` and `drawObjectToComponent`). So the alpha was effectively being applied twice, once incorrectly.

## Fix

Apply the multiply fill at full opacity (`rgbaIntToHex(rgba, false)`) so the RGB tint is full-strength, while transparency continues to be handled downstream via `globalAlpha`. Dark blend colors now render correctly.

## Scope

The change lives in the shared `getRgbaCanvas`, so it corrects all blended bitmaps with a translucent `blendColor` — Poster (including 9-patch), Region, and Bitmap draws — not just the reported case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)