### PR TITLE
feat(scenegraph): implement TargetSet, TargetGroup and TargetList nodes

### DIFF
--- a/src/extensions/scenegraph/factory/NodeFactory.ts
+++ b/src/extensions/scenegraph/factory/NodeFactory.ts
@@ -87,6 +87,9 @@ import {
     StdDlgSideCardArea,
     StdDlgTextItem,
     StdDlgTitleArea,
+    TargetSet,
+    TargetGroup,
+    TargetList,
     Task,
     TextEditBox,
     TimeGrid,
@@ -155,12 +158,17 @@ export class SGNodeFactory {
             case SGNodeType.Node.toLowerCase():
                 return new Node([], name);
             case SGNodeType.Group.toLowerCase():
-            case SGNodeType.TargetGroup.toLowerCase():
             case SGNodeType.StdDlgGraphicItem.toLowerCase():
             case SGNodeType.StdDlgAreaBase.toLowerCase():
             case SGNodeType.StdDlgItemBase.toLowerCase():
             case SGNodeType.StdDlgItemGroup.toLowerCase():
                 return new Group([], name);
+            case SGNodeType.TargetSet.toLowerCase():
+                return new TargetSet([], name);
+            case SGNodeType.TargetGroup.toLowerCase():
+                return new TargetGroup([], name);
+            case SGNodeType.TargetList.toLowerCase():
+                return new TargetList([], name);
             case SGNodeType.ScrollableText.toLowerCase():
                 return new ScrollableText([], name);
             case SGNodeType.MaskGroup.toLowerCase():

--- a/src/extensions/scenegraph/nodes/TargetGroup.ts
+++ b/src/extensions/scenegraph/nodes/TargetGroup.ts
@@ -1,0 +1,309 @@
+import { AAMember, Interpreter, BrsBoolean, BrsType, Float, Int32, isNumberComp, IfDraw2D, Rect } from "brs-engine";
+import { FieldKind, FieldModel } from "../SGTypes";
+import { SGNodeType } from ".";
+import { Group } from "./Group";
+import { ContentNode } from "./ContentNode";
+import { TargetSet } from "./TargetSet";
+import { sgRoot } from "../SGRoot";
+import { createNode } from "../factory/NodeFactory";
+import { brsValueOf } from "../factory/Serializer";
+import { rotateTranslation } from "../SGUtil";
+
+/**
+ * TargetGroup maps the items of its `content` ContentNode onto the rectangular regions defined by a
+ * {@link TargetSet}. An `itemComponentName` XML component is instantiated on demand for each visible
+ * item and positioned at its current target rectangle.
+ *
+ * This is a functional ("snap to target") implementation: `jumpToItem` and `animateToItem` both move
+ * focus immediately, so `currFocusItemIndex`/`currTarget` stay integer and `focusPercent` is 0 or 1.
+ * The `duration`/`easeFunction`/`advancing`/`reversing` fields are registered and stored but do not
+ * yet drive a time-based tween.
+ */
+export class TargetGroup extends Group {
+    readonly defaultFields: FieldModel[] = [
+        { name: "itemComponentName", type: "string", value: "" },
+        { name: "content", type: "node" },
+        { name: "targetSet", type: "node" },
+        { name: "defaultTargetSetFocusIndex", type: "integer", value: "0" },
+        { name: "wrap", type: "boolean", value: "false" },
+        { name: "duration", type: "time", value: "0.3" },
+        { name: "showTargetRects", type: "boolean", value: "false" },
+        { name: "currFocusItemIndex", type: "float", value: "-1.0", alwaysNotify: true },
+        { name: "currTargetSet", type: "node" },
+        { name: "itemSelected", type: "integer", value: "0", alwaysNotify: true },
+        { name: "itemFocused", type: "integer", value: "0", alwaysNotify: true },
+        { name: "itemUnfocused", type: "integer", value: "0", alwaysNotify: true },
+        { name: "jumpToItem", type: "integer", value: "0", alwaysNotify: true },
+        { name: "animateToItem", type: "integer", value: "0", alwaysNotify: true },
+        { name: "animateToTargetSet", type: "node" },
+        { name: "easeFunction", type: "string", value: "inOutCubic" },
+        { name: "advancing", type: "boolean", value: "false" },
+        { name: "reversing", type: "boolean", value: "false" },
+    ];
+
+    protected readonly content: ContentNode[] = [];
+    protected readonly itemComps: Group[] = [];
+    protected focusIndex: number = 0;
+    protected wrap: boolean = false;
+    protected lastPressHandled: string = "";
+
+    constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.TargetGroup) {
+        super([], name);
+        this.setExtendsType(name, SGNodeType.Group);
+
+        this.registerDefaultFields(this.defaultFields);
+        this.registerInitializedFields(initializedFields);
+
+        this.setValueSilent("content", new ContentNode());
+        this.setValueSilent("focusable", BrsBoolean.True);
+        this.wrap = (this.getValueJS("wrap") as boolean) ?? false;
+    }
+
+    setValue(index: string, value: BrsType, alwaysNotify?: boolean, kind?: FieldKind) {
+        const fieldName = index.toLowerCase();
+        if (fieldName === "content" && value instanceof ContentNode) {
+            super.setValue(index, value, alwaysNotify, kind);
+            this.itemComps.length = 0;
+            this.refreshContent();
+            // Initialize focus on the first item. setFocusedItem() short-circuits when the index is
+            // unchanged, so seed the focus fields directly to leave currFocusItemIndex at 0 (not -1).
+            this.focusIndex = 0;
+            if (this.content.length > 0) {
+                super.setValueSilent("currFocusItemIndex", new Float(0));
+                super.setValue("itemFocused", new Int32(0));
+            }
+            return;
+        } else if (fieldName === "targetset" && value instanceof TargetSet) {
+            super.setValue(index, value, alwaysNotify, kind);
+            this.isDirty = true;
+            super.setValueSilent("currTargetSet", value);
+            return;
+        } else if (fieldName === "animatetotargetset" && value instanceof TargetSet) {
+            // Functional version: snap to the new TargetSet immediately.
+            this.setValue("targetSet", value);
+            return;
+        } else if (["jumptoitem", "animatetoitem"].includes(fieldName) && isNumberComp(value)) {
+            this.setFocusedItem(value.getValue() as number);
+        } else if (fieldName === "wrap") {
+            this.wrap = value instanceof BrsBoolean ? value.toBoolean() : this.wrap;
+        }
+        super.setValue(index, value, alwaysNotify, kind);
+    }
+
+    setNodeFocus(focusOn: boolean): boolean {
+        const focus = super.setNodeFocus(focusOn);
+        this.isDirty = true;
+        return focus;
+    }
+
+    handleKey(key: string, press: boolean): boolean {
+        if (!press && this.lastPressHandled === key) {
+            this.lastPressHandled = "";
+            return true;
+        }
+        let handled = false;
+        if (key === "OK") {
+            handled = this.handleOK(press);
+        }
+        this.lastPressHandled = handled && key !== "OK" ? key : "";
+        return handled;
+    }
+
+    protected handleOK(press: boolean): boolean {
+        if (press && this.focusIndex >= 0 && this.focusIndex < this.content.length) {
+            this.setValue("itemSelected", new Int32(this.focusIndex));
+        }
+        return false;
+    }
+
+    protected setFocusedItem(index: number) {
+        if (this.content.length === 0) {
+            return;
+        }
+        if (this.wrap) {
+            index = ((index % this.content.length) + this.content.length) % this.content.length;
+        } else if (index < 0 || index >= this.content.length) {
+            return;
+        }
+        if (index === this.focusIndex) {
+            return;
+        }
+        super.setValue("itemUnfocused", new Int32(this.focusIndex));
+        this.focusIndex = index;
+        super.setValueSilent("currFocusItemIndex", new Float(index));
+        super.setValue("itemFocused", new Int32(index));
+        this.isDirty = true;
+    }
+
+    protected refreshContent() {
+        this.content.length = 0;
+        const content = this.getValue("content");
+        if (!(content instanceof ContentNode)) {
+            return;
+        }
+        for (const child of content.getNodeChildren()) {
+            if (child instanceof ContentNode) {
+                this.content.push(child);
+            }
+        }
+    }
+
+    /** Returns the TargetSet currently driving layout (`currTargetSet`, falling back to `targetSet`). */
+    protected getActiveTargetSet(): TargetSet | undefined {
+        const curr = this.getValue("currTargetSet");
+        if (curr instanceof TargetSet) {
+            return curr;
+        }
+        const target = this.getValue("targetSet");
+        return target instanceof TargetSet ? target : undefined;
+    }
+
+    protected getTargetFocusIndex(targetSet: TargetSet): number {
+        const setIndex = targetSet.getFocusIndex();
+        if (setIndex >= 0) {
+            return setIndex;
+        }
+        return (this.getValueJS("defaultTargetSetFocusIndex") as number) ?? 0;
+    }
+
+    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+        if (!this.isVisible()) {
+            this.updateRenderTracking(true);
+            return;
+        }
+        const nodeTrans = this.getTranslation();
+        const drawTrans = angle === 0 ? nodeTrans.slice() : rotateTranslation(nodeTrans, angle);
+        drawTrans[0] += origin[0];
+        drawTrans[1] += origin[1];
+        const rotation = angle + this.getRotation();
+        opacity = opacity * this.getOpacity();
+
+        const content = this.getValue("content");
+        if (content instanceof ContentNode && content.changed) {
+            this.refreshContent();
+            content.changed = false;
+        }
+
+        const targetSet = this.getActiveTargetSet();
+        if (targetSet) {
+            this.renderItems(interpreter, targetSet, drawTrans, rotation, opacity, draw2D);
+        }
+
+        const size = this.getDimensions();
+        const rect = { x: drawTrans[0], y: drawTrans[1], width: size.width, height: size.height };
+        this.updateBoundingRects(rect, origin, rotation);
+        this.renderChildren(interpreter, drawTrans, rotation, opacity, draw2D);
+        this.nodeRenderingDone(origin, angle, opacity, draw2D);
+    }
+
+    private renderItems(
+        interpreter: Interpreter,
+        targetSet: TargetSet,
+        drawTrans: number[],
+        rotation: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
+        const rects = targetSet.getTargetRects();
+        if (rects.length === 0) {
+            return;
+        }
+        const setFocusIndex = this.getTargetFocusIndex(targetSet);
+        const groupHasFocus = sgRoot.focused === this;
+
+        if (this.getValueJS("showTargetRects")) {
+            this.drawTargetRects(rects, drawTrans, targetSet.getColor(), opacity, draw2D);
+        }
+
+        for (let i = 0; i < this.content.length; i++) {
+            // currTarget is the target-rect index this item occupies. In snap mode the focused item
+            // (this.focusIndex) sits at the TargetSet's focus index; neighbors fill adjacent rects.
+            let currTarget = setFocusIndex + (i - this.focusIndex);
+            if (this.wrap) {
+                currTarget = ((currTarget % rects.length) + rects.length) % rects.length;
+            } else if (currTarget < 0 || currTarget >= rects.length) {
+                continue;
+            }
+            const targetRect = rects[currTarget];
+            const focused = i === this.focusIndex;
+            this.renderItemComponent(
+                interpreter,
+                i,
+                currTarget,
+                targetRect,
+                focused,
+                groupHasFocus,
+                drawTrans,
+                rotation,
+                opacity,
+                draw2D
+            );
+        }
+    }
+
+    private renderItemComponent(
+        interpreter: Interpreter,
+        index: number,
+        currTarget: number,
+        targetRect: Rect,
+        focused: boolean,
+        groupHasFocus: boolean,
+        drawTrans: number[],
+        rotation: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
+        const content = this.content[index];
+        if (!this.itemComps[index]) {
+            const itemComp = this.createItemComponent(interpreter, targetRect, content);
+            if (itemComp instanceof Group) {
+                this.itemComps[index] = itemComp;
+            } else {
+                return;
+            }
+        }
+        const itemComp = this.itemComps[index];
+        // Update the documented interface fields, in order.
+        itemComp.setValue("currTarget", new Float(currTarget), false);
+        itemComp.setValue(
+            "currRect",
+            brsValueOf([targetRect.x, targetRect.y, targetRect.width, targetRect.height]),
+            false
+        );
+        itemComp.setValue("index", new Int32(index), false);
+        itemComp.setValue("groupHasFocus", BrsBoolean.from(groupHasFocus), false);
+        itemComp.setValue("itemContent", content, true);
+        itemComp.setValue("focusPercent", new Float(focused ? 1 : 0), false);
+        itemComp.setValue("itemHasFocus", BrsBoolean.from(focused && groupHasFocus), false);
+
+        const itemOrigin = [drawTrans[0] + targetRect.x, drawTrans[1] + targetRect.y];
+        itemComp.renderNode(interpreter, itemOrigin, rotation, opacity, draw2D);
+    }
+
+    protected createItemComponent(interpreter: Interpreter, itemRect: Rect, content: ContentNode) {
+        const itemCompName = (this.getValueJS("itemComponentName") as string) ?? "";
+        const itemComp = itemCompName ? createNode(itemCompName, interpreter) : new Group();
+        if (itemComp instanceof Group) {
+            itemComp.setNodeParent(this);
+            itemComp.setValue("width", new Float(itemRect.width), false);
+            itemComp.setValue("height", new Float(itemRect.height), false);
+            itemComp.setValue("itemContent", content, false);
+        }
+        return itemComp;
+    }
+
+    private drawTargetRects(rects: Rect[], drawTrans: number[], color: number, opacity: number, draw2D?: IfDraw2D) {
+        if (!draw2D) {
+            return;
+        }
+        for (const rect of rects) {
+            const drawRect = {
+                x: drawTrans[0] + rect.x,
+                y: drawTrans[1] + rect.y,
+                width: rect.width,
+                height: rect.height,
+            };
+            draw2D.doDrawRotatedRect(drawRect, color, 0, [0, 0], opacity);
+        }
+    }
+}

--- a/src/extensions/scenegraph/nodes/TargetList.ts
+++ b/src/extensions/scenegraph/nodes/TargetList.ts
@@ -1,0 +1,110 @@
+import { AAMember, BrsType, Interpreter, IfDraw2D, RoArray } from "brs-engine";
+import { FieldKind, FieldModel } from "../SGTypes";
+import { SGNodeType } from ".";
+import { TargetGroup } from "./TargetGroup";
+import { TargetSet } from "./TargetSet";
+import { sgRoot } from "../SGRoot";
+
+/**
+ * TargetList extends {@link TargetGroup} with the higher-level focus behavior of a typical list/row:
+ * it swaps between a focused and an unfocused {@link TargetSet} as it gains/loses focus, and maps the
+ * configurable `advanceKey`/`reverseKey` remote buttons to moving the focused item.
+ *
+ * Simplification (functional version): when `focusedTargetSet` holds multiple TargetSets the focus
+ * does not "float" across them — the first entry is used and advance/reverse simply move the focused
+ * item (snap).
+ */
+export class TargetList extends TargetGroup {
+    readonly defaultFields: FieldModel[] = [
+        { name: "focusedTargetSet", type: "nodearray", value: "[]" },
+        { name: "unfocusedTargetSet", type: "node" },
+        { name: "advanceKey", type: "string", value: "down" },
+        { name: "reverseKey", type: "string", value: "up" },
+    ];
+
+    // Tracks the focus state observed on the previous render so we can swap target sets on transition.
+    private hadFocus = false;
+
+    constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.TargetList) {
+        super([], name);
+        this.setExtendsType(name, SGNodeType.TargetGroup);
+
+        this.registerDefaultFields(this.defaultFields);
+        this.registerInitializedFields(initializedFields);
+    }
+
+    setValue(index: string, value: BrsType, alwaysNotify?: boolean, kind?: FieldKind) {
+        // focusedTargetSet is an array field, but apps commonly assign a single TargetSet to it
+        // (fixed-focus case). Field validation rejects a lone Node into an array field, so wrap it.
+        if (index.toLowerCase() === "focusedtargetset" && value instanceof TargetSet) {
+            value = new RoArray([value]);
+        }
+        super.setValue(index, value, alwaysNotify, kind);
+    }
+
+    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+        // Swap the active target set when focus changes. The engine moves focus between sibling nodes
+        // by rewriting the focus chain (it does not call setNodeFocus(false) on the node losing focus),
+        // so detecting the transition here is the reliable place to react. Doing it before super's
+        // render means the swap takes effect in this same frame.
+        this.syncFocusTargetSet();
+        super.renderNode(interpreter, origin, angle, opacity, draw2D);
+    }
+
+    private syncFocusTargetSet() {
+        const hasFocus = sgRoot.focused === this;
+        if (hasFocus === this.hadFocus) {
+            return;
+        }
+        this.hadFocus = hasFocus;
+        const targetSet = hasFocus ? this.getFocusedTargetSet() : this.getUnfocusedTargetSet();
+        if (targetSet instanceof TargetSet) {
+            this.setValue("targetSet", targetSet);
+        }
+    }
+
+    handleKey(key: string, press: boolean): boolean {
+        if (!press && this.lastPressHandled === key) {
+            this.lastPressHandled = "";
+            return true;
+        }
+        const advanceKey = (this.getValueJS("advanceKey") as string)?.toLowerCase() ?? "down";
+        const reverseKey = (this.getValueJS("reverseKey") as string)?.toLowerCase() ?? "up";
+        const lowerKey = key.toLowerCase();
+        let handled = false;
+        if (press && lowerKey === advanceKey) {
+            handled = this.moveFocus(1);
+        } else if (press && lowerKey === reverseKey) {
+            handled = this.moveFocus(-1);
+        } else {
+            return super.handleKey(key, press);
+        }
+        this.lastPressHandled = handled ? key : "";
+        return handled;
+    }
+
+    private moveFocus(offset: number): boolean {
+        const previous = this.focusIndex;
+        this.setFocusedItem(this.focusIndex + offset);
+        return this.focusIndex !== previous;
+    }
+
+    private getFocusedTargetSet(): TargetSet | undefined {
+        const value = this.getValue("focusedTargetSet");
+        if (value instanceof RoArray) {
+            for (const element of value.getElements()) {
+                if (element instanceof TargetSet) {
+                    return element;
+                }
+            }
+        } else if (value instanceof TargetSet) {
+            return value;
+        }
+        return undefined;
+    }
+
+    private getUnfocusedTargetSet(): TargetSet | undefined {
+        const value = this.getValue("unfocusedTargetSet");
+        return value instanceof TargetSet ? value : undefined;
+    }
+}

--- a/src/extensions/scenegraph/nodes/TargetSet.ts
+++ b/src/extensions/scenegraph/nodes/TargetSet.ts
@@ -1,0 +1,78 @@
+import { AAMember, Rect } from "brs-engine";
+import { FieldModel } from "../SGTypes";
+import { SGNodeType } from ".";
+import { Node } from "./Node";
+
+/**
+ * TargetSet is a simple data container that defines a set of rectangular regions where the items of
+ * a {@link TargetGroup} are rendered. It is a plain `Node` (never drawn itself) and is consumed by a
+ * TargetGroup via its `targetSet`/`currTargetSet` fields.
+ */
+export class TargetSet extends Node {
+    readonly defaultFields: FieldModel[] = [
+        { name: "targetRects", type: "rect2darray", value: "[]" },
+        { name: "focusIndex", type: "integer", value: "-1" },
+        { name: "color", type: "color", value: "0xFFFFFF80" },
+    ];
+
+    constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.TargetSet) {
+        super([], name);
+        this.setExtendsType(name, SGNodeType.Node);
+
+        this.registerDefaultFields(this.defaultFields);
+        this.registerInitializedFields(initializedFields);
+    }
+
+    /**
+     * Returns the target rectangles normalized to `{ x, y, width, height }`. The spec allows each
+     * rectangle to be specified either as an associative array (`{ x, y, width, height }`) or as a
+     * four-element numeric array (`[x, y, width, height]`); this hides that dual format from callers.
+     */
+    getTargetRects(): Rect[] {
+        const rects = this.getValueJS("targetRects");
+        if (!Array.isArray(rects)) {
+            return [];
+        }
+        const result: Rect[] = [];
+        for (const entry of rects) {
+            const rect = normalizeRect(entry);
+            if (rect) {
+                result.push(rect);
+            }
+        }
+        return result;
+    }
+
+    /** Returns the configured focus index, or -1 when unset (TargetGroup falls back to its default). */
+    getFocusIndex(): number {
+        const value = this.getValueJS("focusIndex");
+        return typeof value === "number" ? value : -1;
+    }
+
+    /** Returns the debug rectangle color used when a TargetGroup's `showTargetRects` is enabled. */
+    getColor(): number {
+        const value = this.getValueJS("color");
+        return typeof value === "number" ? value : 0xffffff80 | 0;
+    }
+}
+
+function normalizeRect(entry: unknown): Rect | undefined {
+    if (Array.isArray(entry) && entry.length >= 4) {
+        return {
+            x: Number(entry[0]) || 0,
+            y: Number(entry[1]) || 0,
+            width: Number(entry[2]) || 0,
+            height: Number(entry[3]) || 0,
+        };
+    }
+    if (entry && typeof entry === "object") {
+        const aa = entry as Record<string, unknown>;
+        return {
+            x: Number(aa.x) || 0,
+            y: Number(aa.y) || 0,
+            width: Number(aa.width) || 0,
+            height: Number(aa.height) || 0,
+        };
+    }
+    return undefined;
+}

--- a/src/extensions/scenegraph/nodes/index.ts
+++ b/src/extensions/scenegraph/nodes/index.ts
@@ -65,6 +65,9 @@ export * from "./StdDlgProgressItem";
 export * from "./StdDlgSideCardArea";
 export * from "./StdDlgTextItem";
 export * from "./StdDlgTitleArea";
+export * from "./TargetSet";
+export * from "./TargetGroup";
+export * from "./TargetList";
 export * from "./Task";
 export * from "./TextEditBox";
 export * from "./TimeGrid";
@@ -89,9 +92,9 @@ export enum SGNodeType {
     Group = "Group",
     LayoutGroup = "LayoutGroup",
     MaskGroup = "MaskGroup",
-    TargetGroup = "TargetGroup", // Not yet implemented
-    TargetList = "TargetList", // Not yet implemented
-    TargetSet = "TargetSet", // Not yet implemented
+    TargetGroup = "TargetGroup",
+    TargetList = "TargetList",
+    TargetSet = "TargetSet",
     ButtonGroup = "ButtonGroup",
     Button = "Button",
     Panel = "Panel",

--- a/test/extensions/scenegraph/TargetNodes.test.js
+++ b/test/extensions/scenegraph/TargetNodes.test.js
@@ -1,0 +1,280 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsDevice, BrsString, Int32, Float, RoArray, RoAssociativeArray } = core;
+
+/** Minimal interpreter accepted by renderNode → renderChildren (never dereferenced when draw2D is absent). */
+const fakeInterpreter = {};
+
+/** Builds a root ContentNode with `count` child item ContentNodes (each with a title). */
+function buildContent(count) {
+    const root = SGNodeFactory.createNode("ContentNode");
+    for (let i = 0; i < count; i++) {
+        const item = SGNodeFactory.createNode("ContentNode");
+        item.setValue("title", new BrsString(`item ${i}`));
+        root.appendChildToParent(item);
+    }
+    return root;
+}
+
+/** Builds a TargetSet with `count` stacked rectangles and an optional focusIndex. */
+function buildTargetSet(count, focusIndex) {
+    const set = SGNodeFactory.createNode("TargetSet");
+    const rects = [];
+    for (let i = 0; i < count; i++) {
+        rects.push(new RoArray([new Float(0), new Float(i * 100), new Float(200), new Float(100)]));
+    }
+    set.setValue("targetRects", new RoArray(rects));
+    if (focusIndex !== undefined) {
+        set.setValue("focusIndex", new Int32(focusIndex));
+    }
+    return set;
+}
+
+describe("Target nodes (TargetSet, TargetGroup, TargetList)", () => {
+    beforeAll(() => {
+        // TargetGroup item components resolve fonts/bitmaps from the common: volume; mount it once.
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    describe("factory wiring", () => {
+        test.each([
+            ["TargetSet", "TargetSet"],
+            ["TargetGroup", "TargetGroup"],
+            ["TargetList", "TargetList"],
+        ])("creates %s as its own subtype (not a fallback Node/Group)", (type, expected) => {
+            const node = SGNodeFactory.createNode(type);
+            expect(node).toBeDefined();
+            expect(node.constructor.name).toBe(expected);
+            expect(node.nodeSubtype).toBe(expected);
+        });
+    });
+
+    describe("TargetSet", () => {
+        test("exposes the documented default fields, types and values", () => {
+            const set = SGNodeFactory.createNode("TargetSet");
+            const fields = set.getNodeFields();
+            // The engine collapses rect2darray/nodearray to the generic "array" FieldKind.
+            const expected = [
+                ["targetRects", "array", []],
+                ["focusIndex", "integer", -1],
+                ["color", "color", 0xffffff80 | 0],
+            ];
+            for (const [name, type, value] of expected) {
+                const field = fields.get(name.toLowerCase());
+                expect(field).toBeDefined();
+                expect(field.getType()).toBe(type);
+                expect(set.getValueJS(name)).toEqual(value);
+            }
+        });
+
+        test("getTargetRects normalizes the four-number-array rectangle format", () => {
+            const set = buildTargetSet(2);
+            expect(set.getTargetRects()).toEqual([
+                { x: 0, y: 0, width: 200, height: 100 },
+                { x: 0, y: 100, width: 200, height: 100 },
+            ]);
+        });
+
+        test("getTargetRects normalizes the associative-array rectangle format", () => {
+            const set = SGNodeFactory.createNode("TargetSet");
+            const aa = new RoAssociativeArray([
+                { name: new BrsString("x"), value: new Float(10) },
+                { name: new BrsString("y"), value: new Float(5) },
+                { name: new BrsString("width"), value: new Float(200) },
+                { name: new BrsString("height"), value: new Float(150) },
+            ]);
+            set.setValue("targetRects", new RoArray([aa]));
+            expect(set.getTargetRects()).toEqual([{ x: 10, y: 5, width: 200, height: 150 }]);
+        });
+    });
+
+    describe("TargetGroup", () => {
+        test("exposes the documented default fields, types and values", () => {
+            const group = SGNodeFactory.createNode("TargetGroup");
+            const fields = group.getNodeFields();
+            const expected = [
+                ["itemComponentName", "string", ""],
+                ["defaultTargetSetFocusIndex", "integer", 0],
+                ["wrap", "boolean", false],
+                ["duration", "time", 0.3],
+                ["showTargetRects", "boolean", false],
+                ["currFocusItemIndex", "float", -1],
+                ["jumpToItem", "integer", 0],
+                ["animateToItem", "integer", 0],
+                ["easeFunction", "string", "inOutCubic"],
+                ["advancing", "boolean", false],
+                ["reversing", "boolean", false],
+            ];
+            for (const [name, type, value] of expected) {
+                const field = fields.get(name.toLowerCase());
+                expect(field).toBeDefined();
+                expect(field.getType()).toBe(type);
+                expect(group.getValueJS(name)).toEqual(value);
+            }
+        });
+
+        test("extends Group (inherits Group fields)", () => {
+            const group = SGNodeFactory.createNode("TargetGroup");
+            const fields = group.getNodeFields();
+            for (const field of ["translation", "opacity", "visible", "content", "targetset"]) {
+                expect(fields.get(field)).toBeDefined();
+            }
+        });
+
+        test("setting content populates items and focuses item 0", () => {
+            const group = SGNodeFactory.createNode("TargetGroup");
+            group.setValue("content", buildContent(5));
+            expect(group.getValueJS("itemFocused")).toBe(0);
+            expect(group.getValueJS("currFocusItemIndex")).toBe(0);
+        });
+
+        test("jumpToItem moves focus (snap) and updates focus fields", () => {
+            const group = SGNodeFactory.createNode("TargetGroup");
+            group.setValue("content", buildContent(5));
+            group.setValue("jumpToItem", new Int32(3));
+            expect(group.getValueJS("itemFocused")).toBe(3);
+            expect(group.getValueJS("currFocusItemIndex")).toBe(3);
+            expect(group.getValueJS("itemUnfocused")).toBe(0);
+        });
+
+        test("animateToItem behaves like jumpToItem in the functional version", () => {
+            const group = SGNodeFactory.createNode("TargetGroup");
+            group.setValue("content", buildContent(5));
+            group.setValue("animateToItem", new Int32(2));
+            expect(group.getValueJS("itemFocused")).toBe(2);
+            expect(group.getValueJS("currFocusItemIndex")).toBe(2);
+        });
+
+        test("jumpToItem out of range is ignored without wrap", () => {
+            const group = SGNodeFactory.createNode("TargetGroup");
+            group.setValue("content", buildContent(3));
+            group.setValue("jumpToItem", new Int32(99));
+            expect(group.getValueJS("itemFocused")).toBe(0);
+        });
+
+        test("setting targetSet mirrors into the read-only currTargetSet", () => {
+            const group = SGNodeFactory.createNode("TargetGroup");
+            const set = buildTargetSet(3, 1);
+            group.setValue("targetSet", set);
+            expect(group.getValue("currTargetSet")).toBe(set);
+        });
+
+        test("renderNode with content + targetSet does not throw (draw2D absent)", () => {
+            const group = SGNodeFactory.createNode("TargetGroup");
+            group.setValue("targetSet", buildTargetSet(5, 2));
+            group.setValue("content", buildContent(5));
+            expect(() => group.renderNode(fakeInterpreter, [0, 0], 0, 1)).not.toThrow();
+        });
+    });
+
+    describe("TargetList", () => {
+        test("exposes the documented default fields, types and values", () => {
+            const list = SGNodeFactory.createNode("TargetList");
+            const fields = list.getNodeFields();
+            // nodearray collapses to the generic "array" FieldKind in the engine.
+            const expected = [
+                ["focusedTargetSet", "array", []],
+                ["advanceKey", "string", "down"],
+                ["reverseKey", "string", "up"],
+            ];
+            for (const [name, type, value] of expected) {
+                const field = fields.get(name.toLowerCase());
+                expect(field).toBeDefined();
+                expect(field.getType()).toBe(type);
+                expect(list.getValueJS(name)).toEqual(value);
+            }
+        });
+
+        test("extends TargetGroup (inherits TargetGroup + Group fields)", () => {
+            const list = SGNodeFactory.createNode("TargetList");
+            const fields = list.getNodeFields();
+            for (const field of ["targetset", "content", "jumptoitem", "translation", "visible"]) {
+                expect(fields.get(field)).toBeDefined();
+            }
+        });
+
+        test("advanceKey advances focus, reverseKey reverses it", () => {
+            const list = SGNodeFactory.createNode("TargetList");
+            list.setValue("content", buildContent(5));
+            expect(list.handleKey("down", true)).toBe(true);
+            expect(list.getValueJS("itemFocused")).toBe(1);
+            expect(list.handleKey("up", true)).toBe(true);
+            expect(list.getValueJS("itemFocused")).toBe(0);
+        });
+
+        test("reverse past the start is not handled without wrap", () => {
+            const list = SGNodeFactory.createNode("TargetList");
+            list.setValue("content", buildContent(5));
+            expect(list.handleKey("up", true)).toBe(false);
+            expect(list.getValueJS("itemFocused")).toBe(0);
+        });
+
+        test("custom advance/reverse keys are honored", () => {
+            const list = SGNodeFactory.createNode("TargetList");
+            list.setValue("content", buildContent(5));
+            list.setValue("advanceKey", new BrsString("right"));
+            list.setValue("reverseKey", new BrsString("left"));
+            expect(list.handleKey("right", true)).toBe(true);
+            expect(list.getValueJS("itemFocused")).toBe(1);
+        });
+
+        test("wrap allows advancing past the end back to the start", () => {
+            const list = SGNodeFactory.createNode("TargetList");
+            list.setValue("wrap", core.BrsBoolean.True);
+            list.setValue("content", buildContent(3));
+            list.setValue("jumpToItem", new Int32(2));
+            expect(list.handleKey("down", true)).toBe(true);
+            expect(list.getValueJS("itemFocused")).toBe(0);
+        });
+
+        test("accepts a single TargetSet assigned to the focusedTargetSet array field", () => {
+            const list = SGNodeFactory.createNode("TargetList");
+            const focused = buildTargetSet(7, 6);
+            list.setValue("focusedTargetSet", focused);
+            const stored = list.getValue("focusedTargetSet");
+            expect(stored).toBeInstanceOf(RoArray);
+            expect(stored.getElements()[0]).toBe(focused);
+        });
+
+        // Reproduces the two-row "fixed focus" example: focus moving between sibling TargetLists must
+        // swap each row's active targetSet (the engine rewrites the focus chain rather than calling
+        // setNodeFocus(false) on the row losing focus, so the swap is detected at render time).
+        test("swaps focused/unfocused target sets as focus moves between rows", () => {
+            const focused = buildTargetSet(7, 6);
+            const unfocused = buildTargetSet(7, 6);
+
+            const list1 = SGNodeFactory.createNode("TargetList");
+            const list2 = SGNodeFactory.createNode("TargetList");
+            for (const list of [list1, list2]) {
+                list.setValue("focusedTargetSet", focused);
+                list.setValue("unfocusedTargetSet", unfocused);
+                list.setValue("content", buildContent(10));
+            }
+            list1.setValue("targetSet", focused);
+            list2.setValue("targetSet", unfocused);
+
+            // List 1 starts focused.
+            sgRoot.setFocused(list1);
+            list1.renderNode(fakeInterpreter, [0, 0], 0, 1);
+            list2.renderNode(fakeInterpreter, [0, 0], 0, 1);
+            expect(list1.getValue("targetSet")).toBe(focused);
+            expect(list2.getValue("targetSet")).toBe(unfocused);
+
+            // Focus moves to list 2: list 1 must shrink (unfocused), list 2 must grow (focused).
+            sgRoot.setFocused(list2);
+            list1.renderNode(fakeInterpreter, [0, 0], 0, 1);
+            list2.renderNode(fakeInterpreter, [0, 0], 0, 1);
+            expect(list1.getValue("targetSet")).toBe(unfocused);
+            expect(list2.getValue("targetSet")).toBe(focused);
+        });
+    });
+});


### PR DESCRIPTION
## Overview

Implements the three layout-group SceneGraph node types that were declared in the `SGNodeType` enum but marked *"Not yet implemented"* — `CreateObject("roSGNode", "TargetGroup")` / `<TargetGroup>` previously fell through to a plain `Node`/`Group` with a warning (no layout, no item rendering, no key navigation).

Field names, types, defaults and the item-component interface mirror the Roku reference spec under `external/dev-doc/.../scenegraph/`.

## Nodes

- **`TargetSet`** (extends `Node`) — data container of rectangular regions. `getTargetRects()` normalizes both documented rectangle formats (associative array `{x,y,width,height}` and 4-number array `[x,y,width,height]`) to a single `Rect` shape.
- **`TargetGroup`** (extends `Group`) — maps `content` ContentNode items onto a TargetSet's rectangles, lazily instantiating the `itemComponentName` XML component per visible item and updating the documented item interface fields (`currTarget`, `currRect`, `index`, `groupHasFocus`, `itemContent`, `focusPercent`, `itemHasFocus`) **in spec order**. Handles `jumpToItem`/`animateToItem`/`animateToTargetSet`, mirrors `targetSet` → `currTargetSet`, draws debug rectangles when `showTargetRects` is set, and supports `wrap`.
- **`TargetList`** (extends `TargetGroup`) — swaps `focused`/`unfocused` target sets as focus changes, maps `advanceKey`/`reverseKey` to focus movement, and accepts a single `TargetSet` assigned to the array-typed `focusedTargetSet` field.

## Notable correctness details

- **Focus swap is detected at render time.** The engine moves focus between sibling nodes by rewriting the focus chain — it does *not* call `setNodeFocus(false)` on the node losing focus. So `TargetList` detects the focus transition in `renderNode` (run for every row each frame) and swaps the active target set there, at the top of the pass so it takes effect the same frame. This makes the two-row "fixed focus" example behave correctly: the row losing focus shrinks (unfocused set) and the row gaining focus grows (focused set).
- **Single `TargetSet` → `focusedTargetSet`.** Apps commonly assign a lone `TargetSet` to this array field (fixed-focus case), which `Field.canAcceptValue` would otherwise reject. `TargetList.setValue` wraps it in a one-element array.

## Scope

Functional **"snap to target"** version: `jumpToItem`/`animateToItem` move focus immediately, so `currFocusItemIndex`/`currTarget` stay integer and `focusPercent` is 0/1. `duration`/`easeFunction`/`advancing`/`reversing` are registered and stored but do not yet drive a time-based tween. Multi-`TargetSet` "floating focus" uses only the first entry. These are documented in the file headers as future work.

## Testing

- New `test/extensions/scenegraph/TargetNodes.test.js` (22 tests): factory wiring, field defaults/types, inheritance, both rectangle formats, focus/jump behavior, key navigation, single-`TargetSet` acceptance, and the two-row focus-swap example.
- Verified the real `TwoRowFixedFocus` rokudev sample through the CLI (`--ecp`): loads cleanly, 25-element data model, no type-mismatch or "not implemented" warnings, `down` key handled.
- Full suite green (121 suites / 1792 tests); `npm run lint` and `npm run prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)