### PR TITLE
feat(scenegraph): implement Dynamic voice keyboard nodes

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -10,16 +10,8 @@ The **BrightScript Engine** implements the BrightScript language specification u
   * The `Task` node is implemented but its behavior is limited:
     * For now only 10 concurrent task threads are supported per application
     * Only one `port` instance can be used on Task `init()` to observe fields
-  * The following nodes are already implemented:
-    * The basic nodes: `ContentNode`, `Group`, `Scene`, `Global`, `Timer`, `Rectangle`, `Poster`, `LayoutGroup` and `RSGPalette`
-    * Typographic nodes: `Font`, `Label`, `ScrollingLabel` and `ScrollableText`
-    * Grids and list nodes based on `ArrayGrid`: `PosterGrid`, `LabelList`, `CheckList`, `RadioButtonList`, `MarkupList`, `MarkupGrid`, `RowList` and `ZoomRowList`
-    * Dialog related nodes: `Dialog`, `KeyboardDialog`, `PinDialog`, `ProgressDialog`, `StandardDialog`, `StandardProgressDialog`, `StdDlgProgressItem`, `StdDlgContentArea` and `StdDlgTitleArea`
-    * Media related nodes: `Audio`, `SoundEffect`, `Video` and `TrickPlayBar`
-    * Animation related nodes: `AnimationBase`, `Animation`, `SequentialAnimation`, `ParallelAnimation`, `ColorFieldInterpolator`, `FloatFieldInterpolator` and `Vector2DFieldInterpolator`
-    * Panel related nodes: `OverhangPanelSetScene`, `PanelSet`, `Panel`, `GridPanel` and `ListPanel`
-    * Other supported nodes: `Button`, `ButtonGroup`, `BusySpinner`, `Overhang`, `InfoPane`, `Keyboard`, `MiniKeyboard`, `PinPad`, `TextEditBox` and `ComponentLibrary`
-  * Some of the nodes listed above may not have full functionality yet, please open a [GitHub issue](https://github.com/lvcabral/brs-engine/issues) if you find any problem or missing feature.
+  * Most SceneGraph nodes are implemented, covering the renderable, layout, list/grid, dialog, media, animation, panel and keyboard (including the dynamic voice keyboards) node families. Because the engine is a simulator and not a hardware emulator, expect **rendering differences** from a real Roku device, and some nodes may not have full functionality yet — please open a [GitHub issue](https://github.com/lvcabral/brs-engine/issues) if you find any problem or missing feature.
+  * Some abstract/base nodes are not implemented on their own and are mocked as a `Group` (for example the Standard Dialog framework's `StdDlgAreaBase`, `StdDlgItemBase`, `StdDlgItemGroup` and `StdDlgGraphicItem`).
   * **Component Libraries** are supported, both declared in XML (`<ComponentLibrary id="..." uri="..."/>`) and created at runtime via `CreateObject("roSGNode", "ComponentLibrary")` with the `uri` assigned in code. The component namespace is the library manifest's `sg_component_libs_provided` value (falling back to the node `id` when not declared), so its components are referenced as `LibraryName:ComponentName`. The `uri` may point to a local volume (`pkg:/`, `tmp:/`, `ext1:/`) or a remote `http(s)://` package (the configured CORS proxy is honored). Current limitations:
     * Libraries are fetched and compiled **synchronously** (the BrightScript event loop never yields, so an asynchronous load could not complete mid-execution). The node reports `loadStatus = "loading"` immediately and the `"ready"`/`"failed"` transition is emitted on the next render frame, so `observeField("loadStatus", ...)` callbacks are notified as on a real device — provided the app is pumping its screen message loop (`wait(...)`).
     * Inside a library, `pkg:/` still resolves to the host app's package (not the library's own); reference a library's bundled scripts with relative `uri` paths in its component XML.

--- a/src/extensions/scenegraph/factory/NodeFactory.ts
+++ b/src/extensions/scenegraph/factory/NodeFactory.ts
@@ -43,6 +43,11 @@ import {
     MarkupGrid,
     MarkupList,
     MiniKeyboard,
+    DynamicKeyGrid,
+    DynamicKeyboard,
+    DynamicMiniKeyboard,
+    DynamicPinPad,
+    DynamicCustomKeyboard,
     MultiStyleLabel,
     MonospaceLabel,
     PinPad,
@@ -247,6 +252,16 @@ export class SGNodeFactory {
                 return new Keyboard([], name);
             case SGNodeType.MiniKeyboard.toLowerCase():
                 return new MiniKeyboard([], name);
+            case SGNodeType.DynamicKeyGrid.toLowerCase():
+                return new DynamicKeyGrid([], name);
+            case SGNodeType.DynamicKeyboard.toLowerCase():
+                return new DynamicKeyboard([], name);
+            case SGNodeType.DynamicMiniKeyboard.toLowerCase():
+                return new DynamicMiniKeyboard([], name);
+            case SGNodeType.DynamicPinPad.toLowerCase():
+                return new DynamicPinPad([], name);
+            case SGNodeType.DynamicCustomKeyboard.toLowerCase():
+                return new DynamicCustomKeyboard([], name);
             case SGNodeType.PinPad.toLowerCase():
                 return new PinPad([], name);
             case SGNodeType.ParentalControlPinPad.toLowerCase():

--- a/src/extensions/scenegraph/nodes/DynamicCustomKeyboard.ts
+++ b/src/extensions/scenegraph/nodes/DynamicCustomKeyboard.ts
@@ -1,0 +1,19 @@
+import { AAMember } from "brs-engine";
+import { SGNodeType } from ".";
+import { DynamicKeyboardBase } from "./DynamicKeyboardBase";
+
+/**
+ * DynamicCustomKeyboard — voice-enabled keyboard with a developer-supplied layout.
+ * The app must set `keyGrid.keyDefinitionUri` to a custom Key Definition File; the
+ * DynamicKeyGrid loads and parses it. Default key-selection handling is inherited
+ * from DynamicKeyboardBase (insert label, clear, backspace, space, etc.).
+ */
+export class DynamicCustomKeyboard extends DynamicKeyboardBase {
+    constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.DynamicCustomKeyboard) {
+        super([], name);
+        this.setExtendsType(name, SGNodeType.DynamicKeyboardBase);
+        this.registerInitializedFields(initializedFields);
+
+        this.configureVoiceBox({ voiceEntryType: "generic", voiceEnabled: true, maxTextLength: 75 });
+    }
+}

--- a/src/extensions/scenegraph/nodes/DynamicKeyGrid.ts
+++ b/src/extensions/scenegraph/nodes/DynamicKeyGrid.ts
@@ -6,7 +6,6 @@ import {
     BrsDevice,
     Float,
     IfDraw2D,
-    Int32,
     Interpreter,
     Rect,
     RoArray,
@@ -36,6 +35,8 @@ interface SuggestionPopup {
     index: number;
     key: RenderedKey;
 }
+
+type NavKeys = "up" | "down" | "left" | "right";
 
 /**
  * DynamicKeyGrid implements a grid of keys defined by a Key Definition File (KDF).
@@ -70,7 +71,7 @@ export class DynamicKeyGrid extends Group {
     private popupSuppressed = false;
 
     private readonly font: Font;
-    private bmpFocus?: RoBitmap;
+    private readonly bmpFocus?: RoBitmap;
     private bmpBackground?: RoBitmap;
     private inset: KeyInset = { top: 0, right: 0, bottom: 0, left: 0 };
     private readonly keyFocusDelta: number;
@@ -292,7 +293,7 @@ export class DynamicKeyGrid extends Group {
         }
     }
 
-    private moveFocus(dir: "up" | "down" | "left" | "right"): boolean {
+    private moveFocus(dir: NavKeys): boolean {
         let next = this.findNeighbor(dir);
         if (next === undefined) {
             const horiz = dir === "left" || dir === "right";
@@ -312,7 +313,7 @@ export class DynamicKeyGrid extends Group {
     }
 
     /** Finds the nearest focusable key in a direction, or undefined if none. */
-    private findNeighbor(dir: "up" | "down" | "left" | "right"): number | undefined {
+    private findNeighbor(dir: NavKeys): number | undefined {
         const cur = this.renderedKeys[this.focusIndex];
         if (!cur) {
             return undefined;
@@ -357,7 +358,7 @@ export class DynamicKeyGrid extends Group {
     }
 
     /** Wraps focus to the opposite edge of the grid, aligned to the current key. */
-    private findWrap(dir: "up" | "down" | "left" | "right"): number | undefined {
+    private findWrap(dir: NavKeys): number | undefined {
         const cur = this.renderedKeys[this.focusIndex];
         if (!cur) {
             return undefined;

--- a/src/extensions/scenegraph/nodes/DynamicKeyGrid.ts
+++ b/src/extensions/scenegraph/nodes/DynamicKeyGrid.ts
@@ -1,0 +1,698 @@
+import {
+    AAMember,
+    BrsBoolean,
+    BrsString,
+    BrsType,
+    BrsDevice,
+    Float,
+    IfDraw2D,
+    Int32,
+    Interpreter,
+    Rect,
+    RoArray,
+    RoBitmap,
+    RoFont,
+} from "brs-engine";
+import { FieldKind, FieldModel } from "../SGTypes";
+import { SGNodeType } from ".";
+import { Group } from "./Group";
+import { Node } from "./Node";
+import { Font } from "./Font";
+import { sgRoot } from "../SGRoot";
+import { jsValueOf } from "../factory/Serializer";
+import { computeLayout, KeyInset, keyboardSize, KeyLayout, RenderedKey, resolveKeyIcon } from "./kdf/KeyDefinition";
+
+/** Default palette colors used when no RSGPalette is found in the scene graph. */
+const DEFAULT_PALETTE: Record<string, number> = {
+    KeyboardColor: 0xffffffff, // no tint applied to the keyboard background bitmap
+    PrimaryTextColor: 0xffffffff,
+    SecondaryItemColor: 0x808080ff,
+    FocusColor: 0xffffffff,
+    FocusItemColor: 0x000000ff,
+};
+
+interface SuggestionPopup {
+    options: string[];
+    index: number;
+    key: RenderedKey;
+}
+
+/**
+ * DynamicKeyGrid implements a grid of keys defined by a Key Definition File (KDF).
+ * Used internally by the DynamicKeyboardBase subclasses or as a standalone node.
+ */
+export class DynamicKeyGrid extends Group {
+    readonly defaultFields: FieldModel[] = [
+        { name: "keyDefinitionUri", type: "uri", value: "" },
+        { name: "mode", type: "string", value: "" },
+        { name: "focusVisible", type: "boolean", value: "true" },
+        { name: "horizWrap", type: "boolean", value: "false" },
+        { name: "vertWrap", type: "boolean", value: "false" },
+        { name: "palette", type: "node" },
+        { name: "keyFocused", type: "string", value: "", alwaysNotify: true },
+        { name: "keySelected", type: "string", value: "", alwaysNotify: true },
+        { name: "jumpToKey", type: "array" },
+        { name: "disableKey", type: "string", value: "" },
+        { name: "enableKey", type: "string", value: "" },
+    ];
+
+    /** Optional callback invoked (with the key's strOut/label) on every selection. */
+    onKeySelected?: (out: string) => void;
+
+    private layout?: KeyLayout;
+    private renderedKeys: RenderedKey[] = [];
+    private focusIndex = -1;
+    private readonly disabledSet = new Set<string>();
+    private popup?: SuggestionPopup;
+    private focusActive = false;
+    private lastFocusTime = 0;
+    // Suppresses the hover-timer pop-up after an option was selected, until focus leaves the key.
+    private popupSuppressed = false;
+
+    private readonly font: Font;
+    private bmpFocus?: RoBitmap;
+    private bmpBackground?: RoBitmap;
+    private inset: KeyInset = { top: 0, right: 0, bottom: 0, left: 0 };
+    private readonly keyFocusDelta: number;
+    private readonly bmpIcons = new Map<string, RoBitmap>();
+
+    // The special-key icon assets shared with the legacy Keyboard/MiniKeyboard/PinPad nodes.
+    private static readonly ICON_NAMES = [
+        "shift",
+        "space",
+        "delete",
+        "clear",
+        "moveCursorLeft",
+        "moveCursorRight",
+        "caps_on",
+        "caps_off",
+        "alphanum_on",
+        "alphanum_off",
+        "symbols_on",
+        "symbols_off",
+        "accent_on",
+        "accent_off",
+    ];
+
+    private readonly hoverDelay = 800; // ms the focus must dwell on a key before its "hover" pop-up opens
+
+    constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.DynamicKeyGrid) {
+        super([], name);
+        this.setExtendsType(name, SGNodeType.Group);
+        this.registerDefaultFields(this.defaultFields);
+        this.registerInitializedFields(initializedFields);
+
+        this.font = new Font();
+        this.keyFocusDelta = this.resolution === "FHD" ? 15 : 10;
+        this.setValueSilent("focusable", BrsBoolean.True);
+        this.bmpFocus = this.loadBitmap("common:/images/focus_keyboard.9.png");
+        for (const icon of DynamicKeyGrid.ICON_NAMES) {
+            const bmp = this.loadBitmap(`common:/images/${this.resolution}/icon_${icon}.png`);
+            if (bmp?.isValid()) {
+                this.bmpIcons.set(icon, bmp);
+            }
+        }
+    }
+
+    /** Installs a Key Definition File directly (used by the built-in keyboards). */
+    setLayout(layout: KeyLayout) {
+        this.layout = layout;
+        this.rebuild();
+    }
+
+    /**
+     * Loads a resolution-specific keyboard background bitmap (e.g. "keyboard_full"),
+     * drawn at natural size like the legacy nodes, with the matching cell inset so
+     * the keys land on the drawn cells.
+     */
+    setBackground(name: string, insetFHD: KeyInset, insetHD: KeyInset) {
+        this.bmpBackground = name ? this.loadBitmap(`common:/images/${this.resolution}/${name}.png`) : undefined;
+        this.inset = this.resolution === "FHD" ? insetFHD : insetHD;
+        this.rebuild();
+    }
+
+    /** Called by the owning keyboard each render so focus only shows while focused. */
+    setFocusActive(active: boolean) {
+        this.focusActive = active;
+    }
+
+    private get mode(): string {
+        return (this.getValueJS("mode") as string) ?? "";
+    }
+
+    private rebuild() {
+        if (!this.layout) {
+            this.renderedKeys = [];
+            this.focusIndex = -1;
+            return;
+        }
+        const res = this.resolution === "FHD" ? "FHD" : "HD";
+        this.renderedKeys = computeLayout(this.layout, this.mode, res, this.inset);
+        const [w, h] = keyboardSize(this.layout, res);
+        this.setValueSilent("width", new Float(w));
+        this.setValueSilent("height", new Float(h));
+        if (this.focusIndex < 0 || !this.keyFocusable(this.renderedKeys[this.focusIndex])) {
+            this.focusIndex = this.renderedKeys.findIndex((k) => this.keyFocusable(k));
+        }
+        this.updateKeyFocused();
+        this.isDirty = true;
+    }
+
+    private keyFocusable(key?: RenderedKey): boolean {
+        return !!key && key.focusable && !this.disabledSet.has(key.out);
+    }
+
+    private updateKeyFocused() {
+        const key = this.renderedKeys[this.focusIndex];
+        super.setValue("keyFocused", new BrsString(key?.out ?? ""));
+        // Focus moved to a (possibly) different key: restart the hover dwell timer and
+        // clear any pop-up suppression, so the timer applies again on the newly focused key.
+        this.lastFocusTime = Date.now();
+        this.popupSuppressed = false;
+    }
+
+    private selectKey(out: string) {
+        super.setValue("keySelected", new BrsString(out));
+        this.onKeySelected?.(out);
+    }
+
+    // -------------------------------------------------------------------------
+    // Field writes (mode, KDF load, jump/disable/enable)
+    // -------------------------------------------------------------------------
+
+    setValue(index: string, value: BrsType, alwaysNotify?: boolean, kind?: FieldKind, sync?: boolean) {
+        const fieldName = index.toLowerCase();
+        if (fieldName === "keydefinitionuri") {
+            super.setValue(index, value, alwaysNotify, kind, sync);
+            this.loadKeyDefinition(jsValueOf(value) as string);
+            return;
+        } else if (fieldName === "mode") {
+            super.setValue(index, value, alwaysNotify, kind, sync);
+            this.rebuild();
+            return;
+        } else if (fieldName === "jumptokey" && value instanceof RoArray) {
+            this.jumpToKey(value.getElements().map((e) => (jsValueOf(e) as number) ?? -1));
+            return;
+        } else if (fieldName === "disablekey") {
+            const key = jsValueOf(value) as string;
+            if (key) {
+                this.setKeyDisabled(key, true);
+            }
+            return;
+        } else if (fieldName === "enablekey") {
+            const key = jsValueOf(value) as string;
+            if (key) {
+                this.setKeyDisabled(key, false);
+            }
+            return;
+        }
+        super.setValue(index, value, alwaysNotify, kind, sync);
+    }
+
+    private loadKeyDefinition(uri: string) {
+        if (!uri?.trim()) {
+            return;
+        }
+        try {
+            const contents = BrsDevice.fileSystem.readFileSync(uri, "utf-8") as string;
+            this.layout = JSON.parse(contents) as KeyLayout;
+            this.focusIndex = -1;
+            this.rebuild();
+        } catch (err: any) {
+            BrsDevice.stderr.write(
+                `warning,DynamicKeyGrid: failed to load Key Definition File "${uri}": ${err?.message}`
+            );
+        }
+    }
+
+    private jumpToKey(coords: number[]) {
+        if (coords.length < 3) {
+            return;
+        }
+        const [section, row, key] = coords;
+        const index = this.renderedKeys.findIndex(
+            (k) => k.section === section && k.row === row && k.col === key && this.keyFocusable(k)
+        );
+        if (index >= 0) {
+            this.focusIndex = index;
+            this.updateKeyFocused();
+            this.isDirty = true;
+        }
+    }
+
+    private setKeyDisabled(out: string, disabled: boolean) {
+        if (disabled) {
+            this.disabledSet.add(out);
+            // If the focused key was just disabled, move focus to an adjacent enabled key.
+            if (this.renderedKeys[this.focusIndex]?.out === out) {
+                const next =
+                    this.findNeighbor("up") ??
+                    this.findNeighbor("down") ??
+                    this.findNeighbor("right") ??
+                    this.findNeighbor("left") ??
+                    this.renderedKeys.findIndex((k) => this.keyFocusable(k));
+                if (next !== undefined && next >= 0) {
+                    this.focusIndex = next;
+                    this.updateKeyFocused();
+                }
+            }
+        } else {
+            this.disabledSet.delete(out);
+        }
+        this.isDirty = true;
+    }
+
+    // -------------------------------------------------------------------------
+    // Navigation
+    // -------------------------------------------------------------------------
+
+    handleKey(key: string, press: boolean): boolean {
+        if (!press) {
+            return false;
+        }
+        if (this.popup) {
+            // Left/right dismiss the pop-up and move the keyboard focus; up/down/OK/back drive the pop-up.
+            if (key === "left" || key === "right") {
+                this.popup = undefined;
+                this.isDirty = true;
+            } else {
+                return this.handlePopupKey(key);
+            }
+        }
+        switch (key) {
+            case "up":
+            case "down":
+            case "left":
+            case "right":
+                return this.moveFocus(key);
+            case "OK":
+                return this.handleOK();
+            default:
+                return false;
+        }
+    }
+
+    private moveFocus(dir: "up" | "down" | "left" | "right"): boolean {
+        let next = this.findNeighbor(dir);
+        if (next === undefined) {
+            const horiz = dir === "left" || dir === "right";
+            const wrap = horiz ? (this.getValueJS("horizWrap") as boolean) : (this.getValueJS("vertWrap") as boolean);
+            if (!wrap) {
+                return false; // propagate to ancestors
+            }
+            next = this.findWrap(dir);
+        }
+        if (next === undefined || next < 0) {
+            return false;
+        }
+        this.focusIndex = next;
+        this.updateKeyFocused();
+        this.isDirty = true;
+        return true;
+    }
+
+    /** Finds the nearest focusable key in a direction, or undefined if none. */
+    private findNeighbor(dir: "up" | "down" | "left" | "right"): number | undefined {
+        const cur = this.renderedKeys[this.focusIndex];
+        if (!cur) {
+            return undefined;
+        }
+        const cx = cur.x + cur.width / 2;
+        const cy = cur.y + cur.height / 2;
+        let best: number | undefined;
+        let bestScore = Infinity;
+        for (let i = 0; i < this.renderedKeys.length; i++) {
+            if (i === this.focusIndex || !this.keyFocusable(this.renderedKeys[i])) {
+                continue;
+            }
+            const k = this.renderedKeys[i];
+            const dx = k.x + k.width / 2 - cx;
+            const dy = k.y + k.height / 2 - cy;
+            let primary: number;
+            let secondary: number;
+            if (dir === "right") {
+                if (dx <= 1) continue;
+                primary = dx;
+                secondary = Math.abs(dy);
+            } else if (dir === "left") {
+                if (dx >= -1) continue;
+                primary = -dx;
+                secondary = Math.abs(dy);
+            } else if (dir === "down") {
+                if (dy <= 1) continue;
+                primary = dy;
+                secondary = Math.abs(dx);
+            } else {
+                if (dy >= -1) continue;
+                primary = -dy;
+                secondary = Math.abs(dx);
+            }
+            const score = primary + secondary * 4; // weight cross-axis to keep alignment
+            if (score < bestScore) {
+                bestScore = score;
+                best = i;
+            }
+        }
+        return best;
+    }
+
+    /** Wraps focus to the opposite edge of the grid, aligned to the current key. */
+    private findWrap(dir: "up" | "down" | "left" | "right"): number | undefined {
+        const cur = this.renderedKeys[this.focusIndex];
+        if (!cur) {
+            return undefined;
+        }
+        const cx = cur.x + cur.width / 2;
+        const cy = cur.y + cur.height / 2;
+        let best: number | undefined;
+        let bestScore = Infinity;
+        for (let i = 0; i < this.renderedKeys.length; i++) {
+            if (i === this.focusIndex || !this.keyFocusable(this.renderedKeys[i])) {
+                continue;
+            }
+            const k = this.renderedKeys[i];
+            const kx = k.x + k.width / 2;
+            const ky = k.y + k.height / 2;
+            let primary: number;
+            let secondary: number;
+            if (dir === "right") {
+                primary = kx; // leftmost
+                secondary = Math.abs(ky - cy);
+            } else if (dir === "left") {
+                primary = -kx; // rightmost
+                secondary = Math.abs(ky - cy);
+            } else if (dir === "down") {
+                primary = ky; // topmost
+                secondary = Math.abs(kx - cx);
+            } else {
+                primary = -ky; // bottommost
+                secondary = Math.abs(kx - cx);
+            }
+            const score = primary + secondary * 4;
+            if (score < bestScore) {
+                bestScore = score;
+                best = i;
+            }
+        }
+        return best;
+    }
+
+    private handleOK(): boolean {
+        const key = this.renderedKeys[this.focusIndex];
+        if (!key || !this.keyFocusable(key)) {
+            return false;
+        }
+        if (key.suggestions && this.triggersInclude(key, "select")) {
+            this.openPopup(key);
+            return true;
+        }
+        this.selectKey(key.out);
+        return true;
+    }
+
+    // -------------------------------------------------------------------------
+    // Suggestion pop-up
+    // -------------------------------------------------------------------------
+
+    private triggersInclude(key: RenderedKey, trigger: string): boolean {
+        const triggers = key.suggestions?.triggers;
+        if (triggers === undefined) {
+            return false;
+        }
+        return Array.isArray(triggers) ? triggers.includes(trigger) : triggers === trigger;
+    }
+
+    private openPopup(key: RenderedKey) {
+        const opts = key.suggestions?.options;
+        const options = opts === undefined ? [] : Array.isArray(opts) ? opts : [opts];
+        if (options.length === 0) {
+            return;
+        }
+        this.popup = { options, index: 0, key };
+        this.isDirty = true;
+    }
+
+    private handlePopupKey(key: string): boolean {
+        if (!this.popup) {
+            return false;
+        }
+        switch (key) {
+            case "up":
+                this.popup.index = Math.max(0, this.popup.index - 1);
+                this.isDirty = true;
+                return true;
+            case "down":
+                this.popup.index = Math.min(this.popup.options.length - 1, this.popup.index + 1);
+                this.isDirty = true;
+                return true;
+            case "OK": {
+                const choice = this.popup.options[this.popup.index];
+                this.popup = undefined;
+                // Keep focus on the key but do not let the hover timer reopen the pop-up
+                // until the focus leaves and returns to the key.
+                this.popupSuppressed = true;
+                this.isDirty = true;
+                this.selectKey(choice);
+                return true;
+            }
+            default:
+                // Only OK and the directional keys drive the pop-up. Everything else (including
+                // "back") is left unhandled so it propagates up the scene graph to be handled
+                // by an ancestor (e.g. closing the dialog/screen).
+                return false;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Palette
+    // -------------------------------------------------------------------------
+
+    private getPaletteColor(name: string): number {
+        let node: Node | undefined = this;
+        while (node) {
+            const palette = node.getValue("palette");
+            if (palette instanceof Node) {
+                const colors = palette.getValue("colors");
+                const value = (jsValueOf(colors) as Record<string, unknown>)?.[name];
+                if (typeof value === "number") {
+                    return value;
+                }
+            }
+            const parent = node.getNodeParent();
+            node = parent instanceof Node ? parent : undefined;
+        }
+        return DEFAULT_PALETTE[name];
+    }
+
+    // -------------------------------------------------------------------------
+    // Rendering
+    // -------------------------------------------------------------------------
+
+    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+        if (!this.isVisible()) {
+            this.updateRenderTracking(true);
+            return;
+        }
+        const nodeTrans = this.getTranslation();
+        const drawTrans = nodeTrans.slice();
+        drawTrans[0] += origin[0];
+        drawTrans[1] += origin[1];
+        const size = this.getDimensions();
+        const rotation = angle + this.getRotation();
+        opacity = opacity * this.getOpacity();
+        const rect = { x: drawTrans[0], y: drawTrans[1], width: size.width, height: size.height };
+
+        const standalone = sgRoot.focused === this;
+        const showFocus = (this.focusActive || standalone) && (this.getValueJS("focusVisible") as boolean);
+
+        // Auto-open a "hover" suggestion pop-up once the focus has dwelled on the key, unless it
+        // was suppressed by a previous selection (until focus leaves and returns to the key).
+        if (showFocus && !this.popup && !this.popupSuppressed) {
+            const key = this.renderedKeys[this.focusIndex];
+            if (
+                key?.suggestions &&
+                this.triggersInclude(key, "hover") &&
+                Date.now() - this.lastFocusTime > this.hoverDelay
+            ) {
+                this.openPopup(key);
+            }
+        }
+
+        const primary = this.getPaletteColor("PrimaryTextColor");
+        const secondary = this.getPaletteColor("SecondaryItemColor");
+        const focusItem = this.getPaletteColor("FocusItemColor");
+        const focusColor = this.getPaletteColor("FocusColor");
+
+        // Keyboard background cell artwork (same image as the legacy nodes), at natural size.
+        if (this.bmpBackground?.isValid() && this.renderedKeys.length > 0) {
+            const bgRect = { x: rect.x, y: rect.y, width: 0, height: 0 };
+            this.drawImage(this.bmpBackground, bgRect, 0, opacity, draw2D, this.getPaletteColor("KeyboardColor"));
+        }
+
+        for (let i = 0; i < this.renderedKeys.length; i++) {
+            const key = this.renderedKeys[i];
+            const hasContent = key.label.length > 0 || (key.icon ?? "").length > 0;
+            if (!hasContent) {
+                continue;
+            }
+            const disabled = !key.focusable || this.disabledSet.has(key.out);
+            const focused = showFocus && i === this.focusIndex;
+            const keyRect: Rect = {
+                x: rect.x + key.x,
+                y: rect.y + key.y,
+                width: key.width,
+                height: key.height,
+            };
+            if (focused && this.bmpFocus?.isValid()) {
+                // The focus indicator is a halo slightly larger than the key cell (legacy look).
+                // Round to whole pixels: the key cells are fractional (even-distribution layout),
+                // and a fractional 9-patch rect leaves a seam where the stretched center meets the
+                // edges, letting a background cell border show through as a divider line.
+                const fx = Math.round(keyRect.x - this.keyFocusDelta);
+                const fy = Math.round(keyRect.y - this.keyFocusDelta);
+                const focusRect: Rect = {
+                    x: fx,
+                    y: fy,
+                    width: Math.round(keyRect.x + keyRect.width + this.keyFocusDelta) - fx,
+                    height: Math.round(keyRect.y + keyRect.height + this.keyFocusDelta) - fy,
+                };
+                this.drawImage(this.bmpFocus, focusRect, 0, opacity, draw2D, focusColor);
+            }
+            const color = disabled ? secondary : focused ? focusItem : primary;
+            this.renderKeyContent(key, keyRect, color, opacity, i, draw2D);
+        }
+
+        if (this.popup) {
+            this.renderPopup(rect, primary, focusItem, focusColor, opacity, draw2D);
+        }
+
+        this.updateBoundingRects(rect, origin, rotation);
+        this.renderChildren(interpreter, drawTrans, rotation, opacity, draw2D);
+        this.nodeRenderingDone(origin, angle, opacity, draw2D);
+    }
+
+    /**
+     * Maps a key's strOut to a legacy icon asset name, honoring the current mode for
+     * the on/off toggle keys (caps/alphanum/symbols/accents), matching the legacy Keyboard.
+     */
+    private iconAssetFor(strOut: string): string | undefined {
+        const mode = this.mode;
+        const upper = mode.endsWith("Upper") || mode.endsWith("Shift");
+        const base = mode.startsWith("Symbols") ? "Symbols" : mode.startsWith("Accents") ? "Accents" : "ABC123";
+        switch (strOut) {
+            case "shift":
+                return "shift";
+            case "space":
+                return "space";
+            case "backspace":
+                return "delete";
+            case "clear":
+                return "clear";
+            case "left":
+                return "moveCursorLeft";
+            case "right":
+                return "moveCursorRight";
+            case "capslock":
+                return upper ? "caps_on" : "caps_off";
+            case "abc123":
+                return base === "ABC123" ? "alphanum_on" : "alphanum_off";
+            case "symbols":
+                return base === "Symbols" ? "symbols_on" : "symbols_off";
+            case "accents":
+                return base === "Accents" ? "accent_on" : "accent_off";
+            default:
+                return undefined;
+        }
+    }
+
+    private renderKeyContent(
+        key: RenderedKey,
+        rect: Rect,
+        color: number,
+        opacity: number,
+        index: number,
+        draw2D?: IfDraw2D
+    ) {
+        // Icon keys: prefer the legacy bitmap asset (drawn at natural size), else a glyph.
+        if (key.strOut.length > 0 && key.label.length === 0) {
+            const iconName = this.iconAssetFor(key.strOut);
+            const bmp = iconName ? this.bmpIcons.get(iconName) : undefined;
+            if (bmp?.isValid()) {
+                const iconX = rect.x + Math.floor((rect.width - bmp.width) / 2);
+                const iconY = rect.y + Math.floor((rect.height - bmp.height) / 2);
+                this.drawImage(
+                    bmp,
+                    { x: iconX, y: iconY, width: bmp.width, height: bmp.height },
+                    0,
+                    opacity,
+                    draw2D,
+                    color
+                );
+                return;
+            }
+            const glyph = resolveKeyIcon(key.strOut)?.glyph ?? key.strOut;
+            this.drawText(glyph, this.font, color, opacity, rect, "center", "center", 0, draw2D, "", index);
+            return;
+        }
+        if (key.label.length > 0) {
+            this.drawText(key.label, this.font, color, opacity, rect, "center", "center", 0, draw2D, "", index);
+        }
+    }
+
+    private renderPopup(
+        rect: Rect,
+        textColor: number,
+        focusItem: number,
+        focusColor: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
+        if (!this.popup) {
+            return;
+        }
+        const key = this.popup.key;
+        const lineH = this.resolution === "FHD" ? 54 : 36;
+        const padX = this.resolution === "FHD" ? 18 : 12;
+        // Width fits the widest option text plus a small side margin.
+        let contentWidth = 0;
+        const drawFont = this.font.createDrawFont();
+        if (drawFont instanceof RoFont) {
+            for (const option of this.popup.options) {
+                contentWidth = Math.max(contentWidth, drawFont.measureTextWidth(option).width);
+            }
+        }
+        const width = Math.ceil(contentWidth) + padX * 2;
+        const totalH = this.popup.options.length * lineH;
+        // Anchor the pop-up to the bottom-left of the key's focus indicator and extend upward,
+        // so it covers the focused key while shown; clamp to the top edge if needed.
+        const x = rect.x + key.x - this.keyFocusDelta;
+        let y = rect.y + key.y + key.height + this.keyFocusDelta - totalH;
+        if (y < 0) {
+            y = 0;
+        }
+        // Per spec: pop-up background uses FocusColor; the focused option is highlighted
+        // with FocusItemColor (its label drawn in PrimaryTextColor); other labels use FocusItemColor.
+        draw2D?.doDrawRotatedRect({ x, y, width, height: totalH }, focusColor, 0, [0, 0], opacity);
+        for (let i = 0; i < this.popup.options.length; i++) {
+            const itemRect: Rect = { x, y: y + i * lineH, width, height: lineH };
+            const focused = i === this.popup.index;
+            if (focused) {
+                draw2D?.doDrawRotatedRect(itemRect, focusItem, 0, [0, 0], opacity);
+            }
+            const labelRect: Rect = { x: x + padX, y: itemRect.y, width: width - padX * 2, height: lineH };
+            this.drawText(
+                this.popup.options[i],
+                this.font,
+                focused ? textColor : focusItem,
+                opacity,
+                labelRect,
+                "left",
+                "center",
+                0,
+                draw2D,
+                "",
+                1000 + i
+            );
+        }
+    }
+}

--- a/src/extensions/scenegraph/nodes/DynamicKeyboard.ts
+++ b/src/extensions/scenegraph/nodes/DynamicKeyboard.ts
@@ -1,0 +1,23 @@
+import { AAMember } from "brs-engine";
+import { SGNodeType } from ".";
+import { DynamicKeyboardBase } from "./DynamicKeyboardBase";
+import { dynamicKeyboardKDF } from "./kdf/builtinKDFs";
+
+/**
+ * DynamicKeyboard — voice-enabled full keyboard (alphanumeric + symbols + accents),
+ * matching the legacy Keyboard layout. Typically used for emails or passwords.
+ */
+export class DynamicKeyboard extends DynamicKeyboardBase {
+    constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.DynamicKeyboard) {
+        super([], name);
+        this.setExtendsType(name, SGNodeType.DynamicKeyboardBase);
+        this.registerInitializedFields(initializedFields);
+
+        this.configureVoiceBox({ voiceEntryType: "alphanumeric", voiceEnabled: true, maxTextLength: 75 });
+        this.setKeyDefinition(dynamicKeyboardKDF, "ABC123Lower", {
+            name: "keyboard_full",
+            insetFHD: { top: 15, right: 13, bottom: 15, left: 11 },
+            insetHD: { top: 11, right: 10, bottom: 11, left: 10 },
+        });
+    }
+}

--- a/src/extensions/scenegraph/nodes/DynamicKeyboardBase.ts
+++ b/src/extensions/scenegraph/nodes/DynamicKeyboardBase.ts
@@ -1,0 +1,225 @@
+import { AAMember, BrsBoolean, BrsString, Float, IfDraw2D, Int32, Interpreter } from "brs-engine";
+import { FieldModel } from "../SGTypes";
+import { SGNodeType } from ".";
+import { Group } from "./Group";
+import { VoiceTextEditBox } from "./VoiceTextEditBox";
+import { DynamicKeyGrid } from "./DynamicKeyGrid";
+import { KeyInset, KeyLayout } from "./kdf/KeyDefinition";
+import { sgRoot } from "../SGRoot";
+
+/**
+ * Abstract base for the Dynamic voice keyboards. Combines a DynamicKeyGrid (the
+ * keys) and a VoiceTextEditBox (the display), wiring key selection to text edits
+ * and keyboard-mode switching. Subclasses install a Key Definition File and
+ * configure the VoiceTextEditBox.
+ */
+export class DynamicKeyboardBase extends Group {
+    readonly defaultFields: FieldModel[] = [
+        { name: "text", type: "string", value: "" },
+        { name: "textEditBox", type: "node" },
+        { name: "hideTextBox", type: "boolean", value: "false" },
+        { name: "keyGrid", type: "node" },
+        { name: "domain", type: "string", value: "generic" },
+    ];
+
+    readonly textEditBox: VoiceTextEditBox;
+    readonly keyGrid: DynamicKeyGrid;
+    private readonly textBoxHeight: number;
+    private readonly gap: number;
+
+    constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.DynamicKeyboardBase) {
+        super([], name);
+        this.setExtendsType(name, SGNodeType.Group);
+        this.registerDefaultFields(this.defaultFields);
+        this.registerInitializedFields(initializedFields);
+
+        this.textBoxHeight = this.resolution === "FHD" ? 72 : 48;
+        this.gap = this.resolution === "FHD" ? 18 : 12;
+
+        this.textEditBox = new VoiceTextEditBox();
+        this.keyGrid = new DynamicKeyGrid();
+        this.keyGrid.onKeySelected = (out) => this.applyKey(out);
+
+        this.setValueSilent("textEditBox", this.textEditBox);
+        this.setValueSilent("keyGrid", this.keyGrid);
+        this.setValueSilent("focusable", BrsBoolean.True);
+
+        // Keep `text` and the VoiceTextEditBox's `text` as a single shared field.
+        this.linkField(this.textEditBox, "text");
+
+        this.appendChildToParent(this.textEditBox);
+        this.appendChildToParent(this.keyGrid);
+    }
+
+    /**
+     * Installs a Key Definition File, initial mode, and optional keyboard background
+     * image (e.g. "keyboard_full") shared with the legacy nodes, along with the cell
+     * insets that align the keys to the background's drawn cells.
+     */
+    protected setKeyDefinition(
+        layout: KeyLayout,
+        initialMode: string,
+        background?: { name: string; insetFHD: KeyInset; insetHD: KeyInset }
+    ) {
+        this.keyGrid.setValueSilent("mode", new BrsString(initialMode));
+        if (background) {
+            this.keyGrid.setBackground(background.name, background.insetFHD, background.insetHD);
+        }
+        this.keyGrid.setLayout(layout);
+        const gridWidth = this.keyGrid.getValueJS("width") as number;
+        const gridHeight = this.keyGrid.getValueJS("height") as number;
+        this.textEditBox.setValueSilent("width", new Float(gridWidth));
+        this.textEditBox.setValueSilent("height", new Float(this.textBoxHeight));
+        this.setValueSilent("width", new Float(gridWidth));
+        this.setValueSilent("height", new Float(gridHeight + this.textBoxHeight + this.gap));
+        this.layoutChildren(false);
+    }
+
+    /** Configures the internal VoiceTextEditBox. */
+    protected configureVoiceBox(opts: { voiceEntryType: string; voiceEnabled: boolean; maxTextLength: number }) {
+        this.textEditBox.setValueSilent("voiceEntryType", new BrsString(opts.voiceEntryType));
+        this.textEditBox.setValueSilent("voiceEnabled", BrsBoolean.from(opts.voiceEnabled));
+        this.textEditBox.setValueSilent("maxTextLength", new Int32(opts.maxTextLength));
+    }
+
+    /** Re-syncs the text box and node dimensions from the key grid (e.g. after a custom KDF loads). */
+    private syncSize() {
+        const gridWidth = this.keyGrid.getValueJS("width") as number;
+        const gridHeight = this.keyGrid.getValueJS("height") as number;
+        if (gridWidth > 0 && (this.textEditBox.getValueJS("width") as number) !== gridWidth) {
+            this.textEditBox.setValueSilent("width", new Float(gridWidth));
+            this.textEditBox.setValueSilent("height", new Float(this.textBoxHeight));
+            this.setValueSilent("width", new Float(gridWidth));
+            this.setValueSilent("height", new Float(gridHeight + this.textBoxHeight + this.gap));
+        }
+    }
+
+    private layoutChildren(hideTextBox: boolean) {
+        this.textEditBox.setValueSilent("visible", BrsBoolean.from(!hideTextBox));
+        this.textEditBox.setTranslation([0, 0]);
+        this.keyGrid.setTranslation([0, hideTextBox ? 0 : this.textBoxHeight + this.gap]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Key selection → text editing / mode switching
+    // -------------------------------------------------------------------------
+
+    /** Applies a selected key (its strOut or label) to the text and keyboard mode. */
+    protected applyKey(out: string) {
+        switch (out) {
+            case "clear":
+                this.textEditBox.setValue("text", new BrsString(""));
+                this.textEditBox.moveCursor(0);
+                return;
+            case "backspace":
+                this.backspace();
+                return;
+            case "space":
+                this.insertText(" ");
+                return;
+            case "left":
+                this.textEditBox.moveCursor(-1);
+                return;
+            case "right":
+                this.textEditBox.moveCursor(1);
+                return;
+            case "shift":
+            case "capslock":
+            case "UpperLower":
+                this.toggleCase();
+                return;
+            case "abc123":
+                this.setBaseMode("ABC123");
+                return;
+            case "symbols":
+                this.setBaseMode("Symbols");
+                return;
+            case "accents":
+                this.setBaseMode("Accents");
+                return;
+            default:
+                this.insertText(out);
+        }
+    }
+
+    private insertText(str: string) {
+        const maxLen = this.textEditBox.getValueJS("maxTextLength") as number;
+        let text = this.textEditBox.getValueJS("text") as string;
+        let pos = this.textEditBox.getValueJS("cursorPosition") as number;
+        const room = maxLen - text.length;
+        if (room <= 0) {
+            return;
+        }
+        if (str.length > room) {
+            str = str.slice(0, room);
+        }
+        text = text.slice(0, pos) + str + text.slice(pos);
+        pos += str.length;
+        this.textEditBox.setValue("text", new BrsString(text));
+        this.textEditBox.setValue("cursorPosition", new Float(pos));
+    }
+
+    private backspace() {
+        let text = this.textEditBox.getValueJS("text") as string;
+        let pos = this.textEditBox.getValueJS("cursorPosition") as number;
+        if (text.length === 0 || pos === 0) {
+            return;
+        }
+        text = text.slice(0, pos - 1) + text.slice(pos);
+        pos--;
+        this.textEditBox.setValue("text", new BrsString(text));
+        this.textEditBox.setValue("cursorPosition", new Float(pos));
+    }
+
+    private parseMode(mode: string): { base: string; upper: boolean } {
+        const base = mode.startsWith("Symbols") ? "Symbols" : mode.startsWith("Accents") ? "Accents" : "ABC123";
+        const upper = mode.endsWith("Upper") || mode.endsWith("Shift");
+        return { base, upper };
+    }
+
+    private toggleCase() {
+        const mode = this.keyGrid.getValueJS("mode") as string;
+        if (!mode) {
+            return;
+        }
+        const { base, upper } = this.parseMode(mode);
+        this.keyGrid.setValue("mode", new BrsString(base + (upper ? "Lower" : "Upper")));
+    }
+
+    private setBaseMode(base: string) {
+        const mode = this.keyGrid.getValueJS("mode") as string;
+        if (!mode) {
+            return;
+        }
+        const { upper } = this.parseMode(mode);
+        this.keyGrid.setValue("mode", new BrsString(base + (upper ? "Upper" : "Lower")));
+    }
+
+    // -------------------------------------------------------------------------
+    // Input routing + rendering
+    // -------------------------------------------------------------------------
+
+    handleKey(key: string, press: boolean): boolean {
+        if (!press) {
+            return false;
+        }
+        if (key.startsWith("Lit_") || key === "replay") {
+            return this.textEditBox.handleKey(key, press);
+        }
+        return this.keyGrid.handleKey(key, press);
+    }
+
+    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+        if (!this.isVisible()) {
+            this.updateRenderTracking(true);
+            return;
+        }
+        const focused = sgRoot.focused === this;
+        const hideTextBox = this.getValueJS("hideTextBox") as boolean;
+        this.syncSize();
+        this.layoutChildren(hideTextBox);
+        this.textEditBox.setActive(focused);
+        this.keyGrid.setFocusActive(focused);
+        super.renderNode(interpreter, origin, angle, opacity, draw2D);
+    }
+}

--- a/src/extensions/scenegraph/nodes/DynamicMiniKeyboard.ts
+++ b/src/extensions/scenegraph/nodes/DynamicMiniKeyboard.ts
@@ -1,0 +1,23 @@
+import { AAMember } from "brs-engine";
+import { SGNodeType } from ".";
+import { DynamicKeyboardBase } from "./DynamicKeyboardBase";
+import { dynamicMiniKeyboardKDF } from "./kdf/builtinKDFs";
+
+/**
+ * DynamicMiniKeyboard — voice-enabled letters/digits keyboard, matching the legacy
+ * MiniKeyboard layout. Typically used for search queries.
+ */
+export class DynamicMiniKeyboard extends DynamicKeyboardBase {
+    constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.DynamicMiniKeyboard) {
+        super([], name);
+        this.setExtendsType(name, SGNodeType.DynamicKeyboardBase);
+        this.registerInitializedFields(initializedFields);
+
+        this.configureVoiceBox({ voiceEntryType: "alphanumeric", voiceEnabled: true, maxTextLength: 75 });
+        this.setKeyDefinition(dynamicMiniKeyboardKDF, "", {
+            name: "keyboard_mini",
+            insetFHD: { top: 19, right: 16, bottom: 17, left: 17 },
+            insetHD: { top: 15, right: 16, bottom: 12, left: 15 },
+        });
+    }
+}

--- a/src/extensions/scenegraph/nodes/DynamicPinPad.ts
+++ b/src/extensions/scenegraph/nodes/DynamicPinPad.ts
@@ -1,0 +1,36 @@
+import { AAMember, BrsBoolean } from "brs-engine";
+import { SGNodeType } from ".";
+import { DynamicKeyboardBase } from "./DynamicKeyboardBase";
+import { dynamicPinPadKDF } from "./kdf/builtinKDFs";
+
+/**
+ * DynamicPinPad — voice-enabled numeric PIN pad, matching the legacy PinPad. The
+ * VoiceTextEditBox displays a per-digit underline for each of the `maxTextLength`
+ * digits rather than flowing text.
+ */
+export class DynamicPinPad extends DynamicKeyboardBase {
+    constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.DynamicPinPad) {
+        super([], name);
+        this.setExtendsType(name, SGNodeType.DynamicKeyboardBase);
+        this.registerInitializedFields(initializedFields);
+
+        const maxTextLength = 4;
+        this.configureVoiceBox({ voiceEntryType: "numeric", voiceEnabled: true, maxTextLength });
+        // PIN entry hides the digits by default (shows dots).
+        this.textEditBox.setValueSilent("secureMode", BrsBoolean.True);
+        this.textEditBox.setPinPadMode(maxTextLength);
+        this.setKeyDefinition(dynamicPinPadKDF, "", {
+            name: "keyboard_pinpad",
+            insetFHD: { top: 22, right: 23, bottom: 24, left: 21 },
+            insetHD: { top: 15, right: 16, bottom: 16, left: 14 },
+        });
+    }
+
+    handleKey(key: string, press: boolean): boolean {
+        // Numeric entry only: ignore non-digit literal keys.
+        if (key.startsWith("Lit_") && !/^\d$/.test(key.substring(4))) {
+            return false;
+        }
+        return super.handleKey(key, press);
+    }
+}

--- a/src/extensions/scenegraph/nodes/VoiceTextEditBox.ts
+++ b/src/extensions/scenegraph/nodes/VoiceTextEditBox.ts
@@ -1,7 +1,8 @@
 import { FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";
 import { TextEditBox } from "./TextEditBox";
-import { AAMember, Float } from "brs-engine";
+import { AAMember, Float, IfDraw2D, Interpreter, Rect, RoBitmap } from "brs-engine";
+import { Font } from "./Font";
 
 export class VoiceTextEditBox extends TextEditBox {
     readonly defaultFields: FieldModel[] = [
@@ -11,6 +12,14 @@ export class VoiceTextEditBox extends TextEditBox {
         { name: "isDictating", type: "boolean", value: "false" },
         { name: "voiceInputRegexFilter", type: "string", value: "" },
     ];
+
+    // Pin-pad display mode: a fixed number of per-digit underline slots (used by
+    // DynamicPinPad) instead of the regular flowing text + cursor display.
+    private pinPadMode = false;
+    private pinPadSlots = 0;
+    private pinPadFont?: Font;
+    private pinPadBg?: RoBitmap;
+    private readonly pinSecureChar = "•";
 
     constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.VoiceTextEditBox) {
         super([], name);
@@ -24,5 +33,79 @@ export class VoiceTextEditBox extends TextEditBox {
         } else {
             this.setValueSilent("voiceToolTipWidth", new Float(214));
         }
+    }
+
+    /** Enables the per-digit underline display used by DynamicPinPad. */
+    setPinPadMode(slots: number) {
+        this.pinPadMode = true;
+        this.pinPadSlots = slots;
+        this.pinPadFont = new Font(); // same default size as the regular text display
+        this.pinPadBg = this.loadBitmap("common:/images/inputField.9.png");
+    }
+
+    renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+        if (!this.pinPadMode) {
+            super.renderNode(interpreter, origin, angle, opacity, draw2D);
+            return;
+        }
+        if (!this.isVisible()) {
+            this.updateRenderTracking(true);
+            return;
+        }
+        const nodeTrans = this.getTranslation();
+        const drawTrans = nodeTrans.slice();
+        drawTrans[0] += origin[0];
+        drawTrans[1] += origin[1];
+        const size = this.getDimensions();
+        const rotation = angle + this.getRotation();
+        opacity *= this.getOpacity();
+        const rect: Rect = { x: drawTrans[0], y: drawTrans[1], width: size.width, height: size.height };
+
+        if (this.pinPadBg?.isValid()) {
+            this.drawImage(this.pinPadBg, { ...rect }, 0, opacity, draw2D);
+        }
+
+        const text = this.getValueJS("text") as string;
+        const secure = this.getValueJS("secureMode") as boolean;
+        const active = this.getValueJS("active") as boolean;
+        const color = this.getValueJS("textColor") as number;
+        const slots = this.pinPadSlots > 0 ? this.pinPadSlots : (this.getValueJS("maxTextLength") as number);
+
+        // The slots are a compact group centered in the box (not spread to the full width).
+        const fhd = this.resolution === "FHD";
+        const pitch = fhd ? 40 : 27;
+        const underlineW = fhd ? 24 : 16;
+        const underlineH = fhd ? 4 : 3;
+        const centerY = rect.y + rect.height / 2;
+        const underlineY = centerY + (fhd ? 12 : 8);
+        const dotCenterY = centerY - (fhd ? 4 : 3);
+        const firstCenterX = rect.x + rect.width / 2 - ((slots - 1) * pitch) / 2;
+
+        for (let i = 0; i < slots; i++) {
+            const centerX = firstCenterX + i * pitch;
+            const underlineRect: Rect = {
+                x: Math.round(centerX - underlineW / 2),
+                y: Math.round(underlineY),
+                width: underlineW,
+                height: underlineH,
+            };
+            const activeSlot = active && i === text.length;
+            draw2D?.doDrawRotatedRect(underlineRect, color, 0, [0, 0], activeSlot ? opacity : opacity * 0.5);
+            if (i < text.length && this.pinPadFont) {
+                // Secure entries show a bullet glyph, otherwise the digit; both at the regular
+                // text size, centered over the slot.
+                const char = secure ? this.pinSecureChar : text[i];
+                const charRect: Rect = {
+                    x: centerX - pitch,
+                    y: dotCenterY - rect.height / 2,
+                    width: 2 * pitch,
+                    height: rect.height,
+                };
+                this.drawText(char, this.pinPadFont, color, opacity, charRect, "center", "center", 0, draw2D, "", i);
+            }
+        }
+
+        this.updateBoundingRects(rect, origin, rotation);
+        this.nodeRenderingDone(origin, angle, opacity, draw2D);
     }
 }

--- a/src/extensions/scenegraph/nodes/index.ts
+++ b/src/extensions/scenegraph/nodes/index.ts
@@ -25,6 +25,12 @@ export * from "./LayoutGroup";
 export * from "./MarkupGrid";
 export * from "./MarkupList";
 export * from "./MiniKeyboard";
+export * from "./DynamicKeyGrid";
+export * from "./DynamicKeyboardBase";
+export * from "./DynamicKeyboard";
+export * from "./DynamicMiniKeyboard";
+export * from "./DynamicPinPad";
+export * from "./DynamicCustomKeyboard";
 export * from "./PinPad";
 export * from "./PinDialog";
 export * from "./Node";
@@ -157,12 +163,12 @@ export enum SGNodeType {
     Scene = "Scene",
     Keyboard = "Keyboard",
     MiniKeyboard = "MiniKeyboard",
-    DynamicKeyboard = "DynamicKeyboard", // Not yet implemented
-    DynamicKeyboardBase = "DynamicKeyboardBase", // Not yet implemented
-    DynamicMiniKeyboard = "DynamicMiniKeyboard", // Not yet implemented
-    DynamicCustomKeyboard = "DynamicCustomKeyboard", // Not yet implemented
-    DynamicPinPad = "DynamicPinPad", // Not yet implemented
-    DynamicKeyGrid = "DynamicKeyGrid", // Not yet implemented
+    DynamicKeyboard = "DynamicKeyboard",
+    DynamicKeyboardBase = "DynamicKeyboardBase",
+    DynamicMiniKeyboard = "DynamicMiniKeyboard",
+    DynamicCustomKeyboard = "DynamicCustomKeyboard",
+    DynamicPinPad = "DynamicPinPad",
+    DynamicKeyGrid = "DynamicKeyGrid",
     TextEditBox = "TextEditBox",
     VoiceTextEditBox = "VoiceTextEditBox",
     Overhang = "Overhang",

--- a/src/extensions/scenegraph/nodes/kdf/KeyDefinition.ts
+++ b/src/extensions/scenegraph/nodes/kdf/KeyDefinition.ts
@@ -1,0 +1,273 @@
+/**
+ * Key Definition File (KDF) model and layout engine for the Dynamic voice keyboards.
+ *
+ * A KDF is a JSON description of a keyboard layout organized as a hierarchy of
+ * KeyLayout → Section → Grid (per mode) → Row → Key. See the Roku reference
+ * `scenegraph/dynamic-voice-keyboard-nodes/key-definition-file.md` for the spec.
+ *
+ * `computeLayout()` flattens the selected grid of every section into absolutely
+ * positioned, renderable keys, applying the spec's size-distribution rules.
+ */
+
+export interface KeySuggestions {
+    options?: string | string[];
+    triggers?: string | string[];
+}
+
+export interface KeyDef {
+    keyWidthFHD?: number;
+    keyWidthHD?: number;
+    label?: string;
+    icon?: string;
+    focusIcon?: string;
+    strOut?: string;
+    autoRepeat?: number;
+    disabled?: number;
+    suggestions?: KeySuggestions;
+}
+
+export interface RowDef {
+    rowHeightFHD?: number;
+    rowHeightHD?: number;
+    keys: KeyDef[];
+}
+
+export interface GridDef {
+    gridHeightFHD?: number;
+    gridHeightHD?: number;
+    modes?: string | string[];
+    rows: RowDef[];
+}
+
+export interface SectionDef {
+    sectionWidthFHD?: number;
+    sectionWidthHD?: number;
+    grids: GridDef[];
+}
+
+export interface KeyLayout {
+    keyboardWidthFHD?: number;
+    keyboardHeightFHD?: number;
+    keyboardWidthHD?: number;
+    keyboardHeightHD?: number;
+    sections: SectionDef[];
+}
+
+/** A single key flattened to absolute coordinates, ready to render and navigate. */
+export interface RenderedKey {
+    section: number;
+    row: number;
+    col: number;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    label: string;
+    icon?: string;
+    focusIcon?: string;
+    /** The value emitted via keyFocused/keySelected: strOut when set, otherwise label. */
+    out: string;
+    /** Raw strOut (may be empty for plain label keys). */
+    strOut: string;
+    disabled: boolean;
+    autoRepeat: boolean;
+    suggestions?: KeySuggestions;
+    /** Whether the key can receive focus (false for blank keys and disabled keys). */
+    focusable: boolean;
+}
+
+type Resolution = "FHD" | "HD";
+
+function pick(res: Resolution, fhd: number | undefined, hd: number | undefined): number | undefined {
+    return res === "FHD" ? fhd : hd;
+}
+
+/** Normalizes a Grid's `modes` (string | string[] | undefined) to a string array. */
+function modesOf(grid: GridDef): string[] {
+    if (grid.modes === undefined) {
+        return [];
+    }
+    return Array.isArray(grid.modes) ? grid.modes : [grid.modes];
+}
+
+/**
+ * Selects the Grid of a Section to display for the given mode.
+ * - A section with a single grid always uses that grid.
+ * - Otherwise the grid whose `modes` contains `mode` is used.
+ * - A grid with no `modes` acts as a fallback shared across all modes.
+ */
+export function selectGrid(section: SectionDef, mode: string): GridDef | undefined {
+    if (section.grids.length === 0) {
+        return undefined;
+    }
+    if (section.grids.length === 1) {
+        return section.grids[0];
+    }
+    let fallback: GridDef | undefined;
+    for (const grid of section.grids) {
+        const modes = modesOf(grid);
+        if (modes.length === 0) {
+            fallback ??= grid;
+        } else if (modes.includes(mode)) {
+            return grid;
+        }
+    }
+    return fallback ?? section.grids[0];
+}
+
+/**
+ * Distributes `total` across N slots. Slots with an explicit size keep it; the
+ * remaining space is divided evenly among the slots without an explicit size.
+ */
+function distribute(total: number, explicit: (number | undefined)[]): number[] {
+    let sumExplicit = 0;
+    let autoCount = 0;
+    for (const value of explicit) {
+        if (value === undefined) {
+            autoCount++;
+        } else {
+            sumExplicit += value;
+        }
+    }
+    const autoSize = autoCount > 0 ? (total - sumExplicit) / autoCount : 0;
+    return explicit.map((value) => value ?? autoSize);
+}
+
+/** Returns the keyboard's overall [width, height] for the resolution. */
+export function keyboardSize(layout: KeyLayout, res: Resolution): [number, number] {
+    const width = pick(res, layout.keyboardWidthFHD, layout.keyboardWidthHD) ?? 0;
+    const height = pick(res, layout.keyboardHeightFHD, layout.keyboardHeightHD) ?? 0;
+    return [width, height];
+}
+
+/** Margins (in keyboard pixels) between the background bitmap edges and the key cells. */
+export interface KeyInset {
+    top: number;
+    right: number;
+    bottom: number;
+    left: number;
+}
+
+const NO_INSET: KeyInset = { top: 0, right: 0, bottom: 0, left: 0 };
+
+/**
+ * Flattens the layout into absolutely positioned keys for the given mode and
+ * resolution. Coordinates are relative to the keyboard's top-left corner. The
+ * optional `inset` carves out the margins that surround the key cells in the
+ * keyboard background bitmap, so the keys land on the drawn cells.
+ */
+export function computeLayout(
+    layout: KeyLayout,
+    mode: string,
+    res: Resolution,
+    inset: KeyInset = NO_INSET
+): RenderedKey[] {
+    const [boardWidth, boardHeight] = keyboardSize(layout, res);
+    const contentWidth = boardWidth - inset.left - inset.right;
+    const contentHeight = boardHeight - inset.top - inset.bottom;
+    const rendered: RenderedKey[] = [];
+
+    const sectionWidths = distribute(
+        contentWidth,
+        layout.sections.map((section) => pick(res, section.sectionWidthFHD, section.sectionWidthHD))
+    );
+
+    // When every section has an explicit width that leaves the keyboard wider than
+    // their sum, the leftover space is distributed as equal gaps between sections
+    // (this matches Roku's keyboard backgrounds, which separate the sections).
+    const sumWidths = sectionWidths.reduce((acc, w) => acc + w, 0);
+    const gap = layout.sections.length > 1 ? Math.max(0, (contentWidth - sumWidths) / (layout.sections.length - 1)) : 0;
+
+    let sectionX = inset.left;
+    for (let s = 0; s < layout.sections.length; s++) {
+        const section = layout.sections[s];
+        const sectionWidth = sectionWidths[s];
+        const grid = selectGrid(section, mode);
+        if (grid) {
+            const gridHeight = pick(res, grid.gridHeightFHD, grid.gridHeightHD) ?? contentHeight;
+            const rowHeights = distribute(
+                gridHeight,
+                grid.rows.map((row) => pick(res, row.rowHeightFHD, row.rowHeightHD))
+            );
+            let rowY = inset.top;
+            for (let r = 0; r < grid.rows.length; r++) {
+                const row = grid.rows[r];
+                const rowHeight = rowHeights[r];
+                const keyWidths = distribute(
+                    sectionWidth,
+                    row.keys.map((key) => pick(res, key.keyWidthFHD, key.keyWidthHD))
+                );
+                let keyX = sectionX;
+                for (let c = 0; c < row.keys.length; c++) {
+                    const key = row.keys[c];
+                    const keyWidth = keyWidths[c];
+                    const label = key.label ?? "";
+                    const strOut = key.strOut ?? "";
+                    const hasContent = label.length > 0 || (key.icon ?? "").length > 0;
+                    const disabled = (key.disabled ?? 0) !== 0;
+                    rendered.push({
+                        section: s,
+                        row: r,
+                        col: c,
+                        x: keyX,
+                        y: rowY,
+                        width: keyWidth,
+                        height: rowHeight,
+                        label,
+                        icon: key.icon,
+                        focusIcon: key.focusIcon,
+                        out: strOut.length > 0 ? strOut : label,
+                        strOut,
+                        disabled,
+                        autoRepeat: (key.autoRepeat ?? 0) !== 0,
+                        suggestions: key.suggestions,
+                        focusable: hasContent && !disabled,
+                    });
+                    keyX += keyWidth;
+                }
+                rowY += rowHeight;
+            }
+        }
+        sectionX += sectionWidth + gap;
+    }
+    return rendered;
+}
+
+/** Resolution-independent icon mapping for a special key, keyed by its strOut. */
+export interface SpecialKeyIcon {
+    /** Base name of an existing `common:/images/{res}/icon_<name>.png` asset, if any. */
+    iconName?: "clear" | "delete" | "space";
+    /** Short text glyph drawn when no bitmap asset is available. */
+    glyph: string;
+}
+
+/**
+ * Maps a key's `strOut` to an icon asset and/or a text-glyph fallback. Only the
+ * clear/space/delete icons ship in `common.zip`; everything else is a glyph.
+ */
+export function resolveKeyIcon(strOut: string): SpecialKeyIcon | undefined {
+    switch (strOut) {
+        case "clear":
+            return { iconName: "clear", glyph: "clear" };
+        case "backspace":
+            return { iconName: "delete", glyph: "⌫" }; // ⌫
+        case "space":
+            return { iconName: "space", glyph: "␣" }; // ␣
+        case "shift":
+            return { glyph: "⇧" }; // ⇧
+        case "left":
+            return { glyph: "◄" }; // ◄
+        case "right":
+            return { glyph: "►" }; // ►
+        case "capslock":
+            return { glyph: "⇪" }; // ⇪
+        case "abc123":
+            return { glyph: "ABC" };
+        case "symbols":
+            return { glyph: "#+=" };
+        case "accents":
+            return { glyph: "àé" }; // àé
+        default:
+            return undefined;
+    }
+}

--- a/src/extensions/scenegraph/nodes/kdf/builtinKDFs.ts
+++ b/src/extensions/scenegraph/nodes/kdf/builtinKDFs.ts
@@ -1,0 +1,213 @@
+/**
+ * Built-in Key Definition Files for the fixed-layout Dynamic keyboards.
+ *
+ * Transcribed from the Roku reference KDF examples
+ * (`scenegraph/dynamic-voice-keyboard-nodes/key-definition-file.md`). The `icon`
+ * fields are kept for fidelity, but the renderer resolves special-key visuals from
+ * each key's `strOut` (see `resolveKeyIcon` in `KeyDefinition.ts`).
+ */
+import { KeyLayout } from "./KeyDefinition";
+
+const clearKey = { icon: "theme:DKB_ClearKeyBitmap", focusIcon: "theme:DKB_ClearKeyFocusBitmap", strOut: "clear" };
+const spaceKey = { icon: "theme:DKB_SpaceKeyBitmap", focusIcon: "theme:DKB_SpaceKeyFocusBitmap", strOut: "space" };
+const deleteKey = {
+    icon: "theme:DKB_DeleteKeyBitmap",
+    focusIcon: "theme:DKB_DeleteKeyFocusBitmap",
+    autoRepeat: 1,
+    strOut: "backspace",
+};
+
+/** DynamicPinPad — single numeric 3×4 grid (1-9, clear/0/backspace). Sized to the legacy keyboard_pinpad.png. */
+export const dynamicPinPadKDF: KeyLayout = {
+    keyboardWidthFHD: 408,
+    keyboardHeightFHD: 378,
+    keyboardWidthHD: 272,
+    keyboardHeightHD: 252,
+    sections: [
+        {
+            grids: [
+                {
+                    rows: [
+                        { keys: [{ label: "1" }, { label: "2" }, { label: "3" }] },
+                        { keys: [{ label: "4" }, { label: "5" }, { label: "6" }] },
+                        { keys: [{ label: "7" }, { label: "8" }, { label: "9" }] },
+                        { keys: [clearKey, { label: "0" }, deleteKey] },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+/** DynamicMiniKeyboard — 6×6 a-z/0-9 grid plus a clear/space/backspace row. Sized to the legacy keyboard_mini.png. */
+export const dynamicMiniKeyboardKDF: KeyLayout = {
+    keyboardWidthFHD: 582,
+    keyboardHeightFHD: 627,
+    keyboardWidthHD: 388,
+    keyboardHeightHD: 418,
+    sections: [
+        {
+            grids: [
+                {
+                    rows: [
+                        { keys: "abcdef".split("").map((label) => ({ label })) },
+                        { keys: "ghijkl".split("").map((label) => ({ label })) },
+                        { keys: "mnopqr".split("").map((label) => ({ label })) },
+                        { keys: "stuvwx".split("").map((label) => ({ label })) },
+                        { keys: "yz1234".split("").map((label) => ({ label })) },
+                        { keys: "567890".split("").map((label) => ({ label })) },
+                        { keys: [clearKey, spaceKey, deleteKey] },
+                    ],
+                },
+            ],
+        },
+    ],
+};
+
+// Helper to turn a string of single-character labels into a row of keys.
+const lblRow = (chars: string) => ({ keys: chars.split("").map((label) => ({ label })) });
+// Same, but from an explicit array (for rows containing quotes/backslashes).
+const rowOf = (labels: string[]) => ({ keys: labels.map((label) => ({ label })) });
+
+/**
+ * DynamicKeyboard — full WiFi-style keyboard matching the legacy Keyboard layout.
+ * Four sections: modifier sidebar, alpha grids (ABC123/Symbols/Accents × Lower/Upper),
+ * numeric+symbol grid, and a mode-toggle sidebar.
+ */
+export const dynamicKeyboardKDF: KeyLayout = {
+    keyboardWidthFHD: 1395,
+    keyboardHeightFHD: 363,
+    keyboardWidthHD: 930,
+    keyboardHeightHD: 242,
+    sections: [
+        // Section 1: shift / space / delete / left-right modifier sidebar (shared across modes).
+        {
+            sectionWidthFHD: 184,
+            sectionWidthHD: 121,
+            grids: [
+                {
+                    rows: [
+                        { keys: [{ icon: "theme:DKB_ShiftKeyBitmap", strOut: "shift" }] },
+                        { keys: [spaceKey] },
+                        { keys: [deleteKey] },
+                        {
+                            keys: [
+                                { icon: "theme:DKB_LeftKeyBitmap", strOut: "left" },
+                                { icon: "theme:DKB_RightKeyBitmap", strOut: "right" },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+        // Section 2: the main alpha/symbol/accent character grids.
+        {
+            sectionWidthFHD: 637,
+            sectionWidthHD: 422,
+            grids: [
+                { modes: "ABC123Lower", rows: ["abcdefg", "hijklmn", "opqrstu", "vwxyz-_"].map(lblRow) },
+                {
+                    modes: ["ABC123Upper", "ABC123Shift"],
+                    rows: ["ABCDEFG", "HIJKLMN", "OPQRSTU", "VWXYZ-_"].map(lblRow),
+                },
+                {
+                    modes: "SymbolsLower",
+                    rows: [
+                        lblRow("!?*#$%^"),
+                        rowOf(["&", ",", ":", ";", "`", "'", '"']),
+                        lblRow("(){}[]~"),
+                        rowOf(["¡", "¿", "<", ">", "|", "\\", "/"]),
+                    ],
+                },
+                {
+                    modes: ["SymbolsUpper", "SymbolsShift"],
+                    rows: [lblRow("•·¢£¥€§"), lblRow("®©™«»‹›"), lblRow("†‡ƒ¶¹²³"), lblRow("º°ª…")],
+                },
+                {
+                    modes: "AccentsLower",
+                    rows: [lblRow("àáâãäåæ"), lblRow("èéêëìíî"), lblRow("ïòóôõöø"), lblRow("œùúûüçñ")],
+                },
+                {
+                    modes: ["AccentsUpper", "AccentsShift"],
+                    rows: [lblRow("ÀÁÂÃÄÅÆ"), lblRow("ÈÉÊËÌÍÎ"), lblRow("ÏÒÓÔÕÖØ"), lblRow("ŒÙÚÛÜÇÑ")],
+                },
+            ],
+        },
+        // Section 3: numeric keypad / extra symbols.
+        {
+            sectionWidthFHD: 272,
+            sectionWidthHD: 180,
+            grids: [
+                {
+                    modes: ["ABC123Lower", "ABC123Upper", "ABC123Shift"],
+                    rows: [
+                        lblRow("123"),
+                        lblRow("456"),
+                        lblRow("789"),
+                        {
+                            keys: [
+                                {
+                                    label: "@",
+                                    suggestions: {
+                                        options: [
+                                            "@gmail.com",
+                                            "@yahoo.com",
+                                            "@outlook.com",
+                                            "@aol.com",
+                                            "@icloud.com",
+                                            "@",
+                                        ],
+                                        triggers: ["hover", "select"],
+                                    },
+                                },
+                                { label: "." },
+                                { label: "0" },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    modes: "SymbolsLower",
+                    rows: [lblRow("´ˆ˜"), lblRow("¨¯¸"), lblRow("=+×"), lblRow("÷±‰")],
+                },
+                {
+                    modes: ["SymbolsUpper", "SymbolsShift"],
+                    rows: [lblRow("¼½¾"), lblRow("“”„"), lblRow("‘’‚"), lblRow("–—")],
+                },
+                {
+                    modes: "AccentsLower",
+                    rows: [lblRow("ýÿš"), lblRow("žðþ"), lblRow("ß")],
+                },
+                {
+                    modes: ["AccentsUpper", "AccentsShift"],
+                    rows: [lblRow("ÝŸŠ"), lblRow("ŽÐÞ")],
+                },
+            ],
+        },
+        // Section 4: mode-toggle sidebar (caps / abc123 / symbols / accents).
+        {
+            sectionWidthFHD: 181,
+            sectionWidthHD: 120,
+            grids: [
+                {
+                    modes: ["ABC123Lower", "ABC123Shift", "SymbolsLower", "AccentsLower"],
+                    rows: [
+                        { keys: [{ icon: "theme:DKB_CapsModOffKeyBitmap", strOut: "capslock" }] },
+                        { keys: [{ icon: "theme:DKB_ABC123ModKeyBitmap", strOut: "abc123" }] },
+                        { keys: [{ icon: "theme:DKB_SymbolsModKeyBitmap", strOut: "symbols" }] },
+                        { keys: [{ icon: "theme:DKB_AccentsModKeyBitmap", strOut: "accents" }] },
+                    ],
+                },
+                {
+                    modes: ["ABC123Upper", "SymbolsUpper", "AccentsUpper"],
+                    rows: [
+                        { keys: [{ icon: "theme:DKB_CapsModOnKeyBitmap", strOut: "capslock" }] },
+                        { keys: [{ icon: "theme:DKB_ABC123ModKeyBitmap", strOut: "abc123" }] },
+                        { keys: [{ icon: "theme:DKB_SymbolsModKeyBitmap", strOut: "symbols" }] },
+                        { keys: [{ icon: "theme:DKB_AccentsModKeyBitmap", strOut: "accents" }] },
+                    ],
+                },
+            ],
+        },
+    ],
+};

--- a/test/extensions/scenegraph/DynamicKeyboard.test.js
+++ b/test/extensions/scenegraph/DynamicKeyboard.test.js
@@ -1,0 +1,556 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsDevice, BrsString, Int32, RoArray } = core;
+
+const fakeInterpreter = {};
+
+/** Builds a jumpToKey array value [section, row, key]. */
+function coords(section, row, key) {
+    return new RoArray([new Int32(section), new Int32(row), new Int32(key)]);
+}
+
+/** Reads the text currently entered in a keyboard. */
+function textOf(node) {
+    return node.getValueJS("text");
+}
+
+describe("Dynamic voice keyboards", () => {
+    beforeAll(() => {
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    describe("factory wiring", () => {
+        const types = [
+            "DynamicKeyGrid",
+            "DynamicKeyboard",
+            "DynamicMiniKeyboard",
+            "DynamicPinPad",
+            "DynamicCustomKeyboard",
+        ];
+        for (const type of types) {
+            test(`creates ${type}`, () => {
+                const node = SGNodeFactory.createNode(type);
+                expect(node).toBeDefined();
+                expect(node.constructor.name).toBe(type);
+                expect(node.nodeSubtype).toBe(type);
+            });
+        }
+    });
+
+    describe("DynamicKeyGrid default fields", () => {
+        test("exposes the documented fields and defaults", () => {
+            const grid = SGNodeFactory.createNode("DynamicKeyGrid");
+            const fields = grid.getNodeFields();
+            const expected = [
+                ["keyDefinitionUri", "string", ""], // "uri" fields are stored as the String kind
+                ["mode", "string", ""],
+                ["focusVisible", "boolean", true],
+                ["horizWrap", "boolean", false],
+                ["vertWrap", "boolean", false],
+                ["keyFocused", "string", ""],
+                ["keySelected", "string", ""],
+            ];
+            for (const [name, type, value] of expected) {
+                const field = fields.get(name.toLowerCase());
+                expect(field).toBeDefined();
+                expect(field.getType()).toBe(type);
+                expect(grid.getValueJS(name)).toBe(value);
+            }
+        });
+    });
+
+    describe("DynamicKeyboardBase fields", () => {
+        test("DynamicKeyboard exposes text, hideTextBox, domain and child nodes", () => {
+            const kbd = SGNodeFactory.createNode("DynamicKeyboard");
+            expect(kbd.getValueJS("text")).toBe("");
+            expect(kbd.getValueJS("hideTextBox")).toBe(false);
+            expect(kbd.getValueJS("domain")).toBe("generic");
+            expect(kbd.textEditBox.constructor.name).toBe("VoiceTextEditBox");
+            expect(kbd.keyGrid.constructor.name).toBe("DynamicKeyGrid");
+        });
+
+        test("subclass VoiceTextEditBox defaults match the spec", () => {
+            const cases = [
+                ["DynamicKeyboard", "alphanumeric", 75],
+                ["DynamicMiniKeyboard", "alphanumeric", 75],
+                ["DynamicPinPad", "numeric", 4],
+                ["DynamicCustomKeyboard", "generic", 75],
+            ];
+            for (const [type, voiceEntryType, maxLen] of cases) {
+                const kbd = SGNodeFactory.createNode(type);
+                expect(kbd.textEditBox.getValueJS("voiceEntryType")).toBe(voiceEntryType);
+                expect(kbd.textEditBox.getValueJS("voiceEnabled")).toBe(true);
+                expect(kbd.textEditBox.getValueJS("maxTextLength")).toBe(maxLen);
+            }
+        });
+    });
+
+    describe("DynamicPinPad", () => {
+        test("key grid matches the legacy keyboard_pinpad size (HD)", () => {
+            const pad = SGNodeFactory.createNode("DynamicPinPad");
+            expect(pad.keyGrid.getValueJS("width")).toBe(272);
+            expect(pad.keyGrid.getValueJS("height")).toBe(252);
+        });
+
+        test("navigation updates keyFocused across the 3x4 grid", () => {
+            const pad = SGNodeFactory.createNode("DynamicPinPad");
+            const grid = pad.keyGrid;
+            expect(grid.getValueJS("keyFocused")).toBe("1");
+            pad.handleKey("right", true);
+            expect(grid.getValueJS("keyFocused")).toBe("2");
+            pad.handleKey("down", true);
+            expect(grid.getValueJS("keyFocused")).toBe("5");
+        });
+
+        test("selecting digit keys enters numbers and caps at maxTextLength", () => {
+            const pad = SGNodeFactory.createNode("DynamicPinPad");
+            // Focus "1" and select it five times; only four digits should be accepted.
+            for (let i = 0; i < 5; i++) {
+                pad.keyGrid.setValue("jumpToKey", coords(0, 0, 0)); // key "1"
+                pad.handleKey("OK", true);
+            }
+            expect(textOf(pad)).toBe("1111");
+        });
+
+        test("clear and backspace keys edit the entry", () => {
+            const pad = SGNodeFactory.createNode("DynamicPinPad");
+            pad.keyGrid.setValue("jumpToKey", coords(0, 0, 1)); // "2"
+            pad.handleKey("OK", true);
+            pad.keyGrid.setValue("jumpToKey", coords(0, 1, 0)); // "4"
+            pad.handleKey("OK", true);
+            expect(textOf(pad)).toBe("24");
+            pad.keyGrid.setValue("jumpToKey", coords(0, 3, 2)); // backspace
+            pad.handleKey("OK", true);
+            expect(textOf(pad)).toBe("2");
+            pad.keyGrid.setValue("jumpToKey", coords(0, 3, 0)); // clear
+            pad.handleKey("OK", true);
+            expect(textOf(pad)).toBe("");
+        });
+
+        test("ignores non-digit literal keys", () => {
+            const pad = SGNodeFactory.createNode("DynamicPinPad");
+            expect(pad.handleKey("Lit_a", true)).toBe(false);
+            expect(textOf(pad)).toBe("");
+            pad.handleKey("Lit_7", true);
+            expect(textOf(pad)).toBe("7");
+        });
+    });
+
+    describe("DynamicMiniKeyboard", () => {
+        test("selecting letters, space and clear edits the text", () => {
+            const mini = SGNodeFactory.createNode("DynamicMiniKeyboard");
+            mini.keyGrid.setValue("jumpToKey", coords(0, 0, 0)); // "a"
+            mini.handleKey("OK", true);
+            mini.keyGrid.setValue("jumpToKey", coords(0, 0, 1)); // "b"
+            mini.handleKey("OK", true);
+            expect(textOf(mini)).toBe("ab");
+            mini.keyGrid.setValue("jumpToKey", coords(0, 6, 1)); // space
+            mini.handleKey("OK", true);
+            expect(textOf(mini)).toBe("ab ");
+            mini.keyGrid.setValue("jumpToKey", coords(0, 6, 0)); // clear
+            mini.handleKey("OK", true);
+            expect(textOf(mini)).toBe("");
+        });
+    });
+
+    describe("DynamicKeyboard", () => {
+        test("starts in ABC123Lower mode and inserts lowercase letters", () => {
+            const kbd = SGNodeFactory.createNode("DynamicKeyboard");
+            expect(kbd.keyGrid.getValueJS("mode")).toBe("ABC123Lower");
+            kbd.keyGrid.setValue("jumpToKey", coords(1, 0, 0)); // "a"
+            kbd.handleKey("OK", true);
+            expect(textOf(kbd)).toBe("a");
+        });
+
+        test("capslock toggles to uppercase and inserts uppercase letters", () => {
+            const kbd = SGNodeFactory.createNode("DynamicKeyboard");
+            kbd.keyGrid.setValue("jumpToKey", coords(3, 0, 0)); // capslock toggle (section 4)
+            kbd.handleKey("OK", true);
+            expect(kbd.keyGrid.getValueJS("mode")).toBe("ABC123Upper");
+            kbd.keyGrid.setValue("jumpToKey", coords(1, 0, 0)); // "A"
+            kbd.handleKey("OK", true);
+            expect(textOf(kbd)).toBe("A");
+        });
+
+        test("symbols toggle switches the mode", () => {
+            const kbd = SGNodeFactory.createNode("DynamicKeyboard");
+            kbd.keyGrid.setValue("jumpToKey", coords(3, 2, 0)); // symbols toggle
+            kbd.handleKey("OK", true);
+            expect(kbd.keyGrid.getValueJS("mode")).toBe("SymbolsLower");
+        });
+
+        test("the @ key opens a suggestions pop-up that can be selected", () => {
+            const kbd = SGNodeFactory.createNode("DynamicKeyboard");
+            kbd.keyGrid.setValue("jumpToKey", coords(2, 3, 0)); // "@" with suggestions
+            expect(kbd.keyGrid.getValueJS("keyFocused")).toBe("@");
+            // First OK opens the pop-up without inserting; second OK picks the first option.
+            kbd.handleKey("OK", true);
+            expect(textOf(kbd)).toBe("");
+            kbd.handleKey("OK", true);
+            expect(textOf(kbd)).toBe("@gmail.com");
+        });
+
+        test("the @ suggestions include a plain @ as the last (bottom) option", () => {
+            const kbd = SGNodeFactory.createNode("DynamicKeyboard");
+            kbd.keyGrid.setValue("jumpToKey", coords(2, 3, 0));
+            kbd.handleKey("OK", true); // open pop-up (index 0)
+            for (let i = 0; i < 5; i++) kbd.handleKey("down", true); // move to the last option
+            kbd.handleKey("OK", true);
+            expect(textOf(kbd)).toBe("@");
+        });
+
+        test("left/right dismiss the pop-up and move the keyboard focus", () => {
+            const kbd = SGNodeFactory.createNode("DynamicKeyboard");
+            kbd.keyGrid.setValue("jumpToKey", coords(2, 3, 0)); // "@"
+            kbd.handleKey("OK", true); // open pop-up
+            kbd.handleKey("right", true); // should close pop-up and move focus to "."
+            expect(textOf(kbd)).toBe("");
+            expect(kbd.keyGrid.getValueJS("keyFocused")).toBe(".");
+            // With the pop-up dismissed, OK now selects the focused "." key.
+            kbd.handleKey("OK", true);
+            expect(textOf(kbd)).toBe(".");
+        });
+
+        // Opens the @ pop-up and returns the focus-indicator rect and the largest pop-up panel rect.
+        function capturePopup(kbd) {
+            let focus = null;
+            let panel = null;
+            const draw2D = {
+                doDrawRotatedText() {},
+                doDrawRotatedRect(rect) {
+                    if (panel === null || rect.height > panel.height) panel = { ...rect };
+                },
+                drawNinePatch(obj, rect) {
+                    const n = obj && typeof obj.getImageName === "function" ? obj.getImageName() : "";
+                    if (n && n.includes("focus_keyboard") && focus === null) focus = { ...rect };
+                },
+                doDrawScaledObject() {},
+                doDrawRotatedBitmap() {},
+            };
+            kbd.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+            return { focus, panel };
+        }
+
+        test("the @ pop-up is anchored to the bottom-left of the focus indicator", () => {
+            const kbd = SGNodeFactory.createNode("DynamicKeyboard");
+            sgRoot.setFocused(kbd);
+            kbd.keyGrid.setValue("jumpToKey", coords(2, 3, 0));
+            kbd.handleKey("OK", true); // open pop-up
+            const { focus, panel } = capturePopup(kbd);
+            expect(focus).not.toBeNull();
+            expect(panel).not.toBeNull();
+            // Pop-up left edge matches the focus indicator's left edge...
+            expect(Math.abs(panel.x - focus.x)).toBeLessThanOrEqual(1);
+            // ...and the pop-up bottom matches the focus indicator's bottom (covering the key).
+            expect(Math.abs(panel.y + panel.height - (focus.y + focus.height))).toBeLessThanOrEqual(1);
+            // It extends upward above the key.
+            expect(panel.y).toBeLessThan(focus.y);
+        });
+
+        test("the @ pop-up width fits the content (much narrower than the keyboard)", () => {
+            const kbd = SGNodeFactory.createNode("DynamicKeyboard");
+            sgRoot.setFocused(kbd);
+            kbd.keyGrid.setValue("jumpToKey", coords(2, 3, 0));
+            kbd.handleKey("OK", true);
+            const { panel } = capturePopup(kbd);
+            expect(panel.width).toBeGreaterThan(0);
+            expect(panel.width).toBeLessThan(kbd.keyGrid.getValueJS("width") / 3);
+        });
+
+        test("the @ pop-up auto-opens via the hover timer once the focus dwells on the key", () => {
+            let now = 1000;
+            const spy = jest.spyOn(Date, "now").mockImplementation(() => now);
+            try {
+                const kbd = SGNodeFactory.createNode("DynamicKeyboard");
+                sgRoot.setFocused(kbd);
+                kbd.keyGrid.setValue("jumpToKey", coords(2, 3, 0)); // focus "@" at t=1000
+                expect(capturePopup(kbd).panel).toBeNull(); // no dwell yet
+                now = 3000; // dwell past the hover delay
+                expect(capturePopup(kbd).panel).not.toBeNull();
+            } finally {
+                spy.mockRestore();
+            }
+        });
+
+        test("the pop-up does not handle back (propagates up) and stays open", () => {
+            const kbd = SGNodeFactory.createNode("DynamicKeyboard");
+            sgRoot.setFocused(kbd);
+            kbd.keyGrid.setValue("jumpToKey", coords(2, 3, 0)); // "@"
+            kbd.handleKey("OK", true); // open the pop-up
+            // back is not consumed by the pop-up: it returns false so an ancestor can handle it,
+            // and the pop-up remains open.
+            expect(kbd.handleKey("back", true)).toBe(false);
+            expect(capturePopup(kbd).panel).not.toBeNull();
+        });
+
+        test("after selecting an option the timer is suppressed until focus leaves and returns", () => {
+            let now = 1000;
+            const spy = jest.spyOn(Date, "now").mockImplementation(() => now);
+            try {
+                const kbd = SGNodeFactory.createNode("DynamicKeyboard");
+                sgRoot.setFocused(kbd);
+                kbd.keyGrid.setValue("jumpToKey", coords(2, 3, 0)); // focus "@"
+                kbd.handleKey("OK", true); // open
+                kbd.handleKey("OK", true); // select first option -> closes + suppresses
+                expect(textOf(kbd)).toBe("@gmail.com");
+                now = 9000; // even well past the dwell, the timer stays suppressed
+                expect(capturePopup(kbd).panel).toBeNull();
+                // Pressing OK again on the key still re-opens it explicitly.
+                kbd.handleKey("OK", true);
+                expect(capturePopup(kbd).panel).not.toBeNull();
+                kbd.handleKey("left", true); // directional key closes the pop-up and moves focus away
+
+                // Returning to "@" restarts the dwell timer (suppression cleared on focus change).
+                kbd.keyGrid.setValue("jumpToKey", coords(2, 3, 0)); // back to "@" at t=9000
+                expect(capturePopup(kbd).panel).toBeNull(); // dwell restarted
+                now = 11000;
+                expect(capturePopup(kbd).panel).not.toBeNull();
+            } finally {
+                spy.mockRestore();
+            }
+        });
+    });
+
+    describe("rendering", () => {
+        // A stub draw surface that records nothing but must never be dereferenced incorrectly.
+        const draw2D = {
+            doDrawRotatedText() {},
+            doDrawScaledObject() {},
+            doDrawRotatedBitmap() {},
+            doDrawRotatedRect() {},
+            drawNinePatch() {},
+        };
+
+        for (const type of ["DynamicKeyboard", "DynamicMiniKeyboard", "DynamicPinPad"]) {
+            test(`${type} renders while focused without throwing`, () => {
+                const kbd = SGNodeFactory.createNode(type);
+                sgRoot.setFocused(kbd);
+                expect(() => kbd.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D)).not.toThrow();
+            });
+        }
+
+        // Captures the URIs of every bitmap drawn during a render.
+        function drawnImageNames(node) {
+            const names = [];
+            const record = (...args) => {
+                const bmp = args.find((a) => a && typeof a.getImageName === "function");
+                if (bmp) names.push(bmp.getImageName());
+            };
+            const capture = {
+                doDrawRotatedText() {},
+                doDrawRotatedRect() {},
+                doDrawScaledObject: record,
+                doDrawRotatedBitmap: record,
+                drawNinePatch: record,
+            };
+            sgRoot.setFocused(node);
+            node.renderNode(fakeInterpreter, [0, 0], 0, 1, capture);
+            return names;
+        }
+
+        const backgrounds = [
+            ["DynamicKeyboard", "keyboard_full"],
+            ["DynamicMiniKeyboard", "keyboard_mini"],
+            ["DynamicPinPad", "keyboard_pinpad"],
+        ];
+        for (const [type, bg] of backgrounds) {
+            test(`${type} draws the legacy ${bg} background`, () => {
+                const names = drawnImageNames(SGNodeFactory.createNode(type));
+                expect(names.some((n) => n.includes(bg))).toBe(true);
+            });
+        }
+
+        test("DynamicCustomKeyboard draws no keyboard background until a KDF is set", () => {
+            const names = drawnImageNames(SGNodeFactory.createNode("DynamicCustomKeyboard"));
+            expect(names.some((n) => n.includes("keyboard_"))).toBe(false);
+        });
+
+        test("DynamicPinPad renders entered digits as underline slots", () => {
+            const pad = SGNodeFactory.createNode("DynamicPinPad");
+            sgRoot.setFocused(pad);
+            pad.keyGrid.setValue("jumpToKey", coords(0, 0, 0));
+            pad.handleKey("OK", true); // enter "1"
+            expect(() => pad.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D)).not.toThrow();
+        });
+
+        test("DynamicPinPad text box defaults to secure mode", () => {
+            const pad = SGNodeFactory.createNode("DynamicPinPad");
+            expect(pad.textEditBox.getValueJS("secureMode")).toBe(true);
+        });
+
+        test("DynamicPinPad pin slots are a compact group centered in the box", () => {
+            const pad = SGNodeFactory.createNode("DynamicPinPad");
+            sgRoot.setFocused(pad);
+            const boxWidth = pad.textEditBox.getValueJS("width");
+            const rects = [];
+            const cap = {
+                doDrawRotatedRect(r) {
+                    rects.push({ ...r });
+                },
+                doDrawRotatedText() {},
+                doDrawScaledObject() {},
+                doDrawRotatedBitmap() {},
+                drawNinePatch() {},
+            };
+            pad.textEditBox.renderNode(fakeInterpreter, [0, 0], 0, 1, cap);
+            expect(rects.length).toBe(4); // one underline per pin slot
+            const left = Math.min(...rects.map((r) => r.x));
+            const right = Math.max(...rects.map((r) => r.x + r.width));
+            // The group is compact (not spread across the whole box) and horizontally centered.
+            expect(right - left).toBeLessThan(boxWidth * 0.6);
+            expect(Math.abs((left + right) / 2 - boxWidth / 2)).toBeLessThanOrEqual(2);
+        });
+
+        test("DynamicKeyboard renders an open suggestions pop-up without throwing", () => {
+            const kbd = SGNodeFactory.createNode("DynamicKeyboard");
+            sgRoot.setFocused(kbd);
+            kbd.keyGrid.setValue("jumpToKey", coords(2, 3, 0)); // "@"
+            kbd.handleKey("OK", true); // open the pop-up
+            expect(() => kbd.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D)).not.toThrow();
+        });
+    });
+
+    describe("alignment with legacy keyboards", () => {
+        // Renders a node and records each glyph position plus the keyboard background origin.
+        function captureLayout(node) {
+            const glyphs = {};
+            let bg = null;
+            const draw2D = {
+                doDrawRotatedText(text, x, y) {
+                    if (glyphs[text] === undefined) glyphs[text] = { x, y };
+                },
+                doDrawScaledObject(x, y, sx, sy, obj) {
+                    const n = obj && typeof obj.getImageName === "function" ? obj.getImageName() : "";
+                    if (n && n.includes("keyboard_")) bg = { x, y };
+                },
+                doDrawRotatedBitmap() {},
+                drawNinePatch() {},
+                doDrawRotatedRect() {},
+            };
+            sgRoot.setFocused(node);
+            node.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+            return { glyphs, bg };
+        }
+
+        // Asserts the dynamic node draws the given chars at the same offset from the
+        // background origin as the legacy node (i.e. centered on the same cells).
+        function expectAligned(legacyType, dynamicType, chars) {
+            const legacy = captureLayout(SGNodeFactory.createNode(legacyType));
+            const dynamic = captureLayout(SGNodeFactory.createNode(dynamicType));
+            expect(legacy.bg).not.toBeNull();
+            expect(dynamic.bg).not.toBeNull();
+            for (const ch of chars) {
+                expect(legacy.glyphs[ch]).toBeDefined();
+                expect(dynamic.glyphs[ch]).toBeDefined();
+                const lx = legacy.glyphs[ch].x - legacy.bg.x;
+                const ly = legacy.glyphs[ch].y - legacy.bg.y;
+                const dx = dynamic.glyphs[ch].x - dynamic.bg.x;
+                const dy = dynamic.glyphs[ch].y - dynamic.bg.y;
+                expect(Math.abs(lx - dx)).toBeLessThanOrEqual(6);
+                expect(Math.abs(ly - dy)).toBeLessThanOrEqual(6);
+            }
+        }
+
+        test("DynamicKeyboard keys align with the legacy Keyboard cells", () => {
+            expectAligned("Keyboard", "DynamicKeyboard", ["a", "g", "m", "5"]);
+        });
+
+        test("DynamicMiniKeyboard keys align with the legacy MiniKeyboard cells", () => {
+            expectAligned("MiniKeyboard", "DynamicMiniKeyboard", ["a", "m", "5"]);
+        });
+
+        test("DynamicPinPad keys align with the legacy PinPad cells", () => {
+            expectAligned("PinPad", "DynamicPinPad", ["1", "5", "9", "0"]);
+        });
+
+        // Captures the focus-indicator rect and the keyboard background origin.
+        function captureFocus(node, prepare) {
+            let bg = null;
+            let focus = null;
+            const draw2D = {
+                doDrawRotatedText() {},
+                doDrawRotatedRect() {},
+                doDrawScaledObject(x, y, sx, sy, obj) {
+                    const n = obj && typeof obj.getImageName === "function" ? obj.getImageName() : "";
+                    if (n && n.includes("keyboard_full")) bg = { x, y };
+                },
+                drawNinePatch(obj, rect) {
+                    const n = obj && typeof obj.getImageName === "function" ? obj.getImageName() : "";
+                    if (n && n.includes("focus_keyboard") && focus === null) focus = { ...rect };
+                },
+                doDrawRotatedBitmap() {},
+            };
+            sgRoot.setFocused(node);
+            if (prepare) prepare(node);
+            node.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+            return { bg, focus };
+        }
+
+        test("the left sidebar focus aligns with the legacy Keyboard (default-focused key)", () => {
+            // Both nodes default the focus to the top-left sidebar key.
+            const legacy = captureFocus(SGNodeFactory.createNode("Keyboard"));
+            const dynamic = captureFocus(SGNodeFactory.createNode("DynamicKeyboard"));
+            expect(legacy.focus).not.toBeNull();
+            expect(dynamic.focus).not.toBeNull();
+            expect(Math.abs(legacy.focus.x - legacy.bg.x - (dynamic.focus.x - dynamic.bg.x))).toBeLessThanOrEqual(6);
+        });
+
+        test("the focus indicator is drawn on whole pixels at FHD (no 9-patch seam line)", () => {
+            // At FHD the row height is fractional (333/4 = 83.25); a fractional 9-patch rect
+            // leaves a seam where the stretched center meets the edge, showing a background
+            // cell border as a divider line. The focus rect must be rounded to whole pixels.
+            const prev = sgRoot.scene;
+            const scene = SGNodeFactory.createNode("Scene");
+            sgRoot.setScene(scene);
+            scene.setResolution("FHD");
+            try {
+                const kbd = SGNodeFactory.createNode("DynamicKeyboard");
+                const { focus } = captureFocus(kbd, (n) => n.keyGrid.setValue("jumpToKey", coords(2, 1, 1))); // "5"
+                expect(focus).not.toBeNull();
+                for (const v of [focus.x, focus.y, focus.width, focus.height]) {
+                    expect(Number.isInteger(v)).toBe(true);
+                }
+            } finally {
+                sgRoot.setScene(prev ?? SGNodeFactory.createNode("Scene")); // restore HD scene
+            }
+        });
+
+        test("the right toggle focus aligns with the legacy Keyboard", () => {
+            // Legacy wraps from col 0 to the right toggle column with one left press.
+            const legacy = captureFocus(SGNodeFactory.createNode("Keyboard"), (n) => n.handleKey("left", true));
+            const dynamic = captureFocus(SGNodeFactory.createNode("DynamicKeyboard"), (n) =>
+                n.keyGrid.setValue("jumpToKey", coords(3, 0, 0))
+            );
+            expect(legacy.focus).not.toBeNull();
+            expect(dynamic.focus).not.toBeNull();
+            const legacyRight = legacy.focus.x - legacy.bg.x + legacy.focus.width;
+            const dynamicRight = dynamic.focus.x - dynamic.bg.x + dynamic.focus.width;
+            expect(Math.abs(legacyRight - dynamicRight)).toBeLessThanOrEqual(6);
+        });
+    });
+
+    describe("DynamicKeyGrid focus management", () => {
+        test("disabling the focused key moves focus to an adjacent key", () => {
+            const pad = SGNodeFactory.createNode("DynamicPinPad");
+            const grid = pad.keyGrid;
+            expect(grid.getValueJS("keyFocused")).toBe("1");
+            grid.setValue("disableKey", new BrsString("1"));
+            expect(grid.getValueJS("keyFocused")).not.toBe("1");
+        });
+
+        test("horizontal arrows return false at the edge without wrap", () => {
+            const pad = SGNodeFactory.createNode("DynamicPinPad");
+            // focus is on "1" (top-left); moving left is unhandled and propagates.
+            expect(pad.keyGrid.handleKey("left", true)).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
## Overview

Implements the **Dynamic voice keyboard** family of SceneGraph nodes, previously stubbed in the `SGNodeType` enum (`// Not yet implemented`). The keyboards are driven by a real **Key Definition File (KDF)** layout engine and reuse the same background/cell artwork and icons as the legacy `Keyboard` / `MiniKeyboard` / `PinPad` nodes.

Voice/dictation behavior itself is **out of scope** — the voice fields are stored on `VoiceTextEditBox` but no mic/recognition is implemented. Everything else (layouts, navigation, text editing, mode switching, palette colors, key enable/disable, key-suggestion pop-ups, and the PinPad per-digit display) is implemented to match a real device.

## What's included

- **KDF model + layout engine** (`nodes/kdf/KeyDefinition.ts`) — section → grid (per mode) → row → key size distribution, content insets, and special-key icon resolution.
- **Built-in KDFs** (`nodes/kdf/builtinKDFs.ts`) — full keyboard, mini and pinpad layouts sized to the legacy `keyboard_full/mini/pinpad.png` cells.
- **`DynamicKeyGrid`** — KDF-driven grid with geometric navigation, `RSGPalette` resolution, `keyFocused`/`keySelected`, `jumpToKey`/`disableKey`/`enableKey`, custom-KDF loading, legacy background + mode-aware icon assets, and the `@`-key suggestion pop-up.
- **`DynamicKeyboardBase`** + **`DynamicKeyboard`**, **`DynamicMiniKeyboard`**, **`DynamicPinPad`**, **`DynamicCustomKeyboard`**.
- **`VoiceTextEditBox`** — per-digit underline (pin-pad) display: centered compact slot group, secure-by-default for `DynamicPinPad`, bullet glyph at the regular text size.
- Wired into the enum, re-exports and `NodeFactory`; limitations docs updated.

### Notable behavior
- Built-in keyboards render the legacy cell background at natural size with per-resolution insets so keys/focus land on the drawn cells (verified against the legacy nodes within a few px).
- Focus indicator drawn on whole pixels to avoid a 9-patch seam that showed a divider line at FHD.
- `@` pop-up: anchored to the focus indicator's bottom-left, content-fit width, opens via the hover timer (suppressed after a selection until focus leaves and returns), and `back` is not consumed (propagates to ancestors).

> Note: a custom component-level `keySelected(key) as boolean` override (an advanced Roku feature for `DynamicCustomKeyboard`) is not hooked up; apps can still observe `keyGrid.keySelected` and the default handlers apply.

## Testing

- New `test/extensions/scenegraph/DynamicKeyboard.test.js` — **44 tests** covering factory wiring, default fields, KDF geometry/alignment vs. the legacy nodes, navigation/wrap, text editing, mode switching, suggestion pop-up behavior, focus management, the FHD seam regression, and the PinPad secure/centered display.
- Full suite green: **122 suites / 1838 tests**; lint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)