### PR TITLE
feat(scenegraph): harden cross-thread rendezvous (fidelity + reliability)

### DIFF
--- a/src/api/task.ts
+++ b/src/api/task.ts
@@ -73,6 +73,17 @@ function notifyAll(eventName: string, eventData?: any) {
 }
 
 /**
+ * Creates a SharedObject whose failures (overflow / dropped updates) are surfaced as app-visible
+ * errors instead of being silently lost.
+ * @returns A new SharedObject wired to report errors through the task observers.
+ */
+function createSharedObject(): SharedObject {
+    const sharedObject = new SharedObject();
+    sharedObject.onError = (message: string) => notifyAll("error", `[task:api] ${message}`);
+    return sharedObject;
+}
+
+/**
  * Handles task data events from the engine.
  * Starts or stops tasks based on the task state.
  * @param taskData Task data containing state and configuration
@@ -81,7 +92,7 @@ function notifyAll(eventName: string, eventData?: any) {
 export function handleTaskData(taskData: TaskData, currentPayload: AppPayload) {
     if (taskData.state === TaskState.RUN) {
         if (taskData.buffer instanceof SharedArrayBuffer) {
-            const taskBuffer = new SharedObject();
+            const taskBuffer = createSharedObject();
             taskBuffer.setBuffer(taskData.buffer);
             threadSyncToMain.set(taskData.id, taskBuffer);
         }
@@ -109,7 +120,7 @@ function runTask(taskData: TaskData, currentPayload: AppPayload) {
     taskWorker.addEventListener("message", taskCallback);
     tasks.set(taskData.id, taskWorker);
     if (!threadSyncToTask.has(taskData.id)) {
-        threadSyncToTask.set(taskData.id, new SharedObject());
+        threadSyncToTask.set(taskData.id, createSharedObject());
     }
     taskData.buffer = threadSyncToTask.get(taskData.id)?.getBuffer();
     const taskPayload: TaskPayload = {
@@ -229,7 +240,7 @@ export function handleThreadUpdate(threadUpdate: ThreadUpdate, fromTask: boolean
  */
 function updateTask(targetId: number, data: ThreadUpdate) {
     if (!threadSyncToTask.has(targetId)) {
-        threadSyncToTask.set(targetId, new SharedObject());
+        threadSyncToTask.set(targetId, createSharedObject());
     }
     threadSyncToTask.get(targetId)?.waitStore(data, 1);
 }

--- a/src/core/SharedObject.ts
+++ b/src/core/SharedObject.ts
@@ -19,14 +19,20 @@ class SharedObject {
     private maxSize: number;
     private atomicView: Int32Array;
     private isProcessing: boolean = false;
+    /**
+     * Optional sink for failures that would otherwise be silently dropped (buffer overflow, store
+     * timeout). When set, the owner can surface these as app-visible errors instead of losing the
+     * update silently. Defaults to `console.error` when unset.
+     */
+    onError?: (message: string) => void;
 
     /**
      * @param initialSize Optional initial buffer size in bytes (defaults to 32KB).
-     * @param maxSize Optional hard cap for automatic growth (defaults to 3MB).
+     * @param maxSize Optional hard cap for automatic growth (defaults to 16MB).
      */
     constructor(initialSize?: number, maxSize?: number) {
         initialSize = initialSize ?? 32 * 1024; // 32KB default
-        this.maxSize = maxSize ?? 3 * 1024 * 1024; // 3MB default
+        this.maxSize = maxSize ?? 16 * 1024 * 1024; // 16MB default
         this.buffer = new SharedArrayBuffer(initialSize, { maxByteLength: this.maxSize });
         this.view = new Uint8Array(this.buffer);
         this.atomicView = new Int32Array(this.buffer, 0, 2);
@@ -57,6 +63,18 @@ class SharedObject {
      */
     getVersion(): number {
         return Atomics.load(this.atomicView, this.versionIdx);
+    }
+
+    /**
+     * Reports a failure that would otherwise lose data, via `onError` when set, else `console.error`.
+     * @param message Human-readable description of the failure.
+     */
+    private reportError(message: string): void {
+        if (this.onError) {
+            this.onError(message);
+        } else {
+            console.error(message);
+        }
     }
 
     /**
@@ -98,7 +116,7 @@ class SharedObject {
                     if (status === "ok") {
                         this.store(obj);
                     } else {
-                        console.error("[SharedObject] Error storing shared data", status, obj.field);
+                        this.reportError(`[SharedObject] Dropped update for "${obj?.field}" (wait: ${status})`);
                     }
                     this.queue.shift();
                     this.isProcessing = false;
@@ -110,7 +128,7 @@ class SharedObject {
                 this.isProcessing = false;
                 this.processQueue();
             } else {
-                console.error("[SharedObject] Error storing shared data: timeout", obj.field);
+                this.reportError(`[SharedObject] Dropped update for "${obj?.field}" (store timeout)`);
                 this.queue.shift();
                 this.isProcessing = false;
                 this.processQueue();
@@ -127,7 +145,7 @@ class SharedObject {
                 } else if (Date.now() - start < timeout) {
                     setTimeout(checkCondition, 10); // Check every 10ms
                 } else {
-                    console.error("[SharedObject] Error storing shared data: timeout", obj.field);
+                    this.reportError(`[SharedObject] Dropped update for "${obj?.field}" (store timeout)`);
                     this.queue.shift();
                     this.isProcessing = false;
                     this.processQueue();
@@ -171,7 +189,7 @@ class SharedObject {
         try {
             return JSON.parse(serialized);
         } catch (error) {
-            console.error("Error parsing data:", error, serialized);
+            this.reportError(`[SharedObject] Error parsing shared data: ${error}`);
             return {};
         }
     }
@@ -232,7 +250,9 @@ class SharedObject {
      */
     private ensureCapacity(size: number): boolean {
         if (size > this.maxSize) {
-            console.error(`[SharedObject] Buffer is full. Cannot store more data. ${size} > ${this.maxSize}`);
+            this.reportError(
+                `[SharedObject] Update dropped: payload of ${size} bytes exceeds the ${this.maxSize}-byte buffer limit`
+            );
             return false;
         }
         if (size > this.buffer.byteLength) {
@@ -242,7 +262,7 @@ class SharedObject {
                 this.view = new Uint8Array(this.buffer); // Update the view
                 this.atomicView = new Int32Array(this.buffer, 0, 2); // Update atomic offset view
             } catch (e) {
-                console.error("[SharedObject] Error growing buffer:", e);
+                this.reportError(`[SharedObject] Update dropped: failed to grow buffer to ${newSize} bytes: ${e}`);
                 return false;
             }
         }

--- a/src/core/common.ts
+++ b/src/core/common.ts
@@ -427,17 +427,25 @@ export function isThreadUpdate(value: any): value is ThreadUpdate {
     );
 }
 
+/** Monotonic per-process counter ensuring addresses are unique within a thread/worker. */
+let addressSequence = 0;
+
 /**
- * Generates a random 6-character hexadecimal address.
- * @returns A random hex string in uppercase format (e.g., "A1B2C3")
+ * Generates a unique hexadecimal address.
+ *
+ * The address combines a 24-bit random prefix with a monotonic per-process sequence suffix. The
+ * sequence guarantees uniqueness within a single thread/worker, while the random prefix makes
+ * collisions across threads (each of which has its own sequence) astronomically unlikely. This
+ * replaces the previous 24-bit random-only scheme, whose ~16M space risked birthday-paradox
+ * collisions in large, long-lived scenes.
+ * @returns A unique hex string in uppercase format (e.g., "A1B2C3000001").
  */
 export function genHexAddress(): string {
-    const randomInt = Math.floor(Math.random() * (0xffffff + 1));
-    let hexString = randomInt.toString(16);
-    while (hexString.length < 6) {
-        hexString = "0" + hexString;
-    }
-    return hexString.toUpperCase();
+    const random = Math.floor(Math.random() * (0xffffff + 1))
+        .toString(16)
+        .padStart(6, "0");
+    const sequence = (++addressSequence).toString(16).padStart(6, "0");
+    return (random + sequence).toUpperCase();
 }
 
 /* Package File Path Interface

--- a/src/extensions/scenegraph/SGRoot.ts
+++ b/src/extensions/scenegraph/SGRoot.ts
@@ -51,6 +51,17 @@ export class SGRoot {
     private _video?: Video;
     private _dirty: boolean = false;
     private readonly _pendingPorts: RoMessagePort[] = [];
+    /**
+     * When `true`, recently-written fields can be re-read from the local copy for a short window,
+     * skipping a rendezvous (a performance heuristic). Defaults to `false` so that every Task-thread
+     * field get rendezvouses with the owning thread, matching real Roku device behavior.
+     */
+    fastFieldReads: boolean = false;
+    /**
+     * When `true`, each rendezvous logs its action, target, and duration (mirroring the Roku
+     * SceneGraph debug console `logrendezvous` command). Defaults to `false`.
+     */
+    logRendezvous: boolean = false;
 
     get interpreter(): Interpreter | undefined {
         return this._interpreter;

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -298,7 +298,10 @@ export class Node extends RoSGNode implements BrsValue {
         if (this.shouldRendezvous()) {
             if (this.fields.has(key)) {
                 const task = sgRoot.getCurrentThreadTask();
-                if (task?.active && !this.consumeFreshField(key)) {
+                // By default every read of a render-owned field rendezvouses, matching real Roku
+                // behavior ("each dot represents a distinct rendezvous"). The freshFields read-cache
+                // is only consulted in the opt-in `fastFieldReads` performance mode.
+                if (task?.active && !(sgRoot.fastFieldReads && this.consumeFreshField(key))) {
                     task.requestFieldValue(this.syncType, this.address, key);
                 }
             } else {

--- a/src/extensions/scenegraph/nodes/Task.ts
+++ b/src/extensions/scenegraph/nodes/Task.ts
@@ -288,23 +288,30 @@ export class Task extends Node {
         if (!this.taskBuffer || this.threadId < 0) {
             return false;
         }
-        const update: ThreadUpdate = {
+        const requestId = this.syncRequestId++;
+        const request: ThreadUpdate = {
             id: this.threadId,
             action: "get",
             type,
             address,
             key: fieldName,
             value: null,
+            requestId,
         };
-        this.sendThreadUpdate(update);
+        const started = sgRoot.logRendezvous ? Date.now() : 0;
+        this.sendThreadUpdate(request);
         const deadline = Date.now() + timeoutMs;
 
         while (true) {
             const update = this.processThreadUpdate();
-            if (update?.action === "set" && update.type === type && update.key === fieldName) {
-                return true;
-            } else if (update?.action === "nil" && update.type === type && update.key === fieldName) {
-                return false;
+            if (update?.requestId === requestId) {
+                if (update.action === "set") {
+                    this.logRendezvousTiming("get", type, fieldName, started);
+                    return true;
+                } else if (update.action === "nil") {
+                    this.logRendezvousTiming("get", type, fieldName, started);
+                    return false;
+                }
             }
             const remaining = deadline - Date.now();
             if (remaining <= 0) {
@@ -342,23 +349,30 @@ export class Task extends Node {
             return undefined;
         }
         const value = payload ?? null;
-        const update: ThreadUpdate = {
+        const requestId = this.syncRequestId++;
+        const request: ThreadUpdate = {
             id: this.threadId,
             action: "call",
             type,
             address,
             key: methodName,
             value,
+            requestId,
         };
-        this.sendThreadUpdate(update);
+        const started = sgRoot.logRendezvous ? Date.now() : 0;
+        this.sendThreadUpdate(request);
         const deadline = Date.now() + timeoutMs;
 
         while (true) {
             const update = this.processThreadUpdate();
-            if (update?.action === "resp" && update.type === type && update.key === methodName) {
-                return brsValueOf(update.value);
-            } else if (update?.action === "nil" && update.type === type && update.key === methodName) {
-                return undefined;
+            if (update?.requestId === requestId) {
+                if (update.action === "resp") {
+                    this.logRendezvousTiming("call", type, methodName, started);
+                    return brsValueOf(update.value);
+                } else if (update.action === "nil") {
+                    this.logRendezvousTiming("call", type, methodName, started);
+                    return undefined;
+                }
             }
             const remaining = deadline - Date.now();
             if (remaining <= 0) {
@@ -422,14 +436,35 @@ export class Task extends Node {
      * @param requestAck When true (default) the method will wait for an acknowledgement from the main thread confirming the update was processed, otherwise it will fire-and-forget without waiting. This should be false for updates originating from the main thread to avoid deadlocks, and can be true for updates originating from the task thread when the caller needs to ensure the main thread has processed the change before proceeding.
      */
     sendThreadUpdate(update: ThreadUpdate, requestAck: boolean = true) {
-        if (this.inThread && update.action === "set") {
-            update.requestId = requestAck ? this.syncRequestId++ : undefined;
-        } else if (update.action !== "ack") {
-            update.requestId = undefined;
+        const isRequest = update.action === "set" || update.action === "get" || update.action === "call";
+        // Tag outbound requests originating from a task thread with a unique id so the matching
+        // response/ack can be correlated unambiguously. Responses (resp/ack/nil) and render-thread
+        // requests preserve the requestId already present on the update.
+        if (this.inThread && isRequest && requestAck && update.requestId === undefined) {
+            update.requestId = this.syncRequestId++;
         }
         postMessage(update);
-        if (this.inThread && update.requestId !== undefined && update.action !== "ack") {
+        if (this.inThread && update.action === "set" && update.requestId !== undefined) {
+            const started = sgRoot.logRendezvous ? Date.now() : 0;
             this.waitForFieldAck(update);
+            this.logRendezvousTiming("set", update.type, update.key, started);
+        }
+    }
+
+    /**
+     * Logs the duration of a completed rendezvous when `sgRoot.logRendezvous` is enabled, mirroring
+     * the Roku SceneGraph debug console `logrendezvous` command to help identify performance issues.
+     * @param action Rendezvous action performed (`get`, `set`, or `call`).
+     * @param type Sync type domain of the target (`global`, `task`, `scene`, or `node`).
+     * @param key Field or method name involved in the rendezvous.
+     * @param startedMs Timestamp (ms) captured before the rendezvous started.
+     */
+    private logRendezvousTiming(action: string, type: SyncType, key: string, startedMs: number) {
+        if (sgRoot.logRendezvous) {
+            const ms = Date.now() - startedMs;
+            BrsDevice.stdout.write(
+                `debug,[rendezvous] thread ${sgRoot.threadId} ${action} ${type}.${key} on thread ${this.threadId} took ${ms}ms`
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

Phase 1 of a broader effort to bring the SceneGraph cross-thread **rendezvous** mechanism closer to real Roku device behavior, with reliability and observability improvements. This phase does **not** change the broker transport topology (that structural rework is deferred); it tightens correctness and removes silent failure modes along the existing path.

Each change is derived from a deep analysis of the current implementation measured against the Roku reference docs (`external/dev-doc/.../core-concepts/threads.md`).

## Changes

- **Fidelity — every render-owned field read rendezvouses by default.** The `freshFields` read-cache (which let a Task thread read a stale local copy and skip a rendezvous) is now gated behind a new, default-**off** `sgRoot.fastFieldReads` flag. With it off, behavior matches Roku ("each dot represents a distinct rendezvous"); the cache remains available as an explicit performance mode.
- **Reliability — no more silently-dropped updates.** `SharedObject` raised its buffer cap 3 MB → 16 MB (real content trees were exceeding 3 MB) and now reports overflow / store-timeout / parse failures through an `onError` sink instead of `console.error`. The task broker wires that to an app-visible `"error"` event.
- **Reliability — responses correlated by `requestId`.** Rendezvous get/call/set responses were matched by `(action, type, key)`, which could be falsely satisfied by an interleaved unrelated update of the same field. Requests are now tagged with a unique `requestId` and responses preserve it, so correlation is unambiguous.
- **Reliability — collision-resistant node addresses.** `genHexAddress` replaces the 24-bit random-only scheme (~16M space, birthday-paradox risk in large/long-lived scenes) with a random prefix + monotonic per-process sequence.
- **Observability — rendezvous timing log.** A default-off `sgRoot.logRendezvous` flag logs each get/set/call rendezvous and its duration in ms, mirroring Roku's `logrendezvous` SceneGraph debug command.

## Notes

- An address→node index was prototyped to make `resolveNode` O(1), but it was **reverted**: reconstructed/serialized node copies share an address with their live counterpart (`Serializer` `setAddress`), so the index could resolve to a transient copy and route a field set to the wrong object — causing a render-thread observer to miss an event (e.g. a screen failing to restore after video playback). A correctness-safe index belongs with the larger transport rework, so the authoritative tree-walk resolution is retained here.

## Testing

- `npm run lint` — clean
- `npm run prettier:write` — applied
- `npm run build:cli` / `build:sg` / `build:api` — all build
- `npm test` — 112 suites, 1663 passed, 2 todo, 177 snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)