### PR TITLE
feat(cli): run a folder app from --root alone (#771)

### DIFF
--- a/docs/run-as-cli.md
+++ b/docs/run-as-cli.md
@@ -93,6 +93,12 @@ Dennis Ritchie said "Hello, World!"
 
 A folder can be passed with the flag `--root` to mount the `pkg:/` volume, and in this case, the BrightScript files path should be relative to the mounted root folder. Please be aware that this is using the host file system, so if you are running the CLI on a Linux machine the paths are case sensitive, unlike Roku (or using `zip` files with the engine).
 
+If `--root` is passed **without** any file arguments, the CLI runs the folder as a full application: it loads every `.brs` under `source/` and serves the `components/` tree (including SceneGraph components) from the mounted `pkg:/` volume, e.g:
+
+```console
+$ brs-cli --root ./my-app
+```
+
 It is also possible to run a full BrightScript application `.zip` or `.bpk` file, e.g:
 
 ```console

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -107,6 +107,9 @@ program
         brs.registerCallback(messageCallback, sharedBuffer);
         if (brsFiles.length > 0) {
             await runAppFiles(brsFiles);
+        } else if (program.root) {
+            // Run a folder app (source/ + components/) from the root alone.
+            await runAppFiles([]);
         } else {
             displayTitle();
             repl();
@@ -177,6 +180,20 @@ async function loadSceneGraphExtension() {
  */
 async function runAppFiles(files: string[]) {
     try {
+        if (files.length === 0) {
+            // No positional files: run the folder app discovered from `--root`.
+            appFileName = path.basename(path.resolve(program.root));
+            deviceData.appList?.push({ id: "dev", title: appFileName, version: "1.0.0" });
+            const payload = await brs.createPayloadFromFiles(
+                files,
+                deviceData,
+                processDeepLink(),
+                program.root,
+                program.extVol
+            );
+            runApp(payload);
+            return;
+        }
         const filePath = files[0];
         const fileName = filePath.split(/.*[/|\\]/)[1] ?? filePath;
         const fileExt = fileName.split(".").pop()?.toLowerCase();

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -505,6 +505,28 @@ export async function createPayloadFromFileMap(
 }
 
 /**
+ * Recursively collects every `.brs` file path under a directory.
+ * Used to auto-discover an app's source files when only a root folder is provided.
+ * @param dir Directory to scan
+ * @returns Array of absolute (or root-relative, matching `dir`) `.brs` file paths
+ */
+function findSourceFiles(dir: string): string[] {
+    const results: string[] = [];
+    if (!fs.existsSync(dir)) {
+        return results;
+    }
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            results.push(...findSourceFiles(fullPath));
+        } else if (entry.name.toLowerCase().endsWith(".brs")) {
+            results.push(fullPath);
+        }
+    }
+    return results;
+}
+
+/**
  * Create the payload to run the app with the provided files.
  * @param files Code files to be executed
  * @param customDeviceData optional object with device info data
@@ -523,6 +545,15 @@ export async function createPayloadFromFiles(
     const paths: PkgFilePath[] = [];
     const source: string[] = [];
     let manifest: Map<string, string> | undefined;
+
+    // When only a root is provided, discover the app's source files automatically,
+    // allowing the CLI/library to run a folder app (including SceneGraph) from the root
+    // alone. Components under `components/` are served from disk via the root-mounted
+    // `pkg:/` volume and loaded by the SceneGraph extension, so they are not added here.
+    const discoverFromRoot = files.length === 0 && root !== undefined;
+    if (discoverFromRoot) {
+        files = findSourceFiles(path.join(root, "source")).map((file) => path.relative(root, file));
+    }
 
     let id = 0;
     for (const file of files) {
@@ -547,6 +578,9 @@ export async function createPayloadFromFiles(
         }
     }
     if (id === 0) {
+        if (discoverFromRoot && root !== undefined) {
+            throw new Error(`No BrightScript files found under '${path.join(root, "source")}'!`);
+        }
         throw new Error("Invalid or inexistent file(s)!");
     }
 

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -293,5 +293,24 @@ describe("cli", () => {
         ]);
     }, 10000);
 
+    it("Run App from Root Folder Only", async () => {
+        // Issue #771: pointing the CLI at a folder with `--root` and no positional files
+        // discovers source/*.brs and loads components/ from the root-mounted pkg:/ volume,
+        // running the SceneGraph app the same way as passing `source/main.brs` explicitly.
+        let command = ["node", brsCliPath, "-r button-label-app", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "=== Button Label Repro ===",
+            "label.text = Save",
+            "=== Button Label Repro Complete ===",
+            "------ Finished 'button-label-app' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+    }, 10000);
+
     it.todo("add tests for the remaining CLI options");
 });


### PR DESCRIPTION
## Summary

Implements #771. Pointing the CLI at an app folder is now enough to run it:

```console
$ brs-cli --root ./my-app
```

When `--root` is passed with **no** positional file arguments, the CLI runs the folder as a full application — including SceneGraph apps. Previously a bare `--root` was ignored and the CLI silently dropped into the REPL.

## How it works

- **`src/core/index.ts`** — `createPayloadFromFiles` auto-discovers source when `files` is empty and `root` is set. A new recursive `findSourceFiles` helper collects every `.brs` under `<root>/source/` into the app's global source. The "no files" error now names the `source/` folder it searched.
- **Components need no special handling** — with `--root`, the `pkg:/` volume reads straight from disk, so the SceneGraph extension scans and loads `components/` itself. This matches exactly how a `.zip` app loads (`source/*.brs` → source array; components stay in the package filesystem).
- **`src/cli/index.ts`** — bare `--root` routes to `runAppFiles([])`, which builds the payload and uses the root folder's basename as the app display name.
- **`docs/run-as-cli.md`** — documents the new mode.

## Testing

- Added `test/cli/cli.test.js` → "Run App from Root Folder Only", running the SceneGraph `button-label-app` with just `-r` and asserting identical output (exercises both source discovery and component auto-load).
- Manual: `-r channel-store` (non-SG) and `-r button-label-app` (SG) produce the same output as their explicit-file invocations.
- Error path: a folder with no `source/` prints `No BrightScript files found under '.../source'!`.
- `npm test` — all 127 suites / 1868 tests pass; `npm run lint` clean; prettier applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)