### PR TITLE
feat(scenegraph): implement MonospaceLabel node

### DIFF
--- a/src/extensions/scenegraph/factory/NodeFactory.ts
+++ b/src/extensions/scenegraph/factory/NodeFactory.ts
@@ -44,6 +44,7 @@ import {
     MarkupList,
     MiniKeyboard,
     MultiStyleLabel,
+    MonospaceLabel,
     PinPad,
     PinDialog,
     Node,
@@ -183,6 +184,8 @@ export class SGNodeFactory {
                 return new SimpleLabel([], name);
             case SGNodeType.MultiStyleLabel.toLowerCase():
                 return new MultiStyleLabel([], name);
+            case SGNodeType.MonospaceLabel.toLowerCase():
+                return new MonospaceLabel([], name);
             case SGNodeType.InfoPane.toLowerCase():
                 return new InfoPane([], name);
             case SGNodeType.ScrollingLabel.toLowerCase():

--- a/src/extensions/scenegraph/nodes/MonospaceLabel.ts
+++ b/src/extensions/scenegraph/nodes/MonospaceLabel.ts
@@ -1,0 +1,129 @@
+import { AAMember, BrsType, IfDraw2D, MeasuredText, Rect, RoFont } from "brs-engine";
+import { FieldKind, FieldModel } from "../SGTypes";
+import { SGNodeType } from ".";
+import { Label } from "./Label";
+import type { Font } from "./Font";
+import { rotateTranslation } from "../SGUtil";
+
+/**
+ * MonospaceLabel draws a single line of text with every character spaced at a fixed
+ * distance, transforming a proportional font into a monospaced one. Each glyph is drawn
+ * centered within its fixed-width character cell (see `firstCharTrueLeftAlign` for the
+ * first-character exception). Available since Roku OS 14.0.
+ */
+export class MonospaceLabel extends Label {
+    readonly defaultFields: FieldModel[] = [
+        { name: "characterWidth", type: "float", value: "0" },
+        { name: "firstCharTrueLeftAlign", type: "boolean", value: "false" },
+    ];
+
+    constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.MonospaceLabel) {
+        super([], name);
+        this.setExtendsType(name, SGNodeType.Label);
+
+        this.registerDefaultFields(this.defaultFields);
+        this.registerInitializedFields(initializedFields);
+    }
+
+    setValue(index: string, value: BrsType, alwaysNotify?: boolean, kind?: FieldKind) {
+        super.setValue(index, value, alwaysNotify, kind);
+        const fieldName = index.toLowerCase();
+        if (fieldName === "characterwidth" || fieldName === "firstchartruealign") {
+            // Cell layout changed: drop the cached measurement and re-measure.
+            this.measured = undefined;
+            this.getMeasured();
+        }
+    }
+
+    protected renderLabel(rect: Rect, rotation: number, opacity: number, draw2D?: IfDraw2D): MeasuredText {
+        const font = this.getValue("font") as Font;
+        const drawFont = font.createDrawFont();
+        const fullText = (this.getValueJS("text") as string) ?? "";
+        if (!(drawFont instanceof RoFont)) {
+            return { text: fullText, width: 0, height: 0, ellipsized: false };
+        }
+
+        const color = this.getValueJS("color") as number;
+        const horizAlign = (this.getValueJS("horizAlign") as string) || "left";
+        const vertAlign = (this.getValueJS("vertAlign") as string) || "top";
+        const ellipsis = (this.getValueJS("ellipsisText") as string) || "...";
+        const characterWidth = (this.getValueJS("characterWidth") as number) ?? 0;
+        const firstCharTrueLeftAlign = (this.getValueJS("firstCharTrueLeftAlign") as boolean) ?? false;
+        const ellipsizeOnBoundary = (this.getValueJS("ellipsizeOnBoundary") as boolean) ?? false;
+        const wordBreakChars = (this.getValueJS("wordBreakChars") as string) || "";
+
+        // MonospaceLabel renders a single line only.
+        const newlineIndex = fullText.indexOf("\n");
+        let text = newlineIndex === -1 ? fullText : fullText.substring(0, newlineIndex);
+
+        // If characterWidth is zero, use the natural width of the font's 'M' character.
+        const cellWidth = characterWidth > 0 ? characterWidth : drawFont.measureTextWidth("M").width;
+
+        let ellipsized = false;
+        if (rect.width > 0 && cellWidth > 0 && text.length * cellWidth > rect.width) {
+            const maxCells = Math.floor(rect.width / cellWidth);
+            const keep = Math.max(0, maxCells - ellipsis.length);
+            let kept = text.substring(0, keep);
+            if (ellipsizeOnBoundary) {
+                kept = this.trimToBoundary(kept, wordBreakChars);
+            }
+            text = kept + ellipsis;
+            ellipsized = true;
+        }
+
+        const lineHeight = drawFont.measureTextHeight();
+        const totalWidth = text.length * cellWidth;
+
+        // Align the whole run within the label box (same rules as Group.drawText).
+        let startX = 0;
+        if (rect.width > totalWidth) {
+            if (horizAlign === "center") {
+                startX = (rect.width - totalWidth) / 2;
+            } else if (horizAlign === "right") {
+                startX = rect.width - totalWidth;
+            }
+        }
+        let startY = 0;
+        if (rect.height > lineHeight) {
+            if (vertAlign === "center") {
+                startY = (rect.height - lineHeight) / 2;
+            } else if (vertAlign === "bottom") {
+                startY = rect.height - lineHeight;
+            }
+        }
+
+        if (draw2D) {
+            const chars = [...text];
+            for (let i = 0; i < chars.length; i++) {
+                const char = chars[i];
+                const centerOffset =
+                    i === 0 && firstCharTrueLeftAlign ? 0 : (cellWidth - drawFont.measureTextWidth(char).width) / 2;
+                const local = [startX + i * cellWidth + centerOffset, startY];
+                const screen = rotation === 0 ? local : rotateTranslation(local, rotation);
+                draw2D.doDrawRotatedText(
+                    char,
+                    rect.x + screen[0],
+                    rect.y + screen[1],
+                    color,
+                    opacity,
+                    drawFont,
+                    rotation
+                );
+            }
+        }
+
+        this.setEllipsized(ellipsized);
+        return { text, width: totalWidth, height: lineHeight, ellipsized };
+    }
+
+    /** Trims trailing partial word back to the last word-break character (space, hyphen, or any in wordBreakChars). */
+    private trimToBoundary(text: string, wordBreakChars: string): string {
+        const breakSet = new Set([" ", "-", ...wordBreakChars]);
+        for (let i = text.length - 1; i >= 0; i--) {
+            if (breakSet.has(text[i])) {
+                return text.substring(0, i);
+            }
+        }
+        return text;
+    }
+}

--- a/src/extensions/scenegraph/nodes/index.ts
+++ b/src/extensions/scenegraph/nodes/index.ts
@@ -18,6 +18,7 @@ export * from "./KeyboardDialog";
 export * from "./Label";
 export * from "./SimpleLabel";
 export * from "./MultiStyleLabel";
+export * from "./MonospaceLabel";
 export * from "./InfoPane";
 export * from "./LabelList";
 export * from "./LayoutGroup";
@@ -130,7 +131,7 @@ export enum SGNodeType {
     Label = "Label",
     SimpleLabel = "SimpleLabel",
     MultiStyleLabel = "MultiStyleLabel",
-    MonospaceLabel = "MonospaceLabel", // Not yet implemented
+    MonospaceLabel = "MonospaceLabel",
     ScrollingLabel = "ScrollingLabel",
     ScrollableText = "ScrollableText",
     InfoPane = "InfoPane",

--- a/test/extensions/scenegraph/MonospaceLabel.test.js
+++ b/test/extensions/scenegraph/MonospaceLabel.test.js
@@ -1,0 +1,175 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsDevice, BrsString, BrsBoolean, Float } = core;
+
+/** Minimal interpreter accepted by renderNode → renderChildren (never dereferenced when draw2D is absent). */
+const fakeInterpreter = {};
+
+/** Renders the label with a stub draw surface, capturing each drawn glyph (text + position + color). */
+function captureGlyphs(label, origin = [0, 0]) {
+    const glyphs = [];
+    const draw2D = {
+        doDrawRotatedText(text, x, y, color, opacity, font, rotation) {
+            glyphs.push({ text, x, y, color, rotation });
+        },
+    };
+    label.renderNode(fakeInterpreter, origin, 0, 1, draw2D);
+    return glyphs;
+}
+
+describe("MonospaceLabel node", () => {
+    beforeAll(() => {
+        // Fonts are resolved from the common: volume; mount it once.
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    test("is wired into the factory as a MonospaceLabel subtype", () => {
+        const label = SGNodeFactory.createNode("MonospaceLabel");
+        expect(label).toBeDefined();
+        expect(label.constructor.name).toBe("MonospaceLabel");
+        expect(label.nodeSubtype).toBe("MonospaceLabel");
+    });
+
+    test("exposes the documented default fields, types and values", () => {
+        const label = SGNodeFactory.createNode("MonospaceLabel");
+        const fields = label.getNodeFields();
+
+        const expected = [
+            ["text", "string", ""],
+            ["color", "color", 0xddddddff | 0], // stored as a signed 32-bit int
+            ["horizAlign", "string", "left"],
+            ["vertAlign", "string", "top"],
+            ["width", "float", 0],
+            ["height", "float", 0],
+            ["characterWidth", "float", 0],
+            ["firstCharTrueLeftAlign", "boolean", false],
+            ["ellipsizeOnBoundary", "boolean", false],
+            ["isTextEllipsized", "boolean", false],
+        ];
+        for (const [name, type, value] of expected) {
+            const field = fields.get(name.toLowerCase()); // the field map is keyed lowercase
+            expect(field).toBeDefined();
+            expect(field.getType()).toBe(type);
+            expect(label.getValueJS(name)).toBe(value);
+        }
+    });
+
+    test("extends Label (inherits Group fields)", () => {
+        const label = SGNodeFactory.createNode("MonospaceLabel");
+        const fields = label.getNodeFields();
+        for (const groupField of ["translation", "opacity", "visible", "rotation", "font"]) {
+            expect(fields.get(groupField.toLowerCase())).toBeDefined();
+        }
+    });
+
+    test("spaces identical characters by exactly characterWidth", () => {
+        const label = SGNodeFactory.createNode("MonospaceLabel");
+        label.setValue("characterWidth", new Float(40));
+        label.setValue("text", new BrsString("iiii"));
+        const glyphs = captureGlyphs(label);
+
+        expect(glyphs.map((g) => g.text)).toEqual(["i", "i", "i", "i"]);
+        for (let i = 1; i < glyphs.length; i++) {
+            expect(glyphs[i].x - glyphs[i - 1].x).toBeCloseTo(40, 5);
+        }
+    });
+
+    test("falls back to the width of 'M' when characterWidth is zero", () => {
+        const label = SGNodeFactory.createNode("MonospaceLabel");
+        label.setValue("text", new BrsString("WWWW")); // identical chars => uniform centering offset
+        const glyphs = captureGlyphs(label);
+
+        expect(glyphs).toHaveLength(4);
+        const cell = glyphs[1].x - glyphs[0].x;
+        expect(cell).toBeGreaterThan(0);
+        for (let i = 1; i < glyphs.length; i++) {
+            expect(glyphs[i].x - glyphs[i - 1].x).toBeCloseTo(cell, 5);
+        }
+    });
+
+    test("firstCharTrueLeftAlign left-aligns only the first character in its cell", () => {
+        const label = SGNodeFactory.createNode("MonospaceLabel");
+        label.setValue("characterWidth", new Float(60)); // wider than 'i' so centering offset is visible
+        label.setValue("firstCharTrueLeftAlign", BrsBoolean.True);
+        label.setValue("text", new BrsString("iii"));
+        const glyphs = captureGlyphs(label);
+
+        // First glyph sits at the cell's left edge (offset 0); the rest are centered.
+        expect(glyphs[0].x).toBeCloseTo(0, 5);
+        const firstDelta = glyphs[1].x - glyphs[0].x;
+        const laterDelta = glyphs[2].x - glyphs[1].x;
+        expect(laterDelta).toBeCloseTo(60, 5);
+        expect(firstDelta).toBeGreaterThan(laterDelta);
+    });
+
+    test("ellipsizes by character when the text exceeds the width", () => {
+        const label = SGNodeFactory.createNode("MonospaceLabel");
+        label.setValue("characterWidth", new Float(40));
+        label.setValue("width", new Float(240)); // 6 cells: keep 3 chars + "..."
+        label.setValue("text", new BrsString("abcdefghij"));
+        const glyphs = captureGlyphs(label);
+
+        expect(label.getValueJS("isTextEllipsized")).toBe(true);
+        expect(glyphs.map((g) => g.text).join("")).toBe("abc...");
+    });
+
+    test("ellipsizeOnBoundary trims back to a whole word", () => {
+        const label = SGNodeFactory.createNode("MonospaceLabel");
+        label.setValue("characterWidth", new Float(40));
+        label.setValue("width", new Float(320)); // 8 cells: keep 5 chars + "..."
+
+        label.setValue("ellipsizeOnBoundary", BrsBoolean.False);
+        label.setValue("text", new BrsString("ab cdefghij"));
+        expect(
+            captureGlyphs(label)
+                .map((g) => g.text)
+                .join("")
+        ).toBe("ab cd...");
+
+        label.setValue("ellipsizeOnBoundary", BrsBoolean.True);
+        expect(
+            captureGlyphs(label)
+                .map((g) => g.text)
+                .join("")
+        ).toBe("ab...");
+    });
+
+    test("horizAlign offsets the whole run within an oversized width", () => {
+        const make = (align) => {
+            const label = SGNodeFactory.createNode("MonospaceLabel");
+            label.setValue("characterWidth", new Float(40));
+            label.setValue("width", new Float(400));
+            label.setValue("text", new BrsString("ab"));
+            label.setValue("horizAlign", new BrsString(align));
+            return captureGlyphs(label);
+        };
+        const left = make("left");
+        const right = make("right");
+        // Both runs share the same per-glyph centering, so the right-aligned run is shifted
+        // by exactly the slack (width - 2 cells = 400 - 80 = 320).
+        expect(right[0].x - left[0].x).toBeCloseTo(320, 5);
+    });
+
+    test("renders without a draw surface for every alignment", () => {
+        const label = SGNodeFactory.createNode("MonospaceLabel");
+        label.setValue("text", new BrsString("monospace"));
+        label.setValue("width", new Float(200));
+        label.setValue("height", new Float(80));
+        for (const h of ["left", "center", "right"]) {
+            for (const v of ["top", "center", "bottom"]) {
+                label.setValue("horizAlign", new BrsString(h));
+                label.setValue("vertAlign", new BrsString(v));
+                expect(() => label.renderNode(fakeInterpreter, [0, 0], 0, 1)).not.toThrow();
+            }
+        }
+    });
+});

--- a/test/simulator/monospace-label-test/components/MonospaceScene.brs
+++ b/test/simulator/monospace-label-test/components/MonospaceScene.brs
@@ -1,0 +1,25 @@
+sub init()
+    m.top.setFocus(true)
+    m.top.backgroundColor = "0x101418FF"
+
+    ' Random-ish counter that visits values of different digit widths, so the proportional
+    ' Label visibly jitters while the MonospaceLabel stays put.
+    m.plCounter = m.top.findNode("plCounter")
+    m.msCounter = m.top.findNode("msCounter")
+    m.count = 11111110
+
+    m.ticker = m.top.findNode("ticker")
+    m.ticker.observeField("fire", "onTick")
+    m.ticker.control = "start"
+end sub
+
+sub onTick()
+    ' Step by an uneven amount so the number of "1" (narrow) vs "8" (wide) digits keeps
+    ' changing - that is exactly what shifts a proportional, right-aligned Label around.
+    m.count = m.count + 1234567
+    if m.count > 99999999 then m.count = 10000001
+
+    text = m.count.ToStr()
+    m.plCounter.text = text
+    m.msCounter.text = text
+end sub

--- a/test/simulator/monospace-label-test/components/MonospaceScene.xml
+++ b/test/simulator/monospace-label-test/components/MonospaceScene.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  MonospaceLabel example scene.
+
+  MonospaceLabel draws a single line of text with every character spaced at a fixed
+  distance, turning a proportional font into a monospaced one. Each glyph is centered in
+  its own fixed-width "character box". This demo shows:
+
+    * fixed-column alignment (the same column index lands at the same x across rows)
+    * an explicit characterWidth vs. the default ('M' width)
+    * firstCharTrueLeftAlign
+    * horizAlign within an oversized width
+    * ellipsis when the text is wider than width
+    * the classic real-world win: a counter that updates without horizontal jitter
+-->
+<component name="MonospaceScene" extends="Scene">
+    <children>
+        <Rectangle width="1920" height="1080" color="0x101418FF" />
+
+        <Label id="title" text="MonospaceLabel" font="font:LargeBoldSystemFont"
+               color="0xFFFFFFFF" translation="[60, 30]" />
+
+        <!-- Fixed-column alignment: same characterWidth, different text. The Nth glyph of
+             every row shares the same x, so the characters line up in a grid. -->
+        <Label text="Fixed columns (characterWidth = 56):" font="font:MediumBoldSystemFont"
+               color="0x8AB4F8FF" translation="[60, 130]" />
+        <MonospaceLabel text="ABCDEFGH" characterWidth="56" font="font:LargeSystemFont"
+                        color="0xDDDDDDFF" translation="[60, 180]" />
+        <MonospaceLabel text="il1mwMW." characterWidth="56" font="font:LargeSystemFont"
+                        color="0xDDDDDDFF" translation="[60, 240]" />
+        <MonospaceLabel text="01234567" characterWidth="56" font="font:LargeSystemFont"
+                        color="0xDDDDDDFF" translation="[60, 300]" />
+
+        <!-- firstCharTrueLeftAlign: with it off (default) a single glyph is centered in its
+             box; with it on the first glyph hugs the left edge of the box. -->
+        <Label text="firstCharTrueLeftAlign:" font="font:MediumBoldSystemFont"
+               color="0x8AB4F8FF" translation="[60, 410]" />
+        <MonospaceLabel text="off: W" characterWidth="56" font="font:LargeSystemFont"
+                        color="0xDDDDDDFF" translation="[60, 460]" />
+        <MonospaceLabel text="on:  W" characterWidth="56" firstCharTrueLeftAlign="true"
+                        font="font:LargeSystemFont" color="0xDDDDDDFF" translation="[60, 520]" />
+
+        <!-- horizAlign inside a fixed width box (box edge drawn for reference). -->
+        <Label text="horizAlign in width=560:" font="font:MediumBoldSystemFont"
+               color="0x8AB4F8FF" translation="[60, 630]" />
+        <Rectangle width="560" height="180" color="0x202832FF" translation="[60, 680]" />
+        <MonospaceLabel text="left" characterWidth="40" width="560" horizAlign="left"
+                        font="font:MediumSystemFont" color="0xDDDDDDFF" translation="[60, 680]" />
+        <MonospaceLabel text="center" characterWidth="40" width="560" horizAlign="center"
+                        font="font:MediumSystemFont" color="0xDDDDDDFF" translation="[60, 740]" />
+        <MonospaceLabel text="right" characterWidth="40" width="560" horizAlign="right"
+                        font="font:MediumSystemFont" color="0xDDDDDDFF" translation="[60, 800]" />
+
+        <!-- Ellipsis: text wider than width is clipped with "..." (per-character here). -->
+        <Label text="ellipsis (width=520):" font="font:MediumBoldSystemFont"
+               color="0x8AB4F8FF" translation="[760, 130]" />
+        <MonospaceLabel id="ellip" text="The quick brown fox jumps"
+                        characterWidth="40" width="520" font="font:MediumSystemFont"
+                        color="0xDDDDDDFF" translation="[760, 180]" />
+
+        <!-- Jitter-free counter: a proportional Label shifts as digit widths change, while
+             the MonospaceLabel keeps every digit in a fixed column. Both updated on a Timer. -->
+        <Label text="Updating counter (Label vs MonospaceLabel):" font="font:MediumBoldSystemFont"
+               color="0x8AB4F8FF" translation="[760, 300]" />
+        <Label text="Label:" font="font:MediumSystemFont" color="0x9AA0A6FF" translation="[760, 360]" />
+        <Label id="plCounter" text="00000000" font="font:LargeSystemFont"
+               color="0xF28B82FF" horizAlign="right" width="420" translation="[940, 350]" />
+        <Label text="Mono:" font="font:MediumSystemFont" color="0x9AA0A6FF" translation="[760, 430]" />
+        <MonospaceLabel id="msCounter" text="00000000" characterWidth="44" font="font:LargeSystemFont"
+                        color="0x81C995FF" horizAlign="right" width="420" translation="[940, 420]" />
+
+        <Timer id="ticker" repeat="true" duration="0.15" />
+    </children>
+
+    <script type="text/brightscript" uri="MonospaceScene.brs" />
+</component>

--- a/test/simulator/monospace-label-test/manifest
+++ b/test/simulator/monospace-label-test/manifest
@@ -1,0 +1,10 @@
+##   Channel Details
+title=MonospaceLabel Test
+major_version=1
+minor_version=0
+build_version=00001
+
+splash_color=#000000
+splash_min_time=1
+
+ui_resolutions=fhd

--- a/test/simulator/monospace-label-test/source/main.brs
+++ b/test/simulator/monospace-label-test/source/main.brs
@@ -1,0 +1,16 @@
+sub Main()
+    ' SceneGraph application entry point: create the screen and show the scene.
+    screen = CreateObject("roSGScreen")
+    m.port = CreateObject("roMessagePort")
+    screen.setMessagePort(m.port)
+
+    scene = screen.CreateScene("MonospaceScene")
+    screen.show()
+
+    while true
+        msg = wait(0, m.port)
+        if type(msg) = "roSGScreenEvent"
+            if msg.isScreenClosed() then return
+        end if
+    end while
+end sub


### PR DESCRIPTION
## Overview

Implements the **`MonospaceLabel`** SceneGraph node (Roku OS 14.0+), which draws a single line of text with every character spaced at a fixed distance — turning a proportional font into a monospaced one. Previously the `SGNodeType.MonospaceLabel` enum slot existed but was marked *Not yet implemented*, so the node fell back to a plain `Node`.

Spec: `external/dev-doc/docs/REFERENCES/scenegraph/label-nodes/monospace-label.md`.

## Implementation

- **`src/extensions/scenegraph/nodes/MonospaceLabel.ts`** (new) — extends `Label` and adds the two documented fields:
  - `characterWidth` (`float`, default `0` → uses the natural width of the font's `M`)
  - `firstCharTrueLeftAlign` (`boolean`, default `false`)
- Overrides `renderLabel` to lay out **each glyph centered within its fixed-width cell** (the first glyph hugs the cell's left edge when `firstCharTrueLeftAlign` is set), advancing `x` by the cell width. It reuses the existing `IfDraw2D.doDrawRotatedText` primitive per glyph together with `rotateTranslation`, so rotation stays correct with **no canvas-API change**.
- Single-line layout with `horizAlign`/`vertAlign` and ellipsis to fit `width`: `ellipsizeOnBoundary` trims by whole word (via `wordBreakChars`), otherwise by character. Updates the read-only `isTextEllipsized`.
- Wires the node into the `SGNodeType` re-export (`nodes/index.ts`) and `SGNodeFactory.createNode` (`factory/NodeFactory.ts`).

### Why not `ctx.letterSpacing`?

`CanvasRenderingContext2D.letterSpacing` only inserts a *uniform gap* between proportional glyphs — it can't center each glyph in a fixed grid cell (so `W` and `i` wouldn't align to a column) nor express `firstCharTrueLeftAlign`. Per-character centered placement is what the spec ("centered in their character box") requires.

## Tests & example

- **`test/extensions/scenegraph/MonospaceLabel.test.js`** — 10 tests: factory wiring, documented default fields/types, fixed-column spacing, `M`-width fallback, `firstCharTrueLeftAlign`, character/word-boundary ellipsis, and alignment.
- **`test/simulator/monospace-label-test/`** — a runnable SceneGraph example app demonstrating fixed-column alignment, `characterWidth`, `firstCharTrueLeftAlign`, `horizAlign`, ellipsis, and a `Timer`-driven jitter-free counter (proportional `Label` vs `MonospaceLabel`).

## Verification

- `npm run lint` and `npm run prettier:check` — clean
- `npx jest test/extensions/scenegraph` — 192 passed (incl. the new 10)
- Ran the example app via `brs-cli --ascii 64 --root test/simulator/monospace-label-test source/main.brs` — renders and animates with no warnings/errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)