### PR TITLE
feat(scenegraph): use Dynamic keyboards in Standard dialog framework

### DIFF
--- a/src/extensions/scenegraph/nodes/DynamicPinPad.ts
+++ b/src/extensions/scenegraph/nodes/DynamicPinPad.ts
@@ -14,11 +14,11 @@ export class DynamicPinPad extends DynamicKeyboardBase {
         this.setExtendsType(name, SGNodeType.DynamicKeyboardBase);
         this.registerInitializedFields(initializedFields);
 
-        const maxTextLength = 4;
-        this.configureVoiceBox({ voiceEntryType: "numeric", voiceEnabled: true, maxTextLength });
-        // PIN entry hides the digits by default (shows dots).
+        this.configureVoiceBox({ voiceEntryType: "numeric", voiceEnabled: true, maxTextLength: 4 });
+        // PIN entry hides the digits by default (shows dots). The number of underline slots tracks
+        // `textEditBox.maxTextLength`, so apps (e.g. StandardPinPadDialog) resize the pin via that field.
         this.textEditBox.setValueSilent("secureMode", BrsBoolean.True);
-        this.textEditBox.setPinPadMode(maxTextLength);
+        this.textEditBox.setPinPadMode();
         this.setKeyDefinition(dynamicPinPadKDF, "", {
             name: "keyboard_pinpad",
             insetFHD: { top: 22, right: 23, bottom: 24, left: 21 },

--- a/src/extensions/scenegraph/nodes/StandardKeyboardDialog.ts
+++ b/src/extensions/scenegraph/nodes/StandardKeyboardDialog.ts
@@ -12,9 +12,8 @@ import { sgRoot } from "../SGRoot";
 /**
  * StandardKeyboardDialog — text/voice entry of alphanumeric strings (Roku's replacement for the
  * legacy KeyboardDialog). Composed of a title area, a content area with optional message text plus
- * a keyboard item hosting a keyboard, and a button area. The embedded keyboard reuses the existing
- * Keyboard node. The base class handles layout, button wiring, and close; this class adds the
- * keyboard ⇄ buttons focus model.
+ * a keyboard item hosting a DynamicKeyboard, and a button area. The base class handles layout,
+ * button wiring, and close; this class adds the keyboard ⇄ buttons focus model.
  */
 export class StandardKeyboardDialog extends StandardDialog {
     readonly defaultFields: FieldModel[] = [
@@ -45,10 +44,11 @@ export class StandardKeyboardDialog extends StandardDialog {
         this.keyboardItem = new StdDlgKeyboardItem();
         this.keyboardItem.setValue("keyLayout", new BrsString("keyboard"));
 
-        // Widen the dialog to fit the keyboard, then share text/textEditBox.
+        // Widen the dialog to fit the keyboard, then share text/textEditBox and the entry domain.
         const keyboard = this.keyboardItem.keyboard;
         if (keyboard) {
             this.contentWidth = Math.max(this.contentWidth, keyboard.getDimensions().width);
+            this.linkField(keyboard, "domain", "keyboardDomain");
         }
         this.linkField(this.keyboardItem, "text", "text");
         this.linkField(this.keyboardItem, "textEditBox", "textEditBox");

--- a/src/extensions/scenegraph/nodes/StandardPinPadDialog.ts
+++ b/src/extensions/scenegraph/nodes/StandardPinPadDialog.ts
@@ -12,8 +12,8 @@ import { sgRoot } from "../SGRoot";
 /**
  * StandardPinPadDialog — text/voice entry of numeric PIN codes (Roku's replacement for the legacy
  * PinDialog). Composed of a title area, a content area with optional message text plus a keyboard
- * item hosting a pin pad, and a button area. The embedded pad reuses the existing PinPad. The base
- * class handles layout, button wiring, and close; this class adds the pad ⇄ buttons focus model.
+ * item hosting a DynamicPinPad, and a button area. The base class handles layout, button wiring,
+ * and close; this class adds the pad ⇄ buttons focus model.
  */
 export class StandardPinPadDialog extends StandardDialog {
     readonly defaultFields: FieldModel[] = [
@@ -43,11 +43,8 @@ export class StandardPinPadDialog extends StandardDialog {
         this.keyboardItem = new StdDlgKeyboardItem();
         this.keyboardItem.setValue("keyLayout", new BrsString("pinpad"));
 
-        // Share the entered PIN and expose the internal VoiceTextEditBox.
-        const pinPad = this.keyboardItem.pinPad;
-        if (pinPad) {
-            this.linkField(pinPad, "pin", "pin");
-        }
+        // Share the entered PIN (the pad's `text`) and expose the internal VoiceTextEditBox.
+        this.linkField(this.keyboardItem, "text", "pin");
         this.linkField(this.keyboardItem, "textEditBox", "textEditBox");
     }
 
@@ -106,7 +103,6 @@ export class StandardPinPadDialog extends StandardDialog {
         if (this.contentDirty) {
             this.rebuildContent();
         }
-        this.keyboardItem.syncTextLimit();
         super.renderNode(interpreter, origin, angle, opacity, draw2D);
     }
 

--- a/src/extensions/scenegraph/nodes/StdDlgKeyboardItem.ts
+++ b/src/extensions/scenegraph/nodes/StdDlgKeyboardItem.ts
@@ -1,18 +1,20 @@
-import { AAMember, BrsType, Float, Int32 } from "brs-engine";
+import { AAMember, BrsType, Float } from "brs-engine";
 import { FieldKind, FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";
 import { Group } from "./Group";
-import { PinPad } from "./PinPad";
-import { Keyboard } from "./Keyboard";
-import { VoiceTextEditBox } from "./VoiceTextEditBox";
+import { DynamicKeyboard } from "./DynamicKeyboard";
+import { DynamicPinPad } from "./DynamicPinPad";
+import { DynamicKeyboardBase } from "./DynamicKeyboardBase";
+import { RSGPalette } from "./RSGPalette";
 import { StdDlgItem, getDialogColors, colorFromPalette } from "./StdDlgItemBase";
-import { jsValueOf } from "../factory/Serializer";
+import { toAssociativeArray, jsValueOf } from "../factory/Serializer";
+import { convertHexColor } from "../SGUtil";
 
 /**
  * A content item that hosts a keyboard or pin pad inside a StandardDialog, selected by `keyLayout`
- * ("keyboard" or "pinpad"). Roku uses a DynamicKeyboard / DynamicPinPad; this engine reuses the
- * existing Keyboard / PinPad nodes. The item's `text` mirrors the entered string and `textEditBox`
- * exposes the widget's VoiceTextEditBox.
+ * ("keyboard" or "pinpad"). Per Roku's spec it hosts a DynamicKeyboard / DynamicPinPad, which bring
+ * voice entry. The item's `text` mirrors the entered string and `textEditBox` exposes the widget's
+ * VoiceTextEditBox.
  */
 export class StdDlgKeyboardItem extends Group implements StdDlgItem {
     readonly defaultFields: FieldModel[] = [
@@ -20,7 +22,8 @@ export class StdDlgKeyboardItem extends Group implements StdDlgItem {
         { name: "text", type: "string", value: "" },
         { name: "textEditBox", type: "node" },
     ];
-    private widget?: PinPad | Keyboard;
+    private widget?: DynamicKeyboardBase;
+    private keyPalette?: RSGPalette;
 
     constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.StdDlgKeyboardItem) {
         super([], name);
@@ -44,29 +47,24 @@ export class StdDlgKeyboardItem extends Group implements StdDlgItem {
             return; // widget already created
         }
         if (layout === "pinpad") {
-            const pad = new PinPad();
-            const textEditBox = new VoiceTextEditBox();
-            // Default to a 4-digit PIN; apps widen it via textEditBox.maxTextLength.
-            textEditBox.setValueSilent("maxTextLength", new Int32(4));
-            this.setValueSilent("textEditBox", textEditBox);
-            this.widget = pad;
-            this.appendChildToParent(pad);
-            this.linkField(pad, "pin", "text");
+            this.widget = new DynamicPinPad();
         } else if (layout === "keyboard") {
-            const keyboard = new Keyboard();
-            this.setValueSilent("textEditBox", keyboard.textEditBox);
-            this.widget = keyboard;
-            this.appendChildToParent(keyboard);
-            this.linkField(keyboard, "text");
+            this.widget = new DynamicKeyboard();
+        } else {
+            return;
         }
+        // Expose the widget's VoiceTextEditBox and keep `text` as a single shared field.
+        this.setValueSilent("textEditBox", this.widget.textEditBox);
+        this.appendChildToParent(this.widget);
+        this.linkField(this.widget, "text");
     }
 
-    get pinPad(): PinPad | undefined {
-        return this.widget instanceof PinPad ? this.widget : undefined;
+    get pinPad(): DynamicPinPad | undefined {
+        return this.widget instanceof DynamicPinPad ? this.widget : undefined;
     }
 
-    get keyboard(): Keyboard | undefined {
-        return this.widget instanceof Keyboard ? this.widget : undefined;
+    get keyboard(): DynamicKeyboard | undefined {
+        return this.widget instanceof DynamicKeyboard ? this.widget : undefined;
     }
 
     /** The focusable widget (pin pad or keyboard), if any. */
@@ -74,33 +72,26 @@ export class StdDlgKeyboardItem extends Group implements StdDlgItem {
         return this.widget;
     }
 
-    /** Applies the keyboard item's text length limit to a pin pad widget. */
-    syncTextLimit() {
-        const textEditBox = this.getValue("textEditBox");
-        if (this.widget instanceof PinPad && textEditBox instanceof VoiceTextEditBox) {
-            const maxLength = textEditBox.getValueJS("maxTextLength") as number;
-            if (typeof maxLength === "number" && maxLength > 0) {
-                this.widget.setValue("pinLength", new Int32(maxLength));
-            }
-        }
-    }
-
-    /** Themes the embedded keyboard / pin pad from the dialog palette (key glyph colors). */
+    /**
+     * Themes the embedded keyboard / pin pad from the dialog palette. The Dynamic key grid resolves
+     * its glyph/focus colors from an ancestor `palette` (RSGPalette) node, so we bridge the dialog's
+     * `Dialog*` colors onto a palette node attached to the key grid using the names it expects.
+     */
     private applyPalette() {
         if (!this.widget) {
             return;
         }
         const colors = getDialogColors(this);
-        const keyColor = colorFromPalette(colors, "DialogTextColor", "0xFFFFFFFF");
-        const focusedKeyColor = colorFromPalette(colors, "DialogFocusItemColor", "0x000000FF");
-        const focusBlend = colorFromPalette(colors, "DialogFocusColor", "0xFFFFFFFF");
-        this.widget.setValueSilent("keyColor", new Int32(keyColor));
-        this.widget.setValueSilent("focusedKeyColor", new Int32(focusedKeyColor));
-        // Tint the per-key focus highlight 9-patch with the palette focus color.
-        this.widget.setValueSilent("focusBitmapBlendColor", new Int32(focusBlend));
-        if (this.widget instanceof PinPad) {
-            this.widget.setValueSilent("pinDisplayTextColor", new Int32(keyColor));
-        }
+        const paletteColors = toAssociativeArray({
+            PrimaryTextColor: colorFromPalette(colors, "DialogTextColor", "0xDDDDDDFF"),
+            FocusItemColor: colorFromPalette(colors, "DialogFocusItemColor", "0x262626FF"),
+            FocusColor: colorFromPalette(colors, "DialogFocusColor", "0xFFFFFFFF"),
+            SecondaryItemColor: colorFromPalette(colors, "DialogSecondaryItemColor", "0xAAAAAAFF"),
+            KeyboardColor: convertHexColor("0xFFFFFFFF"), // no tint on the keyboard background bitmap
+        });
+        this.keyPalette ??= new RSGPalette();
+        this.keyPalette.setValue("colors", paletteColors);
+        this.widget.keyGrid.setValue("palette", this.keyPalette);
     }
 
     layoutItem(width: number): number {

--- a/src/extensions/scenegraph/nodes/VoiceTextEditBox.ts
+++ b/src/extensions/scenegraph/nodes/VoiceTextEditBox.ts
@@ -35,8 +35,11 @@ export class VoiceTextEditBox extends TextEditBox {
         }
     }
 
-    /** Enables the per-digit underline display used by DynamicPinPad. */
-    setPinPadMode(slots: number) {
+    /**
+     * Enables the per-digit underline display used by DynamicPinPad. With no (or a zero) slot
+     * count the number of slots tracks `maxTextLength`, so apps can resize the pin via that field.
+     */
+    setPinPadMode(slots: number = 0) {
         this.pinPadMode = true;
         this.pinPadSlots = slots;
         this.pinPadFont = new Font(); // same default size as the regular text display

--- a/test/extensions/scenegraph/StandardDialogNodes.test.js
+++ b/test/extensions/scenegraph/StandardDialogNodes.test.js
@@ -386,11 +386,16 @@ describe("Standard Dialog Framework nodes", () => {
             dialog.renderNode(fakeInterpreter, [0, 0], 0, 1);
 
             const buttonArea = findDescendant(dialog, "StdDlgButtonArea");
-            const keyboard = findDescendant(dialog, "Keyboard");
+            const keyboard = findDescendant(dialog, "DynamicKeyboard");
             expect(keyboard).toBeDefined();
 
+            // The Dynamic key grid resolves its glyph/focus colors from a palette node bridged from
+            // the dialog's Dialog* colors, so it themes consistently with the button row.
+            const keyGrid = keyboard.getValue("keyGrid");
+            const keyColors = keyGrid.getValue("palette").getValueJS("colors");
+
             // Key glyphs and unfocused button text both use DialogTextColor.
-            const textColor = keyboard.getValueJS("keyColor");
+            const textColor = keyColors.PrimaryTextColor;
             expect(textColor).not.toBe(WHITE);
             expect(buttonArea.getValueJS("textColor")).toBe(textColor);
             // Focused button background uses DialogFocusColor; focused text uses DialogFocusItemColor.
@@ -401,8 +406,10 @@ describe("Standard Dialog Framework nodes", () => {
             const button = buttonArea.getNodeChildren()[0];
             expect(button.getValueJS("textColor")).toBe(textColor);
             expect(button.getValueJS("focusBitmapBlendColor")).toBe(buttonArea.getValueJS("focusBitmapBlendColor"));
-            // The per-key focus highlight is tinted with DialogFocusColor (same as the button focus).
-            expect(keyboard.getValueJS("focusBitmapBlendColor")).toBe(buttonArea.getValueJS("focusBitmapBlendColor"));
+            // The per-key focus highlight uses DialogFocusColor (same as the button focus), and the
+            // focused-key glyph uses DialogFocusItemColor (same as the focused-button text).
+            expect(keyColors.FocusColor).toBe(buttonArea.getValueJS("focusBitmapBlendColor"));
+            expect(keyColors.FocusItemColor).toBe(buttonArea.getValueJS("focusedTextColor"));
         });
 
         test("themes the scrollable text's scrollbar from the palette", () => {


### PR DESCRIPTION
## Summary

Switches the **Standard Dialog Framework** to embed the new **Dynamic** voice keyboards, matching Roku's spec ([`standard-keyboard-dialog`](https://developer.roku.com/docs/references/scenegraph/standard-dialog-framework-nodes/standard-keyboard-dialog.md), [`standard-pinpad-dialog`](https://developer.roku.com/docs/references/scenegraph/standard-dialog-framework-nodes/standard-pinpad-dialog.md), [`std-dlg-keyboard-item`](https://developer.roku.com/docs/references/scenegraph/standard-dialog-framework-nodes/std-dlg-keyboard-item.md)):

- `StandardKeyboardDialog` now hosts a **DynamicKeyboard**
- `StandardPinPadDialog` now hosts a **DynamicPinPad**

Both go through the single integration point, `StdDlgKeyboardItem`, so the dialogs gain voice entry. The legacy `Keyboard` / `MiniKeyboard` / `PinPad` / `KeyboardDialog` / `PinDialog` / `ParentalControlPinPad` nodes are unchanged and still usable standalone.

## Changes

- **`StdDlgKeyboardItem`** — constructs `DynamicKeyboard` (`keyLayout="keyboard"`) or `DynamicPinPad` (`keyLayout="pinpad"`) instead of the legacy nodes; exposes the widget's own `VoiceTextEditBox` and shares the unified `text` field. Theming is bridged from the dialog's `Dialog*` palette colors onto an `RSGPalette` on the key grid (the Dynamic nodes resolve colors from an ancestor palette node, not the legacy `keyColor`/etc. fields).
- **`StandardPinPadDialog`** — links the shared `text` to its `pin` field (DynamicPinPad has no `pin`); dropped the now-unneeded slot-sync render call.
- **`StandardKeyboardDialog`** — wires `keyboardDomain` to the keyboard's `domain` field.
- **`DynamicPinPad` / `VoiceTextEditBox`** — pin-pad slot count now follows `textEditBox.maxTextLength` (the documented way to size a PIN), removing the explicit slot-sync plumbing. Default `maxTextLength=4` keeps 4 slots, so standalone behavior is unchanged.

## Testing

- `npm run lint` — clean
- `npm run prettier:write` — clean
- `npm test` — **122 suites / 1836 tests pass** (`StandardDialogNodes` theming/widget assertions updated to the Dynamic key grid; `DynamicKeyboard` suite unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)