### PR TITLE
feat(scenegraph): implement MultiStyleLabel and StdDlgMultiStyleTextItem nodes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
     "plugins": [
         "eslint-plugin-import",
         "eslint-plugin-jsdoc",
+        "eslint-plugin-unicorn",
         "@typescript-eslint"
     ],
     "root": true,
@@ -117,6 +118,7 @@ module.exports = {
             "off",
             "never"
         ],
+        "unicorn/prefer-at": "error",
         "use-isnan": "error"
     },
     "overrides": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-jsdoc": "^48.2.3",
+        "eslint-plugin-unicorn": "^56.0.1",
         "ifdef-loader": "^2.3.2",
         "javascript-obfuscator": "^4.0.2",
         "jest": "^29.4.3",
@@ -2260,6 +2261,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/qs": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
@@ -4224,6 +4232,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/bundle-name": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -4570,6 +4591,29 @@
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
         "validator": "^13.15.20"
+      }
+    },
+    "node_modules/clean-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
+      "integrity": "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/clean-regexp/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/clean-stack": {
@@ -4981,6 +5025,20 @@
       },
       "peerDependencies": {
         "webpack": "^5.1.0"
+      }
+    },
+    "node_modules/core-js-compat": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
+      "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/core-util-is": {
@@ -6271,6 +6329,69 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-plugin-unicorn": {
+      "version": "56.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-56.0.1.tgz",
+      "integrity": "sha512-FwVV0Uwf8XPfVnKSGpMg7NtlZh0G0gBarCaFcMUOoqPxXryxdYxTRRv4kH6B9TFCVIrjRXG+emcxIk2ayZilog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.24.7",
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "ci-info": "^4.0.0",
+        "clean-regexp": "^1.0.0",
+        "core-js-compat": "^3.38.1",
+        "esquery": "^1.6.0",
+        "globals": "^15.9.0",
+        "indent-string": "^4.0.0",
+        "is-builtin-module": "^3.2.1",
+        "jsesc": "^3.0.2",
+        "pluralize": "^8.0.0",
+        "read-pkg-up": "^7.0.1",
+        "regexp-tree": "^0.1.27",
+        "regjsparser": "^0.10.0",
+        "semver": "^7.6.3",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.56.0"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
@@ -7468,6 +7589,13 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/howler": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/howler/-/howler-2.2.4.tgz",
@@ -7953,6 +8081,22 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "license": "MIT"
+    },
+    "node_modules/is-builtin-module": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "builtin-modules": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
@@ -10365,6 +10509,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -10587,6 +10741,29 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -11358,6 +11535,16 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -11711,6 +11898,116 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg/node_modules/type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
@@ -11805,6 +12102,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -11833,6 +12140,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/regjsparser": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.10.0.tgz",
+      "integrity": "sha512-qx+xQGZVsy55CH0a1hiVwHmqjLryfh7wQyF5HO07XJ9f7dQMY/gPQHhlyDkIzJKC+x2fUCpCcUODUUUFrm7SHA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "jsesc": "~0.5.0"
+      },
+      "bin": {
+        "regjsparser": "bin/parser"
+      }
+    },
+    "node_modules/regjsparser/node_modules/jsesc": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
       }
     },
     "node_modules/require-directory": {
@@ -13094,6 +13423,28 @@
       "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
       "license": "MIT"
     },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-correct/node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
     "node_modules/spdx-exceptions": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
@@ -13523,6 +13874,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -14525,6 +14889,28 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "node_modules/validator": {

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jsdoc": "^48.2.3",
+    "eslint-plugin-unicorn": "^56.0.1",
     "ifdef-loader": "^2.3.2",
     "javascript-obfuscator": "^4.0.2",
     "jest": "^29.4.3",

--- a/src/core/brsTypes/components/RoByteArray.ts
+++ b/src/core/brsTypes/components/RoByteArray.ts
@@ -457,7 +457,7 @@ export class RoByteArray extends BrsComponent implements BrsValue, BrsIterable {
             returns: ValueKind.Dynamic,
         },
         impl: (_: Interpreter) => {
-            const item = this.elements[this.elements.length - 1];
+            const item = this.elements.at(-1);
             return item ? new Int32(item) : BrsInvalid.Instance;
         },
     });

--- a/src/core/brsTypes/components/RoXMLElement.ts
+++ b/src/core/brsTypes/components/RoXMLElement.ts
@@ -65,7 +65,7 @@ export class RoXMLElement extends BrsComponent implements BrsValue, BrsIterable 
     private static syncDerivedState(element: XmlElement) {
         const children = element.children ?? [];
         element.firstChild = children.length > 0 ? children[0] : null;
-        element.lastChild = children.length > 0 ? children[children.length - 1] : null;
+        element.lastChild = children.length > 0 ? children.at(-1)! : null;
         const textParts: string[] = [];
         for (const child of children) {
             if (isTextNode(child)) {

--- a/src/core/interpreter/MicroDebugger.ts
+++ b/src/core/interpreter/MicroDebugger.ts
@@ -325,7 +325,7 @@ function debugHandleCommand(interpreter: Interpreter, currLoc: Location, lastLoc
 function debugList(backTrace: TracePoint[], currLines: string[], flagLine: number): string {
     let list = "";
     if (backTrace.length > 0) {
-        const func = backTrace[backTrace.length - 1];
+        const func = backTrace.at(-1)!;
         const start = func.functionLocation.start.line;
         const end = Math.min(func.functionLocation.end.line, currLines.length);
         for (let index = start; index <= end; index++) {

--- a/src/core/lexer/Lexer.ts
+++ b/src/core/lexer/Lexer.ts
@@ -741,7 +741,7 @@ export class Lexer {
          * @param kind
          */
         function checkPrevious(kind: Lexeme) {
-            let previous = tokens[tokens.length - 1];
+            let previous = tokens.at(-1);
             if (previous && previous.kind === kind) {
                 return true;
             } else {
@@ -832,7 +832,7 @@ export class Lexer {
          * @returns the most recently added token.
          */
         function peekPrevious(): Token | undefined {
-            return tokens[tokens.length - 1];
+            return tokens.at(-1);
         }
 
         /**

--- a/src/core/parser/Parser.ts
+++ b/src/core/parser/Parser.ts
@@ -363,7 +363,7 @@ export class Parser {
                     leftParen = consume(`Expected '(' after ${functionType.text} name`, Lexeme.LeftParen);
 
                     //prevent functions from ending with type designators
-                    let lastChar = name.text[name.text.length - 1];
+                    let lastChar = name.text.at(-1)!;
                     if (["$", "%", "!", "#", "&"].includes(lastChar)) {
                         //don't throw this error; let the parser continue
                         addError(name, `Function name '${name.text}' cannot end with type designator '${lastChar}'`);

--- a/src/core/parser/Statement.ts
+++ b/src/core/parser/Statement.ts
@@ -288,9 +288,7 @@ export class Print implements Statement {
     }
 
     get location() {
-        let end = this.expressions.length
-            ? this.expressions.at(-1)!.location.end
-            : this.tokens.print.location.end;
+        let end = this.expressions.length ? this.expressions.at(-1)!.location.end : this.tokens.print.location.end;
 
         return {
             file: this.tokens.print.location.file,

--- a/src/core/parser/Statement.ts
+++ b/src/core/parser/Statement.ts
@@ -223,7 +223,7 @@ export class If implements Statement {
         } else if (this.elseBranch) {
             return this.elseBranch.location;
         } else if (this.elseIfs.length) {
-            return this.elseIfs[this.elseIfs.length - 1].thenBranch.location;
+            return this.elseIfs.at(-1)!.thenBranch.location;
         } else {
             return this.thenBranch.location;
         }
@@ -289,7 +289,7 @@ export class Print implements Statement {
 
     get location() {
         let end = this.expressions.length
-            ? this.expressions[this.expressions.length - 1].location.end
+            ? this.expressions.at(-1)!.location.end
             : this.tokens.print.location.end;
 
         return {

--- a/src/extensions/scenegraph/factory/NodeFactory.ts
+++ b/src/extensions/scenegraph/factory/NodeFactory.ts
@@ -81,6 +81,7 @@ import {
     StdDlgCustomItem,
     StdDlgDeterminateProgressItem,
     StdDlgKeyboardItem,
+    StdDlgMultiStyleTextItem,
     StdDlgProgressItem,
     StdDlgSideCardArea,
     StdDlgTextItem,
@@ -284,6 +285,8 @@ export class SGNodeFactory {
                 return new StdDlgButtonArea([], name);
             case SGNodeType.StdDlgKeyboardItem.toLowerCase():
                 return new StdDlgKeyboardItem([], name);
+            case SGNodeType.StdDlgMultiStyleTextItem.toLowerCase():
+                return new StdDlgMultiStyleTextItem([], name);
             case SGNodeType.StdDlgProgressItem.toLowerCase():
                 return new StdDlgProgressItem([], name);
             case SGNodeType.StdDlgSideCardArea.toLowerCase():

--- a/src/extensions/scenegraph/factory/NodeFactory.ts
+++ b/src/extensions/scenegraph/factory/NodeFactory.ts
@@ -43,6 +43,7 @@ import {
     MarkupGrid,
     MarkupList,
     MiniKeyboard,
+    MultiStyleLabel,
     PinPad,
     PinDialog,
     Node,
@@ -179,6 +180,8 @@ export class SGNodeFactory {
                 return new Label([], name);
             case SGNodeType.SimpleLabel.toLowerCase():
                 return new SimpleLabel([], name);
+            case SGNodeType.MultiStyleLabel.toLowerCase():
+                return new MultiStyleLabel([], name);
             case SGNodeType.InfoPane.toLowerCase():
                 return new InfoPane([], name);
             case SGNodeType.ScrollingLabel.toLowerCase():

--- a/src/extensions/scenegraph/nodes/MultiStyleLabel.ts
+++ b/src/extensions/scenegraph/nodes/MultiStyleLabel.ts
@@ -1,0 +1,578 @@
+import {
+    AAMember,
+    Interpreter,
+    BrsBoolean,
+    BrsString,
+    BrsType,
+    IfDraw2D,
+    MeasuredText,
+    Rect,
+    RoFont,
+} from "brs-engine";
+import { Group } from "./Group";
+import type { Font } from "./Font";
+import { FieldKind, FieldModel } from "../SGTypes";
+import { SGNodeType } from ".";
+import { SGNodeFactory } from "../factory/NodeFactory";
+import { convertHexColor, rotateTranslation } from "../SGUtil";
+
+/** A resolved drawing style: a configured Font node plus its text color. */
+interface DrawStyle {
+    font: Font;
+    color: number;
+}
+
+/** A measured, style-resolved piece of text to be drawn on a single line. */
+interface Token {
+    text: string;
+    font: RoFont;
+    color: number;
+    width: number;
+    height: number;
+    /** True for a `\n` break marker (zero-width, forces a new line). */
+    newline: boolean;
+}
+
+/** A laid-out line: an ordered list of tokens with its overall width/height. */
+interface Line {
+    tokens: Token[];
+    width: number;
+    height: number;
+    ellipsized: boolean;
+}
+
+/**
+ * Reads a property case-insensitively. BrightScript associative-array literals keep their
+ * keys in the original case (the `RoAssociativeArray` constructor stores them case-sensitively),
+ * so a `drawingStyles` entry exposes `fontUri`/`fontSize` — not the lowercased forms.
+ */
+function ciGet(obj: Record<string, unknown>, key: string): unknown {
+    if (key in obj) {
+        return obj[key];
+    }
+    const lower = key.toLowerCase();
+    for (const k of Object.keys(obj)) {
+        if (k.toLowerCase() === lower) {
+            return obj[k];
+        }
+    }
+    return undefined;
+}
+
+/**
+ * MultiStyleLabel renders a single string of text using mixed styles (different
+ * fonts, sizes, and colors) within one label. Styles are defined in the
+ * `drawingStyles` field (an associative array of `{ fontSize, fontUri, color }`
+ * associative arrays) and the `text` field uses simple markup tags
+ * (`<styleName>...</styleName>`) to select which style draws each span. Text
+ * outside any tag uses the `"default"` style if defined, otherwise the system
+ * default font and the node's `color` field.
+ *
+ * Roku documents MultiStyleLabel as extending LabelBase; this codebase has no
+ * standalone LabelBase class, so (like Label) it extends Group and inlines the
+ * LabelBase fields.
+ */
+export class MultiStyleLabel extends Group {
+    readonly defaultFields: FieldModel[] = [
+        { name: "text", type: "string", value: "" },
+        { name: "color", type: "color", value: "0xddddddff" },
+        { name: "horizAlign", type: "string", value: "left" },
+        { name: "vertAlign", type: "string", value: "top" },
+        { name: "width", type: "float", value: "0" },
+        { name: "height", type: "float", value: "0" },
+        { name: "numLines", type: "integer", value: "0" },
+        { name: "maxLines", type: "integer", value: "0" },
+        { name: "wrap", type: "boolean", value: "false" },
+        { name: "displayPartialLines", type: "boolean", value: "false" },
+        { name: "ellipsizeOnBoundary", type: "boolean", value: "false" },
+        { name: "wordBreakChars", type: "string" },
+        { name: "ellipsisText", type: "string" },
+        { name: "isTextEllipsized", type: "boolean", value: "false" },
+        { name: "monospacedDigits", type: "boolean", value: "false" },
+        { name: "drawingStyles", type: "assocarray" },
+    ];
+    protected measured?: MeasuredText;
+    /** Resolved styles keyed by lowercased style name. */
+    private styles: Map<string, DrawStyle> = new Map();
+    private appliedStyles?: string;
+    private defaultStyle?: DrawStyle;
+
+    constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.MultiStyleLabel) {
+        super([], name);
+        this.setExtendsType(name, SGNodeType.Group);
+
+        this.registerDefaultFields(this.defaultFields);
+        this.registerInitializedFields(initializedFields);
+    }
+
+    setValue(index: string, value: BrsType, alwaysNotify?: boolean, kind?: FieldKind) {
+        const fieldName = index.toLowerCase();
+        const resetFields = [
+            "text",
+            "drawingstyles",
+            "color",
+            "width",
+            "height",
+            "numlines",
+            "maxlines",
+            "wrap",
+            "horizalign",
+            "vertalign",
+            "ellipsizeonboundary",
+            "ellipsistext",
+            "displaypartiallines",
+        ];
+        super.setValue(index, value, alwaysNotify, kind);
+        if (fieldName === "drawingstyles" || fieldName === "color") {
+            this.buildStyles();
+        }
+        if (resetFields.includes(fieldName)) {
+            this.setEllipsized(false);
+            this.measured = undefined;
+            this.getMeasured(); // force re-measure
+        }
+    }
+
+    getMeasured() {
+        if (this.measured === undefined) {
+            const size = this.getDimensions();
+            const rect: Rect = { x: 0, y: 0, ...size };
+            this.measured = this.renderLabel(rect, 0, 1);
+            rect.width = Math.max(this.measured.width, size.width);
+            rect.height = Math.max(this.measured.height, size.height);
+            this.rectLocal = { x: 0, y: 0, width: rect.width, height: rect.height };
+        }
+        return this.measured;
+    }
+
+    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+        if (!this.isVisible()) {
+            this.updateRenderTracking(true);
+            return;
+        }
+        const nodeTrans = this.getTranslation();
+        const drawTrans = angle === 0 ? nodeTrans.slice() : rotateTranslation(nodeTrans, angle);
+        drawTrans[0] += origin[0];
+        drawTrans[1] += origin[1];
+        const size = this.getDimensions();
+        const rect = { x: drawTrans[0], y: drawTrans[1], width: size.width, height: size.height };
+        const rotation = angle + this.getRotation();
+        opacity = opacity * this.getOpacity();
+        this.measured = this.renderLabel(rect, rotation, opacity, draw2D);
+        rect.width = Math.max(this.measured.width, size.width);
+        rect.height = Math.max(this.measured.height, size.height);
+        this.updateBoundingRects(rect, origin, rotation);
+        this.renderChildren(interpreter, drawTrans, rotation, opacity, draw2D);
+        this.nodeRenderingDone(origin, angle, opacity, draw2D);
+    }
+
+    /**
+     * Lays out and draws the styled text. `rect.width`/`rect.height` carry the
+     * `width`/`height` field values (the computed bounding box); the returned
+     * MeasuredText carries the rendered block size for bounding-rect tracking.
+     */
+    protected renderLabel(rect: Rect, rotation: number, opacity: number, draw2D?: IfDraw2D): MeasuredText {
+        this.buildStyles();
+        const fullText = (this.getValueJS("text") as string) ?? "";
+        const horizAlign = (this.getValueJS("horizAlign") as string) || "left";
+        const vertAlign = (this.getValueJS("vertAlign") as string) || "top";
+        const ellipsis = (this.getValueJS("ellipsisText") as string) || "...";
+        const onBoundary = this.getValueJS("ellipsizeOnBoundary") as boolean;
+        const wrap = this.getValueJS("wrap") as boolean;
+        const numLines = this.getValueJS("numLines") as number;
+        const maxLines = this.getValueJS("maxLines") as number;
+        const displayPartialLines = this.getValueJS("displayPartialLines") as boolean;
+
+        const empty: MeasuredText = { text: fullText, width: 0, height: 0, ellipsized: false };
+        const tokens = this.tokenize(this.parseRuns(fullText));
+        if (tokens.length === 0) {
+            this.setEllipsized(false);
+            return empty;
+        }
+
+        // Roku keeps a constant line advance based on the label's leading text and
+        // baseline-aligns each span, so larger inline fonts overflow upward rather than
+        // pushing the lines apart. Use the first run's font as the baseline reference.
+        const baseToken = tokens.find((token) => !token.newline) ?? tokens[0];
+        const baseLineHeight = baseToken.height;
+        const baseAscent = baseLineHeight - 2 * baseToken.font.getTopAdjust();
+
+        // Build the lines of text.
+        let lines: Line[];
+        if (wrap) {
+            // wrap=true with no width renders nothing (LabelBase wrapping rule).
+            if (rect.width <= 0) {
+                this.setEllipsized(false);
+                return empty;
+            }
+            lines = this.wrapTokens(tokens, rect.width);
+        } else {
+            // wrap=false is always a single line (up to the first newline).
+            lines = [this.singleLine(tokens, rect.width, ellipsis, onBoundary)];
+        }
+
+        // Limit the rendered line count by height / numLines / maxLines.
+        let limit = Number.POSITIVE_INFINITY;
+        if (rect.height > 0 && baseLineHeight > 0) {
+            limit = Math.max(1, Math[displayPartialLines ? "ceil" : "floor"](rect.height / baseLineHeight));
+        } else if (numLines > 0) {
+            limit = numLines;
+        } else if (maxLines > 0) {
+            limit = maxLines;
+        }
+        let rendered = lines;
+        if (lines.length > limit) {
+            rendered = lines.slice(0, limit);
+            const last = rendered.length - 1;
+            const fit = rect.width > 0 ? rect.width : rendered[last].width;
+            rendered[last] = this.ellipsizeTokenLine(rendered[last], fit, ellipsis, onBoundary);
+        }
+
+        // Stack lines by their own ascent/descent and baseline-align each span. A larger
+        // inline font raises its line's ascent, pushing the line down to make room for it
+        // (matching Roku) while all spans share a common baseline. A line with no taller span
+        // keeps the base line height.
+        const baseDescent = baseLineHeight - baseAscent;
+        const lineMetrics = rendered.map((line) => {
+            let ascent = baseAscent;
+            let descent = baseDescent;
+            for (const token of line.tokens) {
+                const topAdjust = token.font.getTopAdjust();
+                ascent = Math.max(ascent, token.height - 2 * topAdjust);
+                descent = Math.max(descent, 2 * topAdjust);
+            }
+            return { ascent, descent };
+        });
+        const blockHeight = lineMetrics.reduce((acc, m) => acc + m.ascent + m.descent, 0);
+        let maxWidth = 0;
+        let ellipsized = false;
+        let y = rect.y;
+        if (rect.height > blockHeight) {
+            if (vertAlign === "center") {
+                y += (rect.height - blockHeight) / 2;
+            } else if (vertAlign === "bottom") {
+                y += rect.height - blockHeight;
+            }
+        }
+        for (let i = 0; i < rendered.length; i++) {
+            const line = rendered[i];
+            const { ascent, descent } = lineMetrics[i];
+            const baseline = y + ascent;
+            maxWidth = Math.max(maxWidth, line.width);
+            ellipsized = ellipsized || line.ellipsized;
+            let x = rect.x;
+            if (rect.width > line.width) {
+                if (horizAlign === "center") {
+                    x += (rect.width - line.width) / 2;
+                } else if (horizAlign === "right") {
+                    x += rect.width - line.width;
+                }
+            }
+            for (const token of line.tokens) {
+                if (token.text.length > 0) {
+                    // Place this span's baseline on the line baseline.
+                    const topAdjust = token.font.getTopAdjust();
+                    const drawY = baseline - (token.height - 2 * topAdjust) - topAdjust;
+                    draw2D?.doDrawRotatedText(token.text, x, drawY, token.color, opacity, token.font, rotation);
+                }
+                x += token.width;
+            }
+            y += ascent + descent;
+        }
+        this.setEllipsized(ellipsized);
+        return { text: fullText, width: maxWidth, height: blockHeight, ellipsized };
+    }
+
+    protected setEllipsized(ellipsized: boolean) {
+        this.fields.get("istextellipsized")?.setValue(BrsBoolean.from(ellipsized));
+    }
+
+    /** (Re)builds the resolved styles map when `drawingStyles`/`color` change. */
+    private buildStyles() {
+        const raw = (this.getValueJS("drawingStyles") as Record<string, unknown>) ?? {};
+        const nodeColor = this.getValueJS("color") as number;
+        const signature = JSON.stringify(raw) + "|" + nodeColor;
+        if (this.appliedStyles === signature) {
+            return;
+        }
+        this.styles = new Map();
+        for (const [styleName, def] of Object.entries(raw)) {
+            if (def === null || typeof def !== "object") {
+                continue;
+            }
+            const style = def as Record<string, unknown>;
+            const fontUri = ciGet(style, "fontUri");
+            const uri = typeof fontUri === "string" ? fontUri : "";
+            const size = this.resolveFontSize(ciGet(style, "fontSize"));
+            const font = SGNodeFactory.createNode(SGNodeType.Font) as Font;
+            if (uri.startsWith("font:")) {
+                // System fonts are fixed size; fontSize is ignored.
+                font.setSystemFont(uri.slice(5));
+            } else if (uri !== "") {
+                font.setValue("uri", new BrsString(uri));
+                if (size > 0) {
+                    font.setSize(size);
+                }
+            } else if (size > 0) {
+                font.setSize(size);
+            }
+            const colorValue = ciGet(style, "color");
+            const color = typeof colorValue === "string" && colorValue.length ? convertHexColor(colorValue) : nodeColor;
+            // Markup tag matching is case-insensitive, so key the styles map by lowercase name.
+            this.styles.set(styleName.toLowerCase(), { font, color });
+        }
+        this.appliedStyles = signature;
+    }
+
+    /** A drawing style's fontSize may be a number or an `{ fhd, hd }` map. */
+    private resolveFontSize(fontSize: unknown): number {
+        if (typeof fontSize === "number") {
+            return fontSize;
+        }
+        if (fontSize !== null && typeof fontSize === "object") {
+            const value = ciGet(fontSize as Record<string, unknown>, this.resolution === "HD" ? "hd" : "fhd");
+            if (typeof value === "number") {
+                return value;
+            }
+        }
+        return 0;
+    }
+
+    /** The implicit default style: a system-default font plus the node's `color`. */
+    private getDefaultStyle(): DrawStyle {
+        const color = this.getValueJS("color") as number;
+        if (!this.defaultStyle) {
+            this.defaultStyle = { font: SGNodeFactory.createNode(SGNodeType.Font) as Font, color };
+        } else {
+            this.defaultStyle.color = color;
+        }
+        return this.defaultStyle;
+    }
+
+    /** Resolves a style name to a draw font + color, falling back to default. */
+    private resolveStyle(styleName: string): { drawFont: RoFont; color: number } | undefined {
+        const entry = this.styles.get(styleName.toLowerCase()) ?? this.styles.get("default") ?? this.getDefaultStyle();
+        const drawFont = entry.font.createDrawFont();
+        if (!(drawFont instanceof RoFont)) {
+            return undefined;
+        }
+        return { drawFont, color: entry.color };
+    }
+
+    /** Parses the markup `text` into runs of `{ text, style }`. */
+    private parseRuns(text: string): { text: string; style: string }[] {
+        const runs: { text: string; style: string }[] = [];
+        const tagRe = /<(\/?)([A-Za-z0-9_]+)>/g;
+        const stack: string[] = ["default"];
+        let last = 0;
+        let match: RegExpExecArray | null;
+        while ((match = tagRe.exec(text)) !== null) {
+            if (match.index > last) {
+                runs.push({ text: text.slice(last, match.index), style: stack[stack.length - 1] });
+            }
+            const name = match[2].toLowerCase();
+            if (match[1] === "/") {
+                // Closing tag: pop the matching style (tolerant of mismatches).
+                const idx = stack.lastIndexOf(name);
+                if (idx > 0) {
+                    stack.splice(idx, 1);
+                }
+            } else {
+                stack.push(name);
+            }
+            last = tagRe.lastIndex;
+        }
+        if (last < text.length) {
+            runs.push({ text: text.slice(last), style: stack[stack.length - 1] });
+        }
+        return runs;
+    }
+
+    /** Resolves runs to measured, style-aware tokens (words, spaces, newlines). */
+    private tokenize(runs: { text: string; style: string }[]): Token[] {
+        const tokens: Token[] = [];
+        for (const run of runs) {
+            if (run.text.length === 0) {
+                continue;
+            }
+            const resolved = this.resolveStyle(run.style);
+            if (!resolved) {
+                continue;
+            }
+            const { drawFont, color } = resolved;
+            const parts = run.text.split(/(\n|\s|-)/);
+            for (const part of parts) {
+                if (part === "") {
+                    continue;
+                }
+                if (part === "\n") {
+                    tokens.push({
+                        text: "",
+                        font: drawFont,
+                        color,
+                        width: 0,
+                        height: drawFont.measureTextHeight(),
+                        newline: true,
+                    });
+                } else {
+                    const measured = drawFont.measureText(part);
+                    tokens.push({
+                        text: part,
+                        font: drawFont,
+                        color,
+                        width: measured.width,
+                        height: measured.height,
+                        newline: false,
+                    });
+                }
+            }
+        }
+        return tokens;
+    }
+
+    private makeLine(tokens: Token[]): Line {
+        let width = 0;
+        let height = 0;
+        for (const token of tokens) {
+            width += token.width;
+            height = Math.max(height, token.height);
+        }
+        return { tokens, width, height, ellipsized: false };
+    }
+
+    /** Builds the single line rendered when `wrap` is false (up to first newline). */
+    private singleLine(tokens: Token[], width: number, ellipsis: string, onBoundary: boolean): Line {
+        const lineTokens: Token[] = [];
+        for (const token of tokens) {
+            if (token.newline) {
+                break;
+            }
+            lineTokens.push(token);
+        }
+        let line = this.makeLine(lineTokens);
+        if (width > 0 && line.width > width) {
+            line = this.ellipsizeTokenLine(line, width, ellipsis, onBoundary);
+        }
+        return line;
+    }
+
+    /** Greedily wraps tokens into lines no wider than `width`, breaking at newlines. */
+    private wrapTokens(tokens: Token[], width: number): Line[] {
+        const lines: Line[] = [];
+        let current: Token[] = [];
+        let currentWidth = 0;
+        const flush = () => {
+            if (current.length > 0 || lines.length === 0) {
+                lines.push(this.makeLine(current));
+            }
+            current = [];
+            currentWidth = 0;
+        };
+        for (const token of tokens) {
+            if (token.newline) {
+                flush();
+                continue;
+            }
+            if (token.width > width) {
+                // A single token wider than the line: break it by characters.
+                if (current.length > 0) {
+                    flush();
+                }
+                for (const piece of this.breakToken(token, width)) {
+                    if (currentWidth + piece.width > width && current.length > 0) {
+                        flush();
+                    }
+                    current.push(piece);
+                    currentWidth += piece.width;
+                }
+                continue;
+            }
+            if (currentWidth + token.width > width && current.length > 0) {
+                flush();
+                if (token.text.trim() === "") {
+                    // Drop whitespace that would otherwise lead a wrapped line.
+                    continue;
+                }
+            }
+            current.push(token);
+            currentWidth += token.width;
+        }
+        flush();
+        return lines;
+    }
+
+    /** Splits a token wider than `width` into character-level pieces. */
+    private breakToken(token: Token, width: number): Token[] {
+        const pieces: Token[] = [];
+        let current = "";
+        for (const char of token.text) {
+            if (current !== "" && token.font.measureTextWidth(current + char).width > width) {
+                const measured = token.font.measureText(current);
+                pieces.push({ ...token, text: current, width: measured.width, height: measured.height });
+                current = char;
+            } else {
+                current += char;
+            }
+        }
+        if (current !== "") {
+            const measured = token.font.measureText(current);
+            pieces.push({ ...token, text: current, width: measured.width, height: measured.height });
+        }
+        return pieces;
+    }
+
+    /**
+     * Trims a line to fit `maxWidth` and appends the ellipsis. Used both for
+     * width overflow and for line-count truncation, so it always ends with the
+     * ellipsis. `onBoundary` ellipsizes by whole words; otherwise by characters.
+     */
+    private ellipsizeTokenLine(line: Line, maxWidth: number, ellipsis: string, onBoundary: boolean): Line {
+        if (line.tokens.length === 0) {
+            return { ...line, ellipsized: true };
+        }
+        const lastToken = line.tokens[line.tokens.length - 1];
+        const budget = maxWidth - lastToken.font.measureTextWidth(ellipsis).width;
+        const result: Token[] = [];
+        let used = 0;
+        for (const token of line.tokens) {
+            if (used + token.width <= budget) {
+                result.push(token);
+                used += token.width;
+                continue;
+            }
+            if (!onBoundary) {
+                // Character-level truncation within the overflowing token.
+                let truncated = "";
+                for (const char of token.text) {
+                    if (used + token.font.measureTextWidth(truncated + char).width <= budget) {
+                        truncated += char;
+                    } else {
+                        break;
+                    }
+                }
+                if (truncated.length > 0) {
+                    const measured = token.font.measureText(truncated);
+                    result.push({ ...token, text: truncated, width: measured.width, height: measured.height });
+                    used += measured.width;
+                }
+            } else {
+                // Whole-word ellipsis: drop trailing whitespace-only tokens.
+                while (result.length > 0 && result[result.length - 1].text.trim() === "") {
+                    result.pop();
+                }
+            }
+            break;
+        }
+        const ellipsisFont = result.length > 0 ? result[result.length - 1].font : lastToken.font;
+        const ellipsisColor = result.length > 0 ? result[result.length - 1].color : lastToken.color;
+        result.push({
+            text: ellipsis,
+            font: ellipsisFont,
+            color: ellipsisColor,
+            width: ellipsisFont.measureTextWidth(ellipsis).width,
+            height: ellipsisFont.measureTextHeight(),
+            newline: false,
+        });
+        return { ...this.makeLine(result), ellipsized: true };
+    }
+}

--- a/src/extensions/scenegraph/nodes/MultiStyleLabel.ts
+++ b/src/extensions/scenegraph/nodes/MultiStyleLabel.ts
@@ -368,7 +368,7 @@ export class MultiStyleLabel extends Group {
         let match: RegExpExecArray | null;
         while ((match = tagRe.exec(text)) !== null) {
             if (match.index > last) {
-                runs.push({ text: text.slice(last, match.index), style: stack[stack.length - 1] });
+                runs.push({ text: text.slice(last, match.index), style: stack.at(-1)! });
             }
             const name = match[2].toLowerCase();
             if (match[1] === "/") {
@@ -383,7 +383,7 @@ export class MultiStyleLabel extends Group {
             last = tagRe.lastIndex;
         }
         if (last < text.length) {
-            runs.push({ text: text.slice(last), style: stack[stack.length - 1] });
+            runs.push({ text: text.slice(last), style: stack.at(-1)! });
         }
         return runs;
     }
@@ -530,7 +530,7 @@ export class MultiStyleLabel extends Group {
         if (line.tokens.length === 0) {
             return { ...line, ellipsized: true };
         }
-        const lastToken = line.tokens[line.tokens.length - 1];
+        const lastToken = line.tokens.at(-1)!;
         const budget = maxWidth - lastToken.font.measureTextWidth(ellipsis).width;
         const result: Token[] = [];
         let used = 0;
@@ -557,14 +557,14 @@ export class MultiStyleLabel extends Group {
                 }
             } else {
                 // Whole-word ellipsis: drop trailing whitespace-only tokens.
-                while (result.length > 0 && result[result.length - 1].text.trim() === "") {
+                while (result.length > 0 && result.at(-1)!.text.trim() === "") {
                     result.pop();
                 }
             }
             break;
         }
-        const ellipsisFont = result.length > 0 ? result[result.length - 1].font : lastToken.font;
-        const ellipsisColor = result.length > 0 ? result[result.length - 1].color : lastToken.color;
+        const ellipsisFont = result.length > 0 ? result.at(-1)!.font : lastToken.font;
+        const ellipsisColor = result.length > 0 ? result.at(-1)!.color : lastToken.color;
         result.push({
             text: ellipsis,
             font: ellipsisFont,

--- a/src/extensions/scenegraph/nodes/MultiStyleLabel.ts
+++ b/src/extensions/scenegraph/nodes/MultiStyleLabel.ts
@@ -341,10 +341,10 @@ export class MultiStyleLabel extends Group {
     /** The implicit default style: a system-default font plus the node's `color`. */
     private getDefaultStyle(): DrawStyle {
         const color = this.getValueJS("color") as number;
-        if (!this.defaultStyle) {
-            this.defaultStyle = { font: SGNodeFactory.createNode(SGNodeType.Font) as Font, color };
-        } else {
+        if (this.defaultStyle) {
             this.defaultStyle.color = color;
+        } else {
+            this.defaultStyle = { font: SGNodeFactory.createNode(SGNodeType.Font) as Font, color };
         }
         return this.defaultStyle;
     }
@@ -540,7 +540,12 @@ export class MultiStyleLabel extends Group {
                 used += token.width;
                 continue;
             }
-            if (!onBoundary) {
+            if (onBoundary) {
+                // Whole-word ellipsis: drop trailing whitespace-only tokens.
+                while (result.length > 0 && result.at(-1)!.text.trim() === "") {
+                    result.pop();
+                }
+            } else {
                 // Character-level truncation within the overflowing token.
                 let truncated = "";
                 for (const char of token.text) {
@@ -553,12 +558,6 @@ export class MultiStyleLabel extends Group {
                 if (truncated.length > 0) {
                     const measured = token.font.measureText(truncated);
                     result.push({ ...token, text: truncated, width: measured.width, height: measured.height });
-                    used += measured.width;
-                }
-            } else {
-                // Whole-word ellipsis: drop trailing whitespace-only tokens.
-                while (result.length > 0 && result.at(-1)!.text.trim() === "") {
-                    result.pop();
                 }
             }
             break;

--- a/src/extensions/scenegraph/nodes/StandardDialog.ts
+++ b/src/extensions/scenegraph/nodes/StandardDialog.ts
@@ -153,18 +153,31 @@ export class StandardDialog extends Group {
                 this.lastFocus = undefined;
             }
         } else if (fieldName === "width") {
-            const newWidth = jsValueOf(value) as number;
-            if (newWidth > this.maxWidth) {
-                value = new BrsString(this.maxWidth.toString());
+            // Roku accepts a resolution-dependent { fhd, hd } map here as well as a plain number.
+            const resolved = this.resolveResolutionValue(value);
+            if (Number.isFinite(resolved)) {
+                this.width = Math.min(resolved, this.maxWidth);
+                this.contentWidth = Math.max(this.contentWidth, this.width - 2 * this.padX);
+                // Store a numeric value so the float `width` field accepts it (an AA would type-mismatch).
+                value = new Float(this.width);
             }
-            this.width = jsValueOf(value) as number;
-            this.contentWidth = Math.max(this.contentWidth, this.width - 2 * this.padX);
         }
         super.setValue(index, value, alwaysNotify, kind);
     }
 
     setDefaultTranslation() {
         this.setTranslation(this.dialogTrans);
+    }
+
+    /** Resolves a value that may be a plain number/string or a Roku `{ fhd, hd }` resolution map. */
+    private resolveResolutionValue(value: BrsType): number {
+        const resolved = jsValueOf(value);
+        if (resolved !== null && typeof resolved === "object") {
+            const map = resolved as Record<string, unknown>;
+            const key = this.resolution === "FHD" ? "fhd" : "hd";
+            return Number(map[key] ?? map[key.toUpperCase()] ?? map.hd ?? map.fhd);
+        }
+        return Number(resolved);
     }
 
     /** Requests a re-layout on the next frame (used by content items whose size is only known after

--- a/src/extensions/scenegraph/nodes/StdDlgMultiStyleTextItem.ts
+++ b/src/extensions/scenegraph/nodes/StdDlgMultiStyleTextItem.ts
@@ -1,0 +1,58 @@
+import { AAMember, BrsBoolean, BrsString, Float, Int32 } from "brs-engine";
+import { FieldModel } from "../SGTypes";
+import { SGNodeType } from ".";
+import { Group } from "./Group";
+import { MultiStyleLabel } from "./MultiStyleLabel";
+import { StdDlgItem, getDialogColors, colorFromPalette } from "./StdDlgItemBase";
+
+/**
+ * A line of mixed-style text inside a StandardDialog's content area. Mirrors Roku's
+ * StdDlgMultiStyleTextItem: the `drawingStyles` associative array defines named font styles
+ * (fontSize / fontUri / color) and the `text` field uses `<style>…</style>` markup to switch
+ * styles. Rendering is delegated to a wrapping MultiStyleLabel child; the `text`/`drawingStyles`
+ * fields are shared with it. Untagged text without a "default" style falls back to the dialog's
+ * text color. Extends Group (Roku's StdDlgItemBase is an abstract Group subclass).
+ */
+export class StdDlgMultiStyleTextItem extends Group implements StdDlgItem {
+    readonly defaultFields: FieldModel[] = [
+        { name: "text", type: "string", value: "" },
+        { name: "drawingStyles", type: "assocarray" },
+        { name: "audioGuideText", type: "string", value: "" },
+    ];
+    private label: MultiStyleLabel;
+
+    constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.StdDlgMultiStyleTextItem) {
+        super([], name);
+        this.setExtendsType(name, SGNodeType.Group);
+
+        this.registerDefaultFields(this.defaultFields);
+        this.registerInitializedFields(initializedFields);
+        this.label = this.buildLabel();
+    }
+
+    /** Creates the wrapping MultiStyleLabel and shares the `text`/`drawingStyles` fields with it. */
+    private buildLabel(): MultiStyleLabel {
+        const label = new MultiStyleLabel();
+        label.setValueSilent("wrap", BrsBoolean.True);
+        label.setValueSilent("horizAlign", new BrsString("left"));
+        label.setValueSilent("vertAlign", new BrsString("top"));
+        this.appendChildToParent(label);
+        this.linkField(label, "text");
+        this.linkField(label, "drawingStyles");
+        return label;
+    }
+
+    layoutItem(width: number): number {
+        // Untagged text (or text with no "default" style) uses the dialog's text color.
+        const color = colorFromPalette(getDialogColors(this), "DialogTextColor", "0xDDDDDDFF");
+        this.label.setValueSilent("color", new Int32(color));
+        // Set width through setValue (not silent) so the label rebuilds styles and re-measures
+        // against the shared text/drawingStyles before we read its height.
+        this.label.setValue("width", new Float(width));
+
+        const height = this.label.getMeasured().height;
+        this.setValueSilent("width", new Float(width));
+        this.setValueSilent("height", new Float(height));
+        return height;
+    }
+}

--- a/src/extensions/scenegraph/nodes/StdDlgMultiStyleTextItem.ts
+++ b/src/extensions/scenegraph/nodes/StdDlgMultiStyleTextItem.ts
@@ -19,7 +19,7 @@ export class StdDlgMultiStyleTextItem extends Group implements StdDlgItem {
         { name: "drawingStyles", type: "assocarray" },
         { name: "audioGuideText", type: "string", value: "" },
     ];
-    private label: MultiStyleLabel;
+    private readonly label: MultiStyleLabel;
 
     constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.StdDlgMultiStyleTextItem) {
         super([], name);

--- a/src/extensions/scenegraph/nodes/index.ts
+++ b/src/extensions/scenegraph/nodes/index.ts
@@ -17,6 +17,7 @@ export * from "./Keyboard";
 export * from "./KeyboardDialog";
 export * from "./Label";
 export * from "./SimpleLabel";
+export * from "./MultiStyleLabel";
 export * from "./InfoPane";
 export * from "./LabelList";
 export * from "./LayoutGroup";
@@ -127,7 +128,7 @@ export enum SGNodeType {
     Poster = "Poster",
     Label = "Label",
     SimpleLabel = "SimpleLabel",
-    MultiStyleLabel = "MultiStyleLabel", // Not yet implemented
+    MultiStyleLabel = "MultiStyleLabel",
     MonospaceLabel = "MonospaceLabel", // Not yet implemented
     ScrollingLabel = "ScrollingLabel",
     ScrollableText = "ScrollableText",

--- a/src/extensions/scenegraph/nodes/index.ts
+++ b/src/extensions/scenegraph/nodes/index.ts
@@ -59,6 +59,7 @@ export * from "./StdDlgContentArea";
 export * from "./StdDlgCustomItem";
 export * from "./StdDlgDeterminateProgressItem";
 export * from "./StdDlgKeyboardItem";
+export * from "./StdDlgMultiStyleTextItem";
 export * from "./StdDlgProgressItem";
 export * from "./StdDlgSideCardArea";
 export * from "./StdDlgTextItem";
@@ -119,7 +120,7 @@ export enum SGNodeType {
     StdDlgItemBase = "StdDlgItemBase", // Mocked as Group
     StdDlgItemGroup = "StdDlgItemGroup", // Mocked as Group
     StdDlgKeyboardItem = "StdDlgKeyboardItem",
-    StdDlgMultiStyleTextItem = "StdDlgMultiStyleTextItem", // Not yet implemented
+    StdDlgMultiStyleTextItem = "StdDlgMultiStyleTextItem",
     StdDlgProgressItem = "StdDlgProgressItem",
     StdDlgSideCardArea = "StdDlgSideCardArea",
     StdDlgTextItem = "StdDlgTextItem",

--- a/src/extensions/scenegraph/parser/ComponentDefinition.ts
+++ b/src/extensions/scenegraph/parser/ComponentDefinition.ts
@@ -486,5 +486,5 @@ function getScriptTagLocation(nodeDef: ComponentDefinition, script: XmlElement) 
  * @return the corrected column number for the last line of text as parsed by `xmlDoc`
  */
 function columnsInLastLine(lines: string[]): number {
-    return lines[lines.length - 1].length + lines.length - 1;
+    return lines.at(-1)!.length + lines.length - 1;
 }

--- a/test/extensions/scenegraph/MultiStyleLabel.test.js
+++ b/test/extensions/scenegraph/MultiStyleLabel.test.js
@@ -1,0 +1,207 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsDevice, BrsString, BrsBoolean, Int32, RoAssociativeArray } = core;
+
+/** Minimal interpreter accepted by renderNode → renderChildren (never dereferenced when draw2D is absent). */
+const fakeInterpreter = {};
+
+/**
+ * Builds a `drawingStyles` AA: { styleName: { fontUri, fontSize, color } }.
+ * Uses the RoAssociativeArray constructor (not .set) so keys keep their original
+ * case — exactly how the interpreter builds AA literals. Reading these properties
+ * must be case-insensitive (e.g. "fontUri", not "fonturi").
+ */
+function drawingStyles(styles) {
+    const outerMembers = [];
+    for (const [name, def] of Object.entries(styles)) {
+        const innerMembers = [];
+        if (def.fontUri !== undefined)
+            innerMembers.push({ name: new BrsString("fontUri"), value: new BrsString(def.fontUri) });
+        if (def.fontSize !== undefined)
+            innerMembers.push({ name: new BrsString("fontSize"), value: new Int32(def.fontSize) });
+        if (def.color !== undefined)
+            innerMembers.push({ name: new BrsString("color"), value: new BrsString(def.color) });
+        outerMembers.push({ name: new BrsString(name), value: new RoAssociativeArray(innerMembers) });
+    }
+    return new RoAssociativeArray(outerMembers);
+}
+
+/** Renders the label with a stub draw surface, capturing the font/color used per drawn span. */
+function captureSpans(label) {
+    const spans = [];
+    const draw2D = {
+        doDrawRotatedText(text, x, y, color, opacity, font, rotation) {
+            if (text.trim() !== "") spans.push({ text, family: font.family, size: font.size, color });
+        },
+    };
+    label.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+    return spans;
+}
+
+describe("MultiStyleLabel node", () => {
+    beforeAll(() => {
+        // MultiStyleLabel resolves its fonts from the common: volume; mount it once.
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    test("is wired into the factory as a MultiStyleLabel subtype", () => {
+        const label = SGNodeFactory.createNode("MultiStyleLabel");
+        expect(label).toBeDefined();
+        expect(label.constructor.name).toBe("MultiStyleLabel");
+        expect(label.nodeSubtype).toBe("MultiStyleLabel");
+    });
+
+    test("exposes the documented default fields, types and values", () => {
+        const label = SGNodeFactory.createNode("MultiStyleLabel");
+        const fields = label.getNodeFields();
+
+        const expected = [
+            ["text", "string", ""],
+            ["color", "color", 0xddddddff | 0], // stored as a signed 32-bit int
+            ["horizAlign", "string", "left"],
+            ["vertAlign", "string", "top"],
+            ["width", "float", 0],
+            ["height", "float", 0],
+            ["numLines", "integer", 0],
+            ["maxLines", "integer", 0],
+            ["wrap", "boolean", false],
+            ["ellipsizeOnBoundary", "boolean", false],
+            ["isTextEllipsized", "boolean", false],
+        ];
+        for (const [name, type, value] of expected) {
+            const field = fields.get(name.toLowerCase()); // the field map is keyed lowercase
+            expect(field).toBeDefined();
+            expect(field.getType()).toBe(type);
+            expect(label.getValueJS(name)).toBe(value);
+        }
+        expect(fields.get("drawingstyles")).toBeDefined();
+        expect(fields.get("drawingstyles").getType()).toBe("assocarray");
+    });
+
+    test("extends Group (inherits Group fields)", () => {
+        const label = SGNodeFactory.createNode("MultiStyleLabel");
+        const fields = label.getNodeFields();
+        for (const groupField of ["translation", "opacity", "visible", "rotation"]) {
+            expect(fields.get(groupField.toLowerCase())).toBeDefined();
+        }
+    });
+
+    test("round-trips drawingStyles as an associative array (keys keep their case)", () => {
+        const label = SGNodeFactory.createNode("MultiStyleLabel");
+        label.setValue("drawingStyles", drawingStyles({ red: { fontSize: 36, color: "#FF0000FF" } }));
+        const styles = label.getValueJS("drawingStyles");
+        // AA literals from the interpreter preserve original key case.
+        expect(styles.red.fontSize).toBe(36);
+        expect(styles.red.color).toBe("#FF0000FF");
+    });
+
+    test("resolves each markup span to its style's font and color (case-insensitive keys)", () => {
+        const label = SGNodeFactory.createNode("MultiStyleLabel");
+        label.setValue(
+            "drawingStyles",
+            drawingStyles({
+                default: { fontUri: "font:MediumSystemFont", color: "#FFFFFFFF" },
+                title: { fontUri: "font:LargeSystemFont", color: "#00FF00FF" },
+            })
+        );
+        label.setValue("text", new BrsString("body <title>BIG</title>"));
+        const spans = captureSpans(label);
+
+        const body = spans.find((s) => s.text === "body");
+        const big = spans.find((s) => s.text === "BIG");
+        expect(body).toBeDefined();
+        expect(big).toBeDefined();
+        // The styled span must pick up its own font (here a larger system font) and color.
+        // A regression in key casing (reading `fonturi` instead of `fontUri`) collapses both
+        // spans to the same default font/size, so these would be equal.
+        expect(big.size).toBeGreaterThan(body.size);
+        expect(big.color).toBe(0x00ff00ff | 0);
+        expect(body.color).toBe(0xffffffff | 0);
+    });
+
+    test("measures markup text after a measure pass", () => {
+        const label = SGNodeFactory.createNode("MultiStyleLabel");
+        label.setValue(
+            "drawingStyles",
+            drawingStyles({
+                default: { fontUri: "font:MediumSystemFont", color: "#FFFFFFFF" },
+                red: { fontUri: "font:MediumSystemFont", color: "#FF0000FF" },
+            })
+        );
+        label.setValue("text", new BrsString("Plain <red>Red text</red> tail"));
+        const measured = label.getMeasured();
+        expect(measured.width).toBeGreaterThan(0);
+        expect(measured.height).toBeGreaterThan(0);
+    });
+
+    test("renders mixed styles without a draw surface for every alignment", () => {
+        const label = SGNodeFactory.createNode("MultiStyleLabel");
+        label.setValue(
+            "drawingStyles",
+            drawingStyles({ default: { fontUri: "font:SmallSystemFont" }, big: { fontUri: "font:LargeSystemFont" } })
+        );
+        label.setValue("text", new BrsString("small <big>BIG</big> small"));
+        for (const h of ["left", "center", "right"]) {
+            for (const v of ["top", "center", "bottom"]) {
+                label.setValue("horizAlign", new BrsString(h));
+                label.setValue("vertAlign", new BrsString(v));
+                expect(() => label.renderNode(fakeInterpreter, [0, 0], 0, 1)).not.toThrow();
+            }
+        }
+    });
+
+    test("grows a line's height to make room for a larger inline span (baseline stacking)", () => {
+        const small = SGNodeFactory.createNode("MultiStyleLabel");
+        small.setValue("drawingStyles", drawingStyles({ default: { fontUri: "font:SmallSystemFont" } }));
+        small.setValue("text", new BrsString("small text only"));
+        const smallHeight = small.getMeasured().height;
+
+        const big = SGNodeFactory.createNode("MultiStyleLabel");
+        big.setValue("drawingStyles", drawingStyles({ default: { fontUri: "font:LargeSystemFont" } }));
+        big.setValue("text", new BrsString("big text only"));
+        const bigHeight = big.getMeasured().height;
+
+        const mixed = SGNodeFactory.createNode("MultiStyleLabel");
+        mixed.setValue(
+            "drawingStyles",
+            drawingStyles({ default: { fontUri: "font:SmallSystemFont" }, big: { fontUri: "font:LargeSystemFont" } })
+        );
+        mixed.setValue("text", new BrsString("small <big>BIG</big> small"));
+        // A single line containing a larger span grows to that span's line height (so it has
+        // room), rather than staying at the small base height.
+        expect(bigHeight).toBeGreaterThan(smallHeight);
+        expect(mixed.getMeasured().height).toBe(bigHeight);
+    });
+
+    test("ellipsizes a single line that overflows a fixed width", () => {
+        const label = SGNodeFactory.createNode("MultiStyleLabel");
+        label.setValue("drawingStyles", drawingStyles({ default: { fontUri: "font:MediumSystemFont" } }));
+        label.setValue("width", new Int32(60));
+        label.setValue("text", new BrsString("This text is far too long to ever fit in sixty pixels"));
+        label.getMeasured();
+        expect(label.getValueJS("isTextEllipsized")).toBe(true);
+    });
+
+    test("wraps text across multiple lines when wrap is true", () => {
+        const label = SGNodeFactory.createNode("MultiStyleLabel");
+        label.setValue("drawingStyles", drawingStyles({ default: { fontUri: "font:MediumSystemFont" } }));
+        label.setValue("width", new Int32(120));
+        label.setValue("wrap", BrsBoolean.True);
+        label.setValue("text", new BrsString("one two three four five six seven eight nine ten"));
+        const measured = label.getMeasured();
+        // More than one line tall: total height exceeds a single line's height.
+        const oneLine = SGNodeFactory.createNode("MultiStyleLabel");
+        oneLine.setValue("drawingStyles", drawingStyles({ default: { fontUri: "font:MediumSystemFont" } }));
+        oneLine.setValue("text", new BrsString("one"));
+        expect(measured.height).toBeGreaterThan(oneLine.getMeasured().height);
+    });
+});

--- a/test/extensions/scenegraph/StandardDialogNodes.test.js
+++ b/test/extensions/scenegraph/StandardDialogNodes.test.js
@@ -62,6 +62,7 @@ describe("Standard Dialog Framework nodes", () => {
             ["ParentalControlPinPad", "ParentalControlPinPad"],
             ["StdDlgTextItem", "StdDlgTextItem"],
             ["StdDlgBulletTextItem", "StdDlgBulletTextItem"],
+            ["StdDlgMultiStyleTextItem", "StdDlgMultiStyleTextItem"],
             ["StdDlgButton", "StdDlgButton"],
             ["StdDlgButtonArea", "StdDlgButtonArea"],
             ["StdDlgKeyboardItem", "StdDlgKeyboardItem"],
@@ -216,6 +217,97 @@ describe("Standard Dialog Framework nodes", () => {
             expect(child.constructor.name).toBe("ScrollableText");
             expect(item.getNodeChildren().length).toBe(1);
             expect(child.getValueJS("text")).toBe("Toggle me");
+        });
+    });
+
+    describe("StdDlgMultiStyleTextItem", () => {
+        /** Builds a case-preserving drawingStyles AA (as the interpreter does). */
+        function drawingStyles(styles) {
+            const outer = Object.entries(styles).map(([name, def]) => {
+                const inner = [];
+                if (def.fontUri !== undefined)
+                    inner.push({ name: new BrsString("fontUri"), value: new BrsString(def.fontUri) });
+                if (def.fontSize !== undefined)
+                    inner.push({ name: new BrsString("fontSize"), value: new Int32(def.fontSize) });
+                if (def.color !== undefined)
+                    inner.push({ name: new BrsString("color"), value: new BrsString(def.color) });
+                return { name: new BrsString(name), value: new RoAssociativeArray(inner) };
+            });
+            return new RoAssociativeArray(outer);
+        }
+
+        test("exposes the documented fields with their defaults", () => {
+            const item = SGNodeFactory.createNode("StdDlgMultiStyleTextItem");
+            expect(item.getValueJS("text")).toBe("");
+            expect(item.getValueJS("audioGuideText")).toBe("");
+            expect(item.getNodeFields().get("drawingstyles")).toBeDefined();
+        });
+
+        test("renders the text through a wrapping MultiStyleLabel sharing text/drawingStyles", () => {
+            const item = SGNodeFactory.createNode("StdDlgMultiStyleTextItem");
+            item.setValue(
+                "drawingStyles",
+                drawingStyles({
+                    default: { fontUri: "font:MediumSystemFont", color: "#EFEFEFFF" },
+                    url: { fontUri: "font:MediumSystemFont", color: "#00FF00FF" },
+                })
+            );
+            item.setValue("text", new BrsString("Visit <url>http://www.roku.com</url> for details."));
+
+            const label = item.getNodeChildren()[0];
+            expect(label.constructor.name).toBe("MultiStyleLabel");
+            expect(label.getValueJS("wrap")).toBe(true);
+            // The shared fields drive the inner label.
+            expect(label.getValueJS("text")).toContain("roku.com");
+            expect(label.getValueJS("drawingStyles").url.color).toBe("#00FF00FF");
+
+            const height = item.layoutItem(600);
+            expect(height).toBeGreaterThan(0);
+            expect(item.getValueJS("width")).toBe(600);
+            expect(item.getValueJS("height")).toBe(height);
+            expect(label.getValueJS("width")).toBe(600);
+        });
+
+        test("lays out inside a StandardDialog content area", () => {
+            const dialog = SGNodeFactory.createNode("StandardDialog");
+            const content = SGNodeFactory.createNode("StdDlgContentArea");
+            const item = SGNodeFactory.createNode("StdDlgMultiStyleTextItem");
+            item.setValue("drawingStyles", drawingStyles({ default: { fontUri: "font:MediumSystemFont" } }));
+            item.setValue("text", new BrsString("Plain dialog text item"));
+            content.appendChildToParent(item);
+            dialog.appendChildToParent(content);
+
+            expect(() => dialog.renderNode(fakeInterpreter, [0, 0], 0, 1)).not.toThrow();
+            expect(item.getValueJS("height")).toBeGreaterThan(0);
+        });
+    });
+
+    describe("StandardDialog width", () => {
+        test("resolves a { fhd, hd } resolution map (and recenters to a valid position)", () => {
+            const dialog = SGNodeFactory.createNode("StandardDialog");
+            const content = SGNodeFactory.createNode("StdDlgContentArea");
+            const item = SGNodeFactory.createNode("StdDlgTextItem");
+            item.setValue("text", new BrsString("Body"));
+            content.appendChildToParent(item);
+            dialog.appendChildToParent(content);
+
+            // Roku accepts a resolution-dependent width map; HD picks the `hd` value.
+            dialog.setValue(
+                "width",
+                new RoAssociativeArray([
+                    { name: new BrsString("fhd"), value: new Int32(1380) },
+                    { name: new BrsString("hd"), value: new Int32(920) },
+                ])
+            );
+            dialog.renderNode(fakeInterpreter, [0, 0], 0, 1);
+
+            expect(dialog.getValueJS("width")).toBe(920);
+            // Layout produced finite geometry (a broken width collapses everything to NaN/0).
+            const translation = dialog.getValueJS("translation");
+            expect(Number.isFinite(translation[0])).toBe(true);
+            expect(Number.isFinite(translation[1])).toBe(true);
+            expect(dialog.getValueJS("height")).toBeGreaterThan(0);
+            expect(content.getValueJS("width")).toBeGreaterThan(0);
         });
     });
 


### PR DESCRIPTION
## Summary

Implements two related SceneGraph nodes plus a supporting `StandardDialog` fix.

### `MultiStyleLabel` (renderable / label node, extends `Group`)
Renders a single string of text using mixed styles within one label. Styles are defined in a `drawingStyles` associative array (`fontSize` / `fontUri` / `color`) and the `text` field uses `<style>…</style>` markup to switch styles; untagged text uses the `"default"` style or the node's `color`.

- Reads `drawingStyles` properties **case-insensitively** (`fontUri`/`fontSize`/`color`, and `{ fhd, hd }` size maps) — interpreter AA literals preserve original key case, so lowercased reads would miss them.
- **Baseline-stacked** line layout: each line advances by its own ascent/descent, so a larger inline font pushes the line down to make room while all spans share a common baseline (matching Roku).
- Supports `wrap`, `width`/`height`, `numLines`/`maxLines`, ellipsis, and horizontal/vertical alignment.

### `StdDlgMultiStyleTextItem` (Standard Dialog Framework item, extends `StdDlgItemBase`)
Adds a line of mixed-style text to a custom dialog's content area, delegating rendering to a wrapping `MultiStyleLabel` child (shares the `text`/`drawingStyles` fields) and exposing `audioGuideText`. Untagged text falls back to the dialog's `DialogTextColor`.

### `StandardDialog` width fix
`StandardDialog` now resolves a resolution-dependent `{ fhd, hd }` map for its `width` field (Roku convention). Previously the assoc array was assigned to the float field directly, leaving `width`/`contentWidth` as `NaN` so the dialog sized/recentered to `NaN` — the frame disappeared and content collapsed to the top-left. This surfaced via the `MultiStyleTextItemDialog` sample, which sets `m.top.width = {fhd:1380, hd:920}`.

## Wiring
Both nodes are added to the `SGNodeType` enum and `SGNodeFactory` so `CreateObject("roSGNode", …)` and XML resolve them.

## Tests
- `test/extensions/scenegraph/MultiStyleLabel.test.js` — fields/defaults, per-span font/size/color resolution (case-insensitive keys), baseline stacking, wrap, ellipsis.
- `test/extensions/scenegraph/StandardDialogNodes.test.js` — factory wiring, the item rendering through a shared `MultiStyleLabel` and laying out in a dialog, and the `{ fhd, hd }` width resolution.

All extension tests pass (`npm test`), lint and prettier are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)