### PR TITLE
feat(scenegraph): finalize direct render→task rendezvous (Phase 3)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -163,7 +163,7 @@ Because a node's authoritative copy lives on its owner thread, reading/writing a
 - **Crossing into a node sends ownership**: a `Node` value passed from a task to the render thread is re-owned (`setOwner(0)`) so subsequent access from the task rendezvouses back.
 - **Task startup** — when a Task's `control` becomes `"run"`, `checkTaskRun` posts a `TaskData` (with the shared buffer, serialized `m`, render-thread id, `tmp:`/`cachefs:` volumes). The core spins up a worker, which calls the extension's `execTask` → `initializeTask` to rebuild the node tree on the new thread and invoke the task function. The extension's `tick` hook drains incoming thread updates each iteration via `task.processThreadUpdate()`.
 
-See `docs/extensions.md` and `packages/scenegraph/README.md` for the consumer-facing view.
+See `docs/extensions.md` and `packages/scenegraph/README.md` for the consumer-facing view, and `docs/scenegraph-rendezvous.md` for the rendezvous design (broker → direct render→task channel) and its performance/reliability/memory/fidelity analysis.
 
 ## CLI
 
@@ -179,7 +179,7 @@ See `docs/extensions.md` and `packages/scenegraph/README.md` for the consumer-fa
 
 ## Documentation
 
-`docs/` is the source of truth for usage: `build-from-source.md`, `integrating.md`, `engine-api.md`, `customization.md`, `run-as-cli.md`, `using-node-library.md`, `extensions.md`, `remote-control.md`, `limitations.md`, `contributing.md`.
+`docs/` is the source of truth for usage: `build-from-source.md`, `integrating.md`, `engine-api.md`, `customization.md`, `run-as-cli.md`, `using-node-library.md`, `extensions.md`, `scenegraph-rendezvous.md`, `remote-control.md`, `limitations.md`, `contributing.md`.
 
 ## Roku reference documentation (`external/dev-doc` submodule)
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -29,6 +29,8 @@ registerExtension(() => new MyExtension());
 
 The SceneGraph runtime ships as a standalone extension located under `packages/scenegraph`. It owns the XML component parser, `RoSGScreen`, nodes, and task execution helpers.
 
+For how `Task` nodes read and write render‑owned nodes across threads — the direct render→task rendezvous channel and its design rationale — see [`scenegraph-rendezvous.md`](./scenegraph-rendezvous.md).
+
 ### Browser integrations
 
 1. Ship `brs.worker.js`, `brs.api.js`, and `brs-sg.js` together under the `lib/` folder.

--- a/docs/scenegraph-rendezvous.md
+++ b/docs/scenegraph-rendezvous.md
@@ -1,0 +1,211 @@
+# SceneGraph Cross‑Thread Rendezvous
+
+This document explains how brs‑engine implements the SceneGraph **cross‑thread rendezvous** — the
+mechanism that lets a `Task` thread read and write nodes owned by the render thread — and how the
+implementation evolved from a **main‑thread broker** relay to the current **direct render→task**
+channel. It closes with an analysis of the change across performance, reliability, memory, and
+fidelity to real Roku behavior.
+
+> Audience: contributors working on `src/extensions/scenegraph/` and `src/api/task.ts`. For the
+> consumer‑facing view of the SceneGraph extension see [`extensions.md`](./extensions.md).
+
+## Background: threads, ownership, and rendezvous
+
+SceneGraph apps run BrightScript on multiple threads, mirroring a real Roku device:
+
+- **Render thread** — owns the `Scene`, `m.global`, and every `Task` node; renders the display.
+  In the engine this is the worker running `brs.worker.js` with thread id `0`.
+- **Task threads** — each running `Task` node executes its `functionName` on a dedicated worker
+  (thread id `> 0`) for blocking work (network, file I/O, parsing).
+- **Main thread** — the page/host. It runs **no interpreter**; it owns the canvas, audio/video,
+  and input, and historically also acted as the message **broker** between workers.
+
+Every node has a single **owning thread**. Reading or writing a node you don't own must
+**rendezvous**: a *synchronous, blocking* request to the owner that returns a value as if the call
+had executed locally. On a real device the render thread serves these requests directly; Roku's
+spec notes that *each* field access on a render‑owned node is "a distinct rendezvous."
+
+The engine implements rendezvous with Web Workers and a `SharedArrayBuffer` mailbox
+(`src/core/SharedObject.ts`): a single‑slot buffer with an `[length, version]` header and a
+JSON payload, coordinated with `Atomics.wait`/`waitAsync`/`notify`.
+
+## The original solution: a main‑thread broker
+
+In the original design, **neither worker held a reference to the other's buffer**. Each task had
+two `SharedObject`s, both owned by the main‑thread broker (`src/api/task.ts`):
+
+- `threadSyncToMain` — the render thread's inbound buffer (task → render).
+- `threadSyncToTask` — the task thread's inbound buffer (render → task).
+
+Every cross‑thread message was relayed by the broker:
+
+```
+TASK→RENDER request:  task ──postMessage──▶ main thread (broker) ──SAB──▶ render
+RENDER→TASK response: render ──postMessage──▶ main thread (broker) ──SAB──▶ task
+```
+
+A single rendezvous round‑trip therefore required the **main‑thread event loop to be free twice**,
+and each payload was encoded up to **three times**: structured‑clone over `postMessage`, then
+`JSON.stringify` into the SAB, then `JSON.parse` on receipt. The `SharedArrayBuffer` was used only
+to *wake* the receiver, not as the actual transport.
+
+This worked and was broadly correct, but it diverged from the device (where the render thread
+serves requests directly) and made the main thread a latency, jitter, and contention bottleneck on
+the rendezvous data path.
+
+### Hardening that preceded the structural change
+
+Before removing the broker, several fidelity/reliability fixes landed and are retained in the
+final design:
+
+- **`requestId`‑correlated responses** — every get/call/set response carries the originating
+  request's id, so responses can never be mismatched under interleaving.
+- **Device‑accurate timeouts** — a rendezvous that is not served within the timeout raises an
+  `ExecutionTimeout` runtime error (mirroring a device terminating an app on a blocked render
+  thread) instead of silently returning `invalid`/`false`.
+- **`roRenderThreadQueue`** — the OS 15 non‑blocking task→render messaging API.
+- **Faithful node‑field serialization** — fields holding `invalid` retain their declared type when
+  crossing threads.
+- **`freshFields` gated behind `fastFieldReads`** — by default every render‑owned field read
+  rendezvouses, matching the device rule, instead of returning a locally cached value.
+
+## The final solution: a direct render→task channel
+
+The key realization is that `SharedArrayBuffer` + `Atomics` connect **two worker threads directly**
+— the main thread does not need to be involved in the data path. The final design gives the render
+thread dedicated buffers it writes **straight into the task worker**, removing the broker hop in the
+render→task direction.
+
+Each running task now has **three** `SharedObject`s, all created on the render‑thread `Task`
+instance when the task activates (`Task.ensureDirectBuffers`) and handed to the task worker via
+`TaskData`:
+
+| Buffer | Direction | Carries | Writer → Reader |
+| --- | --- | --- | --- |
+| `taskBuffer` (`threadSyncToMain`) | task → render | rendezvous **requests** (`get`/`set`/`call`), `roRenderThreadQueue` posts | task → *(broker)* → render |
+| `directBuffer` | render → task | rendezvous **responses** (`set`/`resp`/`ack`/`nil`) | render → task (direct) |
+| `fanoutBuffer` | render → task | **observed‑field fan‑out** + cross‑task propagation | render → task (direct) |
+
+Resulting data paths:
+
+```
+TASK→RENDER request:   task ──postMessage──▶ main thread (broker) ──SAB──▶ render   (unchanged)
+RENDER→TASK response:  render ──SAB(directBuffer)──▶ task                            (direct)
+RENDER→TASK fan-out:   render ──SAB(fanoutBuffer)──▶ task                            (direct)
+```
+
+Two render‑thread constraints shaped the design:
+
+1. **Responses are written synchronously.** When the render serves a request, it writes the
+   response straight into `directBuffer` with `store()` and the blocked task wakes via `Atomics`.
+2. **Fan‑out is queued, then flushed.** The render worker **busy‑waits to enforce its frame rate**
+   (`RoSGScreen`) and does not yield its event loop mid‑frame, so it cannot rely on asynchronous
+   writes. Render‑side field fan‑out is enqueued (`fanoutQueue`) and drained **synchronously** into
+   the single‑slot `fanoutBuffer` during `processTasks` — one update per free slot, the rest stay
+   queued for the next pass. This is non‑blocking and lossless without a lock‑free ring buffer.
+
+**Cross‑task propagation** (one task setting a `global`/`scene`/`node` field that another task
+observes) is performed by the render thread directly: when it applies a task's set, it fans the new
+value out to the *other* observing tasks, excluding the originator. Per‑task (`task`‑type) fields
+are **never** cross‑fanned — they are private to one task — matching the broker's original
+`type !== "task"` rule.
+
+The **task→render request direction still goes through the broker**: the task `postMessage`s the
+request and the broker writes it into `threadSyncToMain` to wake the render thread. Making that
+direction direct as well (plus a ring‑buffer protocol and single‑copy/msgpack encoding) is the
+remaining future step.
+
+### Reliability hardening in the final design
+
+Moving work onto the render thread made it essential that task‑servicing can never destabilize the
+render loop:
+
+- **Per‑task fault isolation** — `processTasks` snapshots the task list and wraps each task's
+  servicing in try/catch, so a fault handling one task cannot tear down the render thread (which
+  would stall every rendezvous and silently drop in‑flight updates).
+- **Fan‑out flush resilience** — a non‑serializable payload is dropped and logged rather than
+  thrown into the render loop.
+- **Ownership preservation** — render‑side fan‑out no longer re‑owns the node it sends
+  (`setOwner(0)` is only applied when a node genuinely crosses task → render), so fanning a value
+  out can't corrupt the live render‑owned node tree.
+- **Teardown safety** — `SharedObject.dispose()` cancels pending `Atomics` waits when a task is
+  torn down, so a late timeout from a terminated app can't surface a stale "dropped update" error
+  against the next app to run.
+- **Diagnostics** — dropped‑update messages identify the exact update (`{id action type.key}`) and
+  buffer (`toMain`/`toTask`), and a broker warning fires if a render→task fan‑out ever leaks back
+  onto the broker path.
+
+## Analysis: final vs. broker
+
+The comparison below is the **direct render→task** design against the original **broker‑relay**
+design (both share the `requestId`, timeout, `roRenderThreadQueue`, and serialization work listed
+above).
+
+### Performance
+
+| | Broker relay | Direct render→task |
+| --- | --- | --- |
+| Render→task hops | render → **main thread** → task (2 event‑loop hops) | render → task (0 intermediate hops) |
+| Encodings per message | up to 3: structured‑clone + `JSON.stringify` + `JSON.parse` | 2: `JSON.stringify` + `JSON.parse` |
+| Main‑thread load | every response/fan‑out occupies the page event loop | page uninvolved; freed for UI/input/audio/video |
+
+- Lower and **more consistent latency and jitter** on responses and fan‑out, since delivery no
+  longer waits for the main thread to be free twice.
+- One fewer serialization per render→task message (no structured clone) and no main‑thread
+  contention — most noticeable for chatty tasks and large content‑node transfers.
+- Per‑message encoding is still JSON; single‑copy / msgpack encoding remains future work, so the
+  raw encoding cost per message is unchanged.
+
+### Reliability
+
+- The broker's single‑slot relay is no longer in the render→task path, so it cannot drop those
+  updates under back‑pressure.
+- Failures while servicing a task are **contained and observable** (fault isolation, flush
+  resilience, precise diagnostics) instead of fatal to the render thread.
+- The ownership‑preservation and `task`‑type cross‑fan‑exclusion fixes remove a class of
+  node‑tree‑corruption bugs that the render‑side propagation could otherwise introduce.
+- Net: fewer silent‑loss paths and no new fatal paths versus the broker design.
+
+### Memory usage
+
+- **Slightly higher baseline:** ~3 growable `SharedArrayBuffer`s per active task
+  (`taskBuffer` + `directBuffer` + `fanoutBuffer`) vs. ~2 in the broker design
+  (`threadSyncToMain` + `threadSyncToTask`) — one extra buffer per task (each starts at 32 KB with
+  the same growth cap).
+- **Lower transient/peak:** the main thread no longer holds a relayed copy of every payload, so
+  large node trees are not double‑buffered through the page.
+- A small render‑side JS fan‑out queue is added, bounded by how quickly a task drains its buffer.
+- Overall a modest fixed per‑task cost traded for less peak duplication during big transfers.
+
+### Adherence to Roku specs
+
+- On a real device the render thread **serves rendezvous directly**; there is no page/broker
+  relaying between render and task threads. The direct render→task channel is **architecturally
+  closer to the device model**.
+- Reduced, more uniform latency also makes cross‑thread timing behave more like hardware.
+- The design retains device‑accurate timeout semantics (`ExecutionTimeout` rather than a silent
+  `invalid`).
+- **Partial:** only the render→task direction is direct today; task→render requests still traverse
+  the broker, so this is a step toward the device model rather than the complete picture.
+
+## Remaining gaps / future work
+
+- Make the **task→render request** direction direct as well (currently broker‑relayed).
+- Replace the single‑slot mailbox with a **ring‑buffer / `requestId`‑correlated** protocol to allow
+  multiple in‑flight messages without head‑of‑line blocking.
+- Carry payloads **once** in the SAB and switch node‑tree encoding to **msgpack** (already a
+  dependency) to remove the remaining JSON encode/decode cost.
+- Task threading/rendezvous remains **browser‑only**; the Node CLI host does not yet spawn task
+  workers.
+
+## Key source references
+
+- `src/extensions/scenegraph/nodes/Task.ts` — rendezvous transport, request/response/ack, direct
+  buffers (`ensureDirectBuffers`, `directBuffer`, `fanoutBuffer`, `flushFanout`).
+- `src/extensions/scenegraph/nodes/Node.ts` — `shouldRendezvous`, `rendezvousSet`/`rendezvousCall`,
+  ownership (`setOwner`), `fanOutFieldToObservingTasks`.
+- `src/extensions/scenegraph/SGRoot.ts` — `processTasks` (drain + flush + fault isolation), thread
+  map, render‑loop integration.
+- `src/api/task.ts` — main‑thread broker: task spawn, `threadSyncToMain` relay for task→render
+  requests, teardown/disposal.
+- `src/core/SharedObject.ts` — the growable `SharedArrayBuffer` mailbox.

--- a/src/api/task.ts
+++ b/src/api/task.ts
@@ -80,9 +80,9 @@ function notifyAll(eventName: string, eventData?: any) {
  * errors instead of being silently lost.
  * @returns A new SharedObject wired to report errors through the task observers.
  */
-function createSharedObject(): SharedObject {
+function createSharedObject(label: string = ""): SharedObject {
     const sharedObject = new SharedObject();
-    sharedObject.onError = (message: string) => notifyAll("error", `[task:api] ${message}`);
+    sharedObject.onError = (message: string) => notifyAll("error", `[task:api]${label ? ` ${label}` : ""} ${message}`);
     return sharedObject;
 }
 
@@ -95,7 +95,7 @@ function createSharedObject(): SharedObject {
 export function handleTaskData(taskData: TaskData, currentPayload: AppPayload) {
     if (taskData.state === TaskState.RUN) {
         if (taskData.buffer instanceof SharedArrayBuffer) {
-            const taskBuffer = createSharedObject();
+            const taskBuffer = createSharedObject(`toMain[${taskData.id}]`);
             taskBuffer.setBuffer(taskData.buffer);
             threadSyncToMain.set(taskData.id, taskBuffer);
         }
@@ -129,7 +129,7 @@ function runTask(taskData: TaskData, currentPayload: AppPayload) {
         taskData.buffer = taskData.fanout;
     } else {
         if (!threadSyncToTask.has(taskData.id)) {
-            threadSyncToTask.set(taskData.id, createSharedObject());
+            threadSyncToTask.set(taskData.id, createSharedObject(`toTask[${taskData.id}]`));
         }
         taskData.buffer = threadSyncToTask.get(taskData.id)?.getBuffer();
     }
@@ -265,8 +265,17 @@ export function handleThreadUpdate(threadUpdate: ThreadUpdate, fromTask: boolean
  * @param data Thread update data with field changes
  */
 function updateTask(targetId: number, data: ThreadUpdate) {
+    if (directMode) {
+        // In direct mode the render thread owns the render→task channel; the broker has no buffer the
+        // task actually reads. Routing here means a render-side fan-out escaped the direct path and
+        // will be dropped — surface it loudly so the offending update is identifiable.
+        notifyAll(
+            "warning",
+            `[task:api] Direct-mode fan-out leaked to broker for task ${targetId}: {${data.action} ${data.type}.${data.key}} — update will not reach the task`
+        );
+    }
     if (!threadSyncToTask.has(targetId)) {
-        threadSyncToTask.set(targetId, createSharedObject());
+        threadSyncToTask.set(targetId, createSharedObject(`toTask[${targetId}]`));
     }
     threadSyncToTask.get(targetId)?.waitStore(data, 1);
 }

--- a/src/api/task.ts
+++ b/src/api/task.ts
@@ -29,6 +29,9 @@ const threadSyncToTask: Map<number, SharedObject> = new Map();
 const threadSyncToMain: Map<number, SharedObject> = new Map();
 let sharedBuffer: ArrayBufferLike;
 let brsWrkLib: string;
+// Phase 3b: when a task is started with a dedicated fan-out buffer, the render thread delivers
+// fan-out and cross-task propagation directly, so the broker stops relaying those.
+let directMode: boolean = false;
 let inDebugLib: boolean = false;
 /// #if DEBUG
 inDebugLib = true;
@@ -119,10 +122,17 @@ function runTask(taskData: TaskData, currentPayload: AppPayload) {
     const taskWorker = new Worker(brsWrkLib);
     taskWorker.addEventListener("message", taskCallback);
     tasks.set(taskData.id, taskWorker);
-    if (!threadSyncToTask.has(taskData.id)) {
-        threadSyncToTask.set(taskData.id, createSharedObject());
+    if (taskData.fanout instanceof SharedArrayBuffer) {
+        // Phase 3b (direct mode): the render thread owns the render→task fan-out buffer; forward it
+        // to the task as its read buffer. The broker does not relay fan-out or cross-task updates.
+        directMode = true;
+        taskData.buffer = taskData.fanout;
+    } else {
+        if (!threadSyncToTask.has(taskData.id)) {
+            threadSyncToTask.set(taskData.id, createSharedObject());
+        }
+        taskData.buffer = threadSyncToTask.get(taskData.id)?.getBuffer();
     }
-    taskData.buffer = threadSyncToTask.get(taskData.id)?.getBuffer();
     const taskPayload: TaskPayload = {
         device: currentPayload.device,
         manifest: currentPayload.manifest,
@@ -174,6 +184,7 @@ export function resetTasks() {
     tasks.clear();
     threadSyncToTask.clear();
     threadSyncToMain.clear();
+    directMode = false;
 }
 
 /**
@@ -228,8 +239,13 @@ function taskCallback(event: MessageEvent) {
  */
 export function handleThreadUpdate(threadUpdate: ThreadUpdate, fromTask: boolean = false) {
     if (fromTask) {
-        // Update main thread buffer
+        // Update main thread buffer (relay the request/post to the render thread).
         threadSyncToMain.get(threadUpdate.id)?.waitStore(threadUpdate, 1);
+        // Phase 3b: in direct mode the render thread performs cross-task propagation itself, so the
+        // broker must not also fan a task's set out to the other tasks (which would double-deliver).
+        if (directMode) {
+            return;
+        }
     }
     if (threadUpdate.id > 0 && !fromTask) {
         updateTask(threadUpdate.id, threadUpdate);

--- a/src/core/SharedObject.ts
+++ b/src/core/SharedObject.ts
@@ -9,6 +9,21 @@
  * SharedObject serializes JSON payloads or raw buffers into a resizable SharedArrayBuffer
  * to coordinate state between the host and worker threads via Atomics.
  */
+/**
+ * Builds a concise human-readable description of a dropped payload for diagnostics. Thread updates
+ * carry id/action/type/key; anything else falls back to its JSON shape.
+ * @param obj The payload that could not be delivered.
+ * @returns A short label identifying the payload.
+ */
+function describeUpdate(obj: any): string {
+    if (obj && typeof obj === "object" && "action" in obj) {
+        return `{id:${obj.id} ${obj.action} ${obj.type}.${obj.key}${
+            obj.requestId !== undefined ? ` #${obj.requestId}` : ""
+        }}`;
+    }
+    return `"${typeof obj}"`;
+}
+
 class SharedObject {
     private readonly offset = 8;
     private readonly queue: { obj: any; version: number; timeout: number }[] = [];
@@ -137,7 +152,7 @@ class SharedObject {
                     if (status === "ok") {
                         this.store(obj);
                     } else {
-                        this.reportError(`[SharedObject] Dropped update for "${obj?.field}" (wait: ${status})`);
+                        this.reportError(`[SharedObject] Dropped update ${describeUpdate(obj)} (wait: ${status})`);
                     }
                     this.queue.shift();
                     this.isProcessing = false;
@@ -170,7 +185,7 @@ class SharedObject {
                 } else if (Date.now() - start < timeout) {
                     setTimeout(checkCondition, 10); // Check every 10ms
                 } else {
-                    this.reportError(`[SharedObject] Dropped update for "${obj?.field}" (store timeout)`);
+                    this.reportError(`[SharedObject] Dropped update ${describeUpdate(obj)} (store timeout)`);
                     this.queue.shift();
                     this.isProcessing = false;
                     this.processQueue();

--- a/src/core/common.ts
+++ b/src/core/common.ts
@@ -374,6 +374,8 @@ export type TaskData = {
     buffer?: SharedArrayBuffer;
     /** Phase 3a: dedicated buffer for direct render→task rendezvous responses (bypasses the broker). */
     directToTask?: SharedArrayBuffer;
+    /** Phase 3b: dedicated buffer for direct render→task fan-out of observed-field updates. */
+    fanout?: SharedArrayBuffer;
     tmp?: SharedArrayBuffer;
     cacheFS?: SharedArrayBuffer;
     m?: any;

--- a/src/core/common.ts
+++ b/src/core/common.ts
@@ -57,12 +57,6 @@ export interface DeviceInfo {
     debugOnCrash?: boolean;
     corsProxy?: string;
     extensions?: Map<SupportedExtension, string>;
-    /**
-     * Experimental (Phase 3a): when true, SceneGraph rendezvous responses are delivered directly
-     * from the render thread to the requesting Task thread over a dedicated SharedArrayBuffer,
-     * bypassing the main-thread broker. Defaults to false (responses relayed via the broker).
-     */
-    rendezvousDirect?: boolean;
 }
 
 export enum LogLevel {
@@ -158,7 +152,6 @@ export const DefaultDeviceInfo: DeviceInfo = {
     tmpVolSize: 32 * 1024 * 1024, // 32 MB
     cacheFSVolSize: 32 * 1024 * 1024, // 32 MB
     logLevel: LogLevel.Warning,
-    rendezvousDirect: false, // Experimental (Phase 3a): direct render→task rendezvous responses
 };
 
 // Valid Closed Captions Options

--- a/src/extensions/scenegraph/SGRoot.ts
+++ b/src/extensions/scenegraph/SGRoot.ts
@@ -380,6 +380,8 @@ export class SGRoot {
             if (task?.active) {
                 task.checkTaskRun();
             }
+            // Phase 3b: drain any queued direct fan-out into the task's buffer (render thread only).
+            task?.flushFanout();
         }
         return updates;
     }

--- a/src/extensions/scenegraph/SGRoot.ts
+++ b/src/extensions/scenegraph/SGRoot.ts
@@ -79,13 +79,6 @@ export class SGRoot {
      * `ExecutionTimeout` runtime error instead of silently returning `invalid`. Defaults to 10s.
      */
     rendezvousTimeout: number = 10000;
-    /**
-     * Experimental (Phase 3a): when true, the render thread delivers rendezvous responses directly to
-     * the requesting Task thread over a dedicated SharedArrayBuffer, bypassing the main-thread broker.
-     * Set from `DeviceInfo.rendezvousDirect`. Requests, fan-out, and cross-task propagation still use
-     * the broker. Defaults to false.
-     */
-    directRendezvous: boolean = false;
     /** roRenderThreadQueue instances on the render thread, keyed by node address, drained each frame. */
     private readonly _renderQueues: Map<string, RenderThreadQueue> = new Map();
 
@@ -188,7 +181,6 @@ export class SGRoot {
      */
     setInterpreter(interpreter: Interpreter) {
         this._interpreter = interpreter;
-        this.directRendezvous = BrsDevice.deviceInfo.rendezvousDirect ?? false;
         const resolutions = interpreter.manifest.get("ui_resolutions");
         if (resolutions?.length) {
             const resArray = resolutions.split(",");
@@ -374,14 +366,25 @@ export class SGRoot {
      */
     processTasks(): boolean {
         let updates = false;
-        for (const thread of this._threads.values()) {
+        // Snapshot the thread list so a handler that creates/stops a task mid-iteration can't disturb
+        // the loop, and isolate each task: a fault while serving one task must never tear down the
+        // render thread (which would stall every rendezvous and silently drop in-flight updates).
+        for (const thread of [...this._threads.values()]) {
             const task = thread.task;
-            updates = task?.processThreadUpdate() !== undefined || updates;
-            if (task?.active) {
-                task.checkTaskRun();
+            try {
+                updates = task?.processThreadUpdate() !== undefined || updates;
+                if (task?.active) {
+                    task.checkTaskRun();
+                }
+                // Phase 3b: drain any queued direct fan-out into the task's buffer (render thread only).
+                task?.flushFanout();
+            } catch (err: any) {
+                BrsDevice.stderr.write(
+                    `error,[sg] Error processing task ${task?.nodeSubtype} (thread ${task?.threadId}): ${
+                        err?.message ?? err
+                    }${err?.stack ? `\n${err.stack}` : ""}`
+                );
             }
-            // Phase 3b: drain any queued direct fan-out into the task's buffer (render thread only).
-            task?.flushFanout();
         }
         return updates;
     }

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -1648,10 +1648,29 @@ export class Node extends RoSGNode implements BrsValue {
             task?.syncRemoteField(fieldName, value, this.syncType, this.address);
             this.changed = false;
         } else if (!sgRoot.inTaskThread()) {
-            for (const task of sgRoot.threadTasks) {
-                if (task.active && field.isPortObserved(task)) {
-                    task.syncRemoteField(fieldName, value, this.syncType, this.address);
-                }
+            this.fanOutFieldToObservingTasks(fieldName);
+        }
+    }
+
+    /**
+     * Fans a field value out (from the render thread) to every Task thread observing it via a port.
+     * Used both for the render thread's own field sets and to propagate a set the render applied on
+     * behalf of a Task to the *other* observing tasks (cross-task propagation).
+     * @param fieldName Field whose current value should be delivered.
+     * @param excludeThreadId Task thread id to skip (e.g. the originating task); -1 skips none.
+     */
+    fanOutFieldToObservingTasks(fieldName: string, excludeThreadId: number = -1) {
+        if (sgRoot.inTaskThread()) {
+            return;
+        }
+        const field = this.fields.get(fieldName.toLowerCase());
+        if (!field) {
+            return;
+        }
+        const value = field.getValue(false);
+        for (const task of sgRoot.threadTasks) {
+            if (task.active && task.threadId !== excludeThreadId && field.isPortObserved(task)) {
+                task.syncRemoteField(fieldName, value, this.syncType, this.address);
             }
         }
     }

--- a/src/extensions/scenegraph/nodes/Task.ts
+++ b/src/extensions/scenegraph/nodes/Task.ts
@@ -41,19 +41,19 @@ export class Task extends Node {
     /** Shared buffer used to communicate updates between host and task thread (via the broker). */
     private taskBuffer?: SharedObject;
     /**
-     * Phase 3a: dedicated buffer carrying rendezvous responses directly between the render thread
-     * (writer) and this Task thread (reader), bypassing the main-thread broker. Present only when
-     * `DeviceInfo.rendezvousDirect` is enabled; otherwise responses arrive on `taskBuffer`.
+     * Dedicated buffer carrying rendezvous responses directly between the render thread (writer) and
+     * this Task thread (reader), bypassing the main-thread broker. Allocated on the render-thread
+     * instance when the task activates.
      */
     private directBuffer?: SharedObject;
     /**
-     * Phase 3b: render-side write handle for the dedicated fan-out buffer (render → this task).
-     * Present only on the render-thread instance when direct rendezvous is enabled.
+     * Render-side write handle for the dedicated fan-out buffer (render → this task) used to deliver
+     * observed-field updates directly. Present only on the render-thread instance.
      */
     private fanoutBuffer?: SharedObject;
     /**
-     * Phase 3b: render-side queue of pending fan-out updates for this task, flushed synchronously
-     * into `fanoutBuffer` during `processTasks` (the render thread can't rely on async writes — it
+     * Render-side queue of pending fan-out updates for this task, flushed synchronously into
+     * `fanoutBuffer` during `processTasks` (the render thread can't rely on async writes — it
      * busy-waits for FPS and doesn't yield its event loop mid-frame).
      */
     private readonly fanoutQueue: ThreadUpdate[] = [];
@@ -188,7 +188,7 @@ export class Task extends Node {
      * @returns True if acknowledgement was received, false on timeout.
      */
     private waitForFieldAck(update: ThreadUpdate, timeoutMs: number = sgRoot.rendezvousTimeout) {
-        // Phase 3a: responses (including acks) arrive on the direct buffer when enabled, else taskBuffer.
+        // Responses (including acks) arrive on the dedicated direct buffer; taskBuffer is the fallback.
         const responseBuffer = this.directBuffer ?? this.taskBuffer;
         if (!responseBuffer || update.requestId === undefined) {
             return false;
@@ -235,11 +235,35 @@ export class Task extends Node {
     private activateTask() {
         this.active = true;
         if (this.inThread) return;
+        // Create the direct render→task buffers up front — before any field can be synced — so every
+        // render-side fan-out takes the direct path. Done lazily in checkTaskRun they would miss the
+        // window between activation and the first processTasks pass, where a field set (e.g. a Task's
+        // `request`) would fall back to the broker, which in direct mode has no read buffer for the
+        // task and silently drops the update.
+        this.ensureDirectBuffers();
         // In main thread add this task to sgRoot. (in a task thread it's added by `loadTaskData()`)
         if (this.threadId < 0) {
             sgRoot.addTask(this);
         } else if (sgRoot.getThreadTask(this.threadId) !== this) {
             sgRoot.setThread(this.threadId, this.address, this);
+        }
+    }
+
+    /**
+     * Allocates the dedicated render→task rendezvous buffers (direct response + observed-field
+     * fan-out) so the render thread delivers them straight to the Task thread without a main-thread
+     * relay hop. Idempotent and render-thread only.
+     */
+    private ensureDirectBuffers() {
+        if (this.inThread || this.fanoutBuffer) {
+            return;
+        }
+        this.directBuffer = new SharedObject();
+        this.fanoutBuffer = new SharedObject();
+        if (sgRoot.logRendezvous) {
+            BrsDevice.stdout.write(
+                `debug,[rendezvous] thread ${sgRoot.threadId} allocated direct buffers for task ${this.nodeSubtype} (thread ${this.threadId})`
+            );
         }
     }
 
@@ -328,7 +352,13 @@ export class Task extends Node {
         }
         const value = fieldValue instanceof Node ? fromSGNode(fieldValue, true) : jsValueOf(fieldValue);
         if (fieldValue instanceof Node) {
-            fieldValue.setOwner(0); // Once the Node is sent to the Render thread, it's forever owned by it
+            // Re-own to the render thread only when the node actually crosses task → render (a task
+            // setting a field). On the render side this is a fan-out (render → task): the node stays
+            // render-authoritative and the task receives a serialized copy, so mutating its ownership
+            // here would corrupt the live node tree (setOwner recurses into children).
+            if (this.inThread) {
+                fieldValue.setOwner(0); // Once the Node is sent to the Render thread, it's forever owned by it
+            }
             fieldValue.changed = false;
         }
         const update: ThreadUpdate = {
@@ -343,7 +373,19 @@ export class Task extends Node {
         // instead of relaying it through the main-thread broker.
         if (this.fanoutBuffer && !this.inThread) {
             this.fanoutQueue.push(update);
+            if (sgRoot.logRendezvous) {
+                BrsDevice.stdout.write(
+                    `debug,[rendezvous] thread ${sgRoot.threadId} queued fan-out ${type}.${key} -> task thread ${this.threadId} (queue ${this.fanoutQueue.length})`
+                );
+            }
             return;
+        }
+        if (sgRoot.logRendezvous) {
+            BrsDevice.stdout.write(
+                `debug,[rendezvous] thread ${sgRoot.threadId} broker fan-out ${type}.${key} -> task thread ${
+                    this.threadId
+                } (inThread=${this.inThread} fanoutBuffer=${!!this.fanoutBuffer})`
+            );
         }
         this.sendThreadUpdate(update);
     }
@@ -358,7 +400,24 @@ export class Task extends Node {
             return;
         }
         while (this.fanoutQueue.length > 0 && this.fanoutBuffer.getVersion() === 0) {
-            this.fanoutBuffer.store(this.fanoutQueue.shift());
+            const update = this.fanoutQueue.shift();
+            try {
+                this.fanoutBuffer.store(update);
+                if (sgRoot.logRendezvous) {
+                    BrsDevice.stdout.write(
+                        `debug,[rendezvous] thread ${sgRoot.threadId} flushed fan-out ${update?.type}.${update?.key} -> task thread ${this.threadId} (queue ${this.fanoutQueue.length})`
+                    );
+                }
+            } catch (err: any) {
+                // A non-serializable payload (e.g. a value with a cycle) must never propagate out of
+                // here: on the render thread this runs inside the render loop, so a throw would stall
+                // every rendezvous. Drop just this update and keep draining the rest.
+                BrsDevice.stderr.write(
+                    `error,[task:${sgRoot.threadId}] Dropped fan-out ${update?.type}.${update?.key} to thread ${
+                        this.threadId
+                    }: ${err?.message ?? err}`
+                );
+            }
         }
     }
 
@@ -503,12 +562,9 @@ export class Task extends Node {
         }
         if (!this.started) {
             this.taskBuffer = new SharedObject();
-            // Phase 3a/3b: when enabled, create dedicated render→task buffers (responses + fan-out)
-            // so the render thread delivers them directly without a main-thread relay hop.
-            if (sgRoot.directRendezvous) {
-                this.directBuffer = new SharedObject();
-                this.fanoutBuffer = new SharedObject();
-            }
+            // Direct render→task buffers (responses + fan-out) are normally allocated at activation;
+            // ensure they exist here too in case the task was started without going through activate.
+            this.ensureDirectBuffers();
             const taskData: TaskData = {
                 id: this.threadId,
                 name: this.nodeSubtype,
@@ -665,9 +721,17 @@ export class Task extends Node {
         }
         node.markFieldFresh(update.key);
         node.setValue(update.key, value, false, undefined, false);
-        // Phase 3b: in direct mode the broker no longer blind-propagates a task's set to other tasks,
-        // so the render fans it out (targeted to observers, excluding the originator) on apply.
-        if (this.fanoutBuffer && !this.inThread) {
+        if (sgRoot.logRendezvous) {
+            BrsDevice.stdout.write(
+                `debug,[rendezvous] thread ${sgRoot.threadId} applied set ${update.type}.${update.key} from thread ${update.id}`
+            );
+        }
+        // The render fans a task's applied set out to the other observing tasks itself (targeted to
+        // observers, excluding the originator) rather than relying on the broker to blind-relay. Only
+        // shared domains (global/scene/node) cross between tasks — `task`-type fields are private to a
+        // single task, mirroring the broker's `type !== "task"` guard; fanning them out would deliver
+        // one task's field into another task's identically-named field (and corrupt node ownership).
+        if (this.fanoutBuffer && !this.inThread && update.type !== "task") {
             node.fanOutFieldToObservingTasks(update.key, update.id);
         }
         // Send acknowledgement back to the other thread if needed

--- a/src/extensions/scenegraph/nodes/Task.ts
+++ b/src/extensions/scenegraph/nodes/Task.ts
@@ -46,6 +46,17 @@ export class Task extends Node {
      * `DeviceInfo.rendezvousDirect` is enabled; otherwise responses arrive on `taskBuffer`.
      */
     private directBuffer?: SharedObject;
+    /**
+     * Phase 3b: render-side write handle for the dedicated fan-out buffer (render → this task).
+     * Present only on the render-thread instance when direct rendezvous is enabled.
+     */
+    private fanoutBuffer?: SharedObject;
+    /**
+     * Phase 3b: render-side queue of pending fan-out updates for this task, flushed synchronously
+     * into `fanoutBuffer` during `processTasks` (the render thread can't rely on async writes — it
+     * busy-waits for FPS and doesn't yield its event loop mid-frame).
+     */
+    private readonly fanoutQueue: ThreadUpdate[] = [];
 
     /** Thread identifier assigned by sgRoot once scheduled. */
     threadId: number;
@@ -328,7 +339,27 @@ export class Task extends Node {
             key,
             value,
         };
+        // Phase 3b: on the render thread, queue fan-out for direct delivery (drained in processTasks)
+        // instead of relaying it through the main-thread broker.
+        if (this.fanoutBuffer && !this.inThread) {
+            this.fanoutQueue.push(update);
+            return;
+        }
         this.sendThreadUpdate(update);
+    }
+
+    /**
+     * Flushes queued fan-out updates into the dedicated buffer (render thread only). Writes are
+     * synchronous and non-blocking: one update is stored whenever the single slot is free, leaving
+     * the rest queued for the next render pass so a slow task can never stall the render thread.
+     */
+    flushFanout() {
+        if (!this.fanoutBuffer) {
+            return;
+        }
+        while (this.fanoutQueue.length > 0 && this.fanoutBuffer.getVersion() === 0) {
+            this.fanoutBuffer.store(this.fanoutQueue.shift());
+        }
     }
 
     /**
@@ -472,10 +503,11 @@ export class Task extends Node {
         }
         if (!this.started) {
             this.taskBuffer = new SharedObject();
-            // Phase 3a: when enabled, create a dedicated buffer the render thread writes responses
-            // into directly, so the blocked task wakes without a main-thread relay hop.
+            // Phase 3a/3b: when enabled, create dedicated render→task buffers (responses + fan-out)
+            // so the render thread delivers them directly without a main-thread relay hop.
             if (sgRoot.directRendezvous) {
                 this.directBuffer = new SharedObject();
+                this.fanoutBuffer = new SharedObject();
             }
             const taskData: TaskData = {
                 id: this.threadId,
@@ -483,6 +515,7 @@ export class Task extends Node {
                 state: TaskState.RUN,
                 buffer: this.taskBuffer.getBuffer(),
                 directToTask: this.directBuffer?.getBuffer(),
+                fanout: this.fanoutBuffer?.getBuffer(),
                 tmp: BrsDevice.getTmpVolume(),
                 cacheFS: BrsDevice.getCacheFS(),
                 m: fromAssociativeArray(this.m, true, this),
@@ -632,6 +665,11 @@ export class Task extends Node {
         }
         node.markFieldFresh(update.key);
         node.setValue(update.key, value, false, undefined, false);
+        // Phase 3b: in direct mode the broker no longer blind-propagates a task's set to other tasks,
+        // so the render fans it out (targeted to observers, excluding the originator) on apply.
+        if (this.fanoutBuffer && !this.inThread) {
+            node.fanOutFieldToObservingTasks(update.key, update.id);
+        }
         // Send acknowledgement back to the other thread if needed
         if (!this.inThread && update.requestId !== undefined) {
             update.action = "ack";

--- a/test/extensions/scenegraph/DirectRendezvous.test.js
+++ b/test/extensions/scenegraph/DirectRendezvous.test.js
@@ -121,4 +121,44 @@ describe("Phase 3b direct fan-out", () => {
         task.syncRemoteField("foo", new BrsString("bar"), "node", "ABC123");
         expect(global.postMessage).toHaveBeenCalledTimes(1);
     });
+
+    test("render-side fan-out does not re-own the node (ownership stays render-authoritative)", () => {
+        const task = renderSideTask();
+        attachFanout(task);
+
+        // A node owned by a task thread, held in a render-owned field being fanned out. Re-owning it to
+        // thread 0 here would recurse into its children and corrupt the live tree (the rokanban bug).
+        const node = new Task([], "Inner");
+        node.setOwner(7);
+        task.syncRemoteField("foo", node, "node", "ABC123");
+
+        expect(node.getOwner()).toBe(7); // unchanged on the render side
+    });
+
+    test("a task-thread set DOES re-own the node to the render thread", () => {
+        const task = renderSideTask();
+        task.inThread = true; // simulate running on the task worker
+        const node = new Task([], "Inner");
+        node.setOwner(7);
+        task.syncRemoteField("foo", node, "node", "ABC123");
+
+        expect(node.getOwner()).toBe(0); // crossed task -> render, now render-owned
+    });
+
+    test("a non-serializable fan-out is dropped without throwing; the rest still flush", () => {
+        const task = renderSideTask();
+        const reader = attachFanout(task);
+
+        // A payload with a cycle: JSON.stringify (used by store) throws on this. flushFanout runs on
+        // the render loop, so it must swallow the error, drop the bad update, and keep draining.
+        const cyclic = { id: 1, action: "set", type: "node", address: "ABC123", key: "bad", value: {} };
+        cyclic.value.self = cyclic.value;
+        task.fanoutQueue.push(cyclic);
+        task.syncRemoteField("good", new BrsString("ok"), "node", "ABC123");
+
+        expect(() => task.flushFanout()).not.toThrow();
+        // Bad update dropped (version untouched by it), good update delivered into the single slot.
+        expect(reader.getVersion()).toBe(1);
+        expect(reader.load(true).key).toBe("good");
+    });
 });

--- a/test/extensions/scenegraph/DirectRendezvous.test.js
+++ b/test/extensions/scenegraph/DirectRendezvous.test.js
@@ -2,7 +2,7 @@ const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
 const core = require("../../../packages/node/bin/brs.node.js");
 
 const { Task } = scenegraph;
-const { SharedObject } = core;
+const { SharedObject, BrsString } = core;
 
 /**
  * Builds a render-side Task (inThread = false) that is active on a thread id, the role that serves
@@ -61,6 +61,64 @@ describe("Phase 3a direct rendezvous responses", () => {
         const response = { id: 1, action: "resp", type: "node", address: "ABC123", key: "m", value: 0, requestId: 9 };
         task.sendThreadUpdate(response);
 
+        expect(global.postMessage).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("Phase 3b direct fan-out", () => {
+    let originalPostMessage;
+    beforeEach(() => {
+        originalPostMessage = global.postMessage;
+        global.postMessage = jest.fn();
+    });
+    afterEach(() => {
+        global.postMessage = originalPostMessage;
+    });
+
+    /** Attaches a render-side fan-out buffer to a task and returns a reader over the same SAB. */
+    function attachFanout(task) {
+        const writer = new SharedObject();
+        task.fanoutBuffer = writer; // render-side write handle (TS-private; runtime-accessible)
+        const reader = new SharedObject();
+        reader.setBuffer(writer.getBuffer());
+        return reader;
+    }
+
+    test("render-side fan-out is queued (not posted) and flushed into the fan-out buffer", () => {
+        const task = renderSideTask();
+        const reader = attachFanout(task);
+
+        task.syncRemoteField("foo", new BrsString("bar"), "node", "ABC123");
+        // Queued for the next render pass, not relayed through the broker.
+        expect(global.postMessage).not.toHaveBeenCalled();
+        expect(reader.getVersion()).toBe(0);
+
+        task.flushFanout();
+        expect(reader.getVersion()).toBe(1);
+        const got = reader.load(true);
+        expect(got.action).toBe("set");
+        expect(got.key).toBe("foo");
+        expect(got.value).toBe("bar");
+    });
+
+    test("flush respects the single slot: drains one, leaves the rest until the reader consumes", () => {
+        const task = renderSideTask();
+        const reader = attachFanout(task);
+
+        task.syncRemoteField("a", new BrsString("1"), "node", "ABC123");
+        task.syncRemoteField("b", new BrsString("2"), "node", "ABC123");
+
+        task.flushFanout();
+        expect(reader.getVersion()).toBe(1);
+        expect(reader.load(true).key).toBe("a"); // resets version to 0
+
+        task.flushFanout();
+        expect(reader.load(true).key).toBe("b");
+    });
+
+    test("without a fan-out buffer (flag off), fan-out falls back to the broker", () => {
+        const task = renderSideTask(); // no fanoutBuffer
+        task.syncRemoteField("foo", new BrsString("bar"), "node", "ABC123");
         expect(global.postMessage).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
Finalizes the SceneGraph cross-thread **rendezvous** rework: the direct render→task channel is now the only path and the experimental `DeviceInfo.rendezvousDirect` feature flag is removed.

## What changed

Originally every cross-thread message was relayed by the main-thread **broker** (`src/api/task.ts`) — two event-loop hops and up to three encodings per round-trip. This series moves the **render→task** direction onto dedicated per-task `SharedArrayBuffer`s the render thread writes straight into the task worker:

- `directBuffer` — rendezvous **responses** (`set`/`resp`/`ack`/`nil`), written synchronously.
- `fanoutBuffer` — observed-field **fan-out** + cross-task propagation, queued render-side and flushed during `processTasks` (the render thread busy-waits for FPS and can't use async writes).

The **task→render request** direction still goes through the broker (a direct-both-ways ring-buffer protocol and msgpack encoding are future work).

## Finalization in this update

- Remove the `rendezvousDirect` flag (`DeviceInfo`) and `SGRoot.directRendezvous`; direct delivery is always on. Buffers are allocated in `activateTask`.
- **Reliability/correctness** fixes found validating against real apps (hero-grid, rokanban):
  - Per-task **fault isolation** in `processTasks` — a fault servicing one task can't tear down the render thread.
  - `flushFanout` drops a non-serializable payload (logged) instead of throwing into the render loop.
  - Render-side fan-out no longer **re-owns** the node it sends (`setOwner(0)` only on a real task→render crossing) — fixes node-tree corruption that left grids empty.
  - `task`-type fields are no longer cross-fanned between tasks (private per task), matching the broker's `type !== "task"` rule.
  - Precise dropped-update diagnostics + broker leak warning; `SharedObject.dispose()` teardown safety.

## Docs

Adds `docs/scenegraph-rendezvous.md` — the broker→direct evolution and the **performance / reliability / memory / Roku-fidelity** analysis — cross-linked from `extensions.md` and `CLAUDE.md`.

## Testing

`DirectRendezvous` suite covers fan-out queue/flush/fallback, flush resilience, and ownership preservation. Full suite green (1678 passing). Verified at runtime: hero-grid and rokanban render correctly with the direct path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)