### PR TITLE
fix: trim script.val in getScripts() to ignore whitespace-only bodies

### DIFF
--- a/src/extensions/scenegraph/parser/ComponentDefinition.ts
+++ b/src/extensions/scenegraph/parser/ComponentDefinition.ts
@@ -396,7 +396,8 @@ function getScripts(node: XmlDocument, nodeDef: ComponentDefinition): ComponentS
     const componentScripts: ComponentScript[] = [];
 
     for (const script of scripts) {
-        if (script.attr.uri && script.val) {
+        const scriptContent = script.val?.trim() ?? "";
+        if (script.attr.uri && scriptContent) {
             throw new Error(
                 BrsError.format(
                     `<script> element cannot contain both internal and external source`,
@@ -409,12 +410,12 @@ function getScripts(node: XmlDocument, nodeDef: ComponentDefinition): ComponentS
                 type: script.attr.type,
                 uri: absoluteUri,
             });
-        } else if (typeof script.val === "string") {
+        } else if (scriptContent) {
             // pad with new lines to match original XML line numbers
             const padLines = script.line > 0 ? "\n".repeat(script.line) : "";
             componentScripts.push({
                 type: script.attr.type,
-                content: `${padLines}${script.val}`,
+                content: `${padLines}${scriptContent}`,
                 xmlPath: nodeDef.xmlPath,
             });
         }

--- a/test/extensions/scenegraph/ComponentDefinition.test.js
+++ b/test/extensions/scenegraph/ComponentDefinition.test.js
@@ -1,0 +1,112 @@
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+
+const { getComponentDefinitionMap } = scenegraph;
+
+describe("ComponentDefinition script tag parsing", () => {
+    const xmlPath = "pkg:/components/TestComponent.xml";
+
+    function createMockFS(componentXml) {
+        return {
+            existsSync: jest.fn(() => true),
+            findSync: jest.fn((uri, ext) => {
+                if (ext === "xml") {
+                    return [xmlPath];
+                }
+                return [];
+            }),
+            readFileSync: jest.fn((path) => {
+                if (path === xmlPath) {
+                    return componentXml;
+                }
+                return "";
+            }),
+        };
+    }
+
+    test("self-closing <script uri=\"...\" /> sets uri property", () => {
+        const xml = `<?xml version="1.0" encoding="utf-8"?>
+<component name="TestComponent" extends="Scene">
+    <script type="text/brightscript" uri="test.brs" />
+</component>`;
+        const components = getComponentDefinitionMap(createMockFS(xml));
+        const component = components.get("testcomponent");
+        expect(component).toBeDefined();
+        expect(component.scripts).toHaveLength(1);
+        expect(component.scripts[0].uri).toMatch(/test\.brs$/);
+        expect(component.scripts[0].content).toBeUndefined();
+    });
+
+    test("non-self-closing with uri and newline body treats as external only", () => {
+        const xml = `<?xml version="1.0" encoding="utf-8"?>
+<component name="TestComponent" extends="Scene">
+    <script type="text/brightscript" uri="test.brs">
+    </script>
+</component>`;
+        const components = getComponentDefinitionMap(createMockFS(xml));
+        const component = components.get("testcomponent");
+        expect(component).toBeDefined();
+        expect(component.scripts).toHaveLength(1);
+        expect(component.scripts[0].uri).toMatch(/test\.brs$/);
+        expect(component.scripts[0].content).toBeUndefined();
+    });
+
+    test("non-self-closing with uri and whitespace body treats as external only", () => {
+        const xml = `<?xml version="1.0" encoding="utf-8"?>
+<component name="TestComponent" extends="Scene">
+    <script type="text/brightscript" uri="test.brs">   </script>
+</component>`;
+        const components = getComponentDefinitionMap(createMockFS(xml));
+        const component = components.get("testcomponent");
+        expect(component).toBeDefined();
+        expect(component.scripts).toHaveLength(1);
+        expect(component.scripts[0].uri).toMatch(/test\.brs$/);
+        expect(component.scripts[0].content).toBeUndefined();
+    });
+
+    test("inline CDATA content sets content property", () => {
+        const xml = `<?xml version="1.0" encoding="utf-8"?>
+<component name="TestComponent" extends="Scene">
+    <script type="text/brightscript"><![CDATA[sub init()
+end sub]]></script>
+</component>`;
+        const components = getComponentDefinitionMap(createMockFS(xml));
+        const component = components.get("testcomponent");
+        expect(component).toBeDefined();
+        expect(component.scripts).toHaveLength(1);
+        expect(component.scripts[0].content).toContain("sub init()");
+        expect(component.scripts[0].uri).toBeUndefined();
+    });
+
+    test("both uri and CDATA content throws error", () => {
+        const xml = `<?xml version="1.0" encoding="utf-8"?>
+<component name="TestComponent" extends="Scene">
+    <script type="text/brightscript" uri="test.brs"><![CDATA[sub init()
+end sub]]></script>
+</component>`;
+        expect(() => getComponentDefinitionMap(createMockFS(xml))).toThrow(
+            /script.*element cannot contain both internal and external source/
+        );
+    });
+
+    test("whitespace-only body with no uri produces empty scripts", () => {
+        const xml = `<?xml version="1.0" encoding="utf-8"?>
+<component name="TestComponent" extends="Scene">
+    <script type="text/brightscript">   </script>
+</component>`;
+        const components = getComponentDefinitionMap(createMockFS(xml));
+        const component = components.get("testcomponent");
+        expect(component).toBeDefined();
+        expect(component.scripts).toHaveLength(0);
+    });
+
+    test("empty body with no uri produces empty scripts", () => {
+        const xml = `<?xml version="1.0" encoding="utf-8"?>
+<component name="TestComponent" extends="Scene">
+    <script type="text/brightscript"></script>
+</component>`;
+        const components = getComponentDefinitionMap(createMockFS(xml));
+        const component = components.get("testcomponent");
+        expect(component).toBeDefined();
+        expect(component.scripts).toHaveLength(0);
+    });
+});

--- a/test/extensions/scenegraph/ComponentDefinition.test.js
+++ b/test/extensions/scenegraph/ComponentDefinition.test.js
@@ -23,7 +23,7 @@ describe("ComponentDefinition script tag parsing", () => {
         };
     }
 
-    test("self-closing <script uri=\"...\" /> sets uri property", () => {
+    test('self-closing <script uri="..." /> sets uri property', () => {
         const xml = `<?xml version="1.0" encoding="utf-8"?>
 <component name="TestComponent" extends="Scene">
     <script type="text/brightscript" uri="test.brs" />


### PR DESCRIPTION
## Issue

Non-self-closing `<script uri="...">` tags that contain only whitespace or newlines between opening and closing tags (e.g. `<script uri="test.brs">\n</script>`) were incorrectly treated as having both internal and external source. The `xmldoc` parser captures whitespace text nodes in `script.val`, making it truthy even when there's no meaningful inline content.

## Fix

Trim `script.val` before the truthiness check in `getScripts()` (`ComponentDefinition.ts:399`). Whitespace-only content after trimming is falsy, so the tag is correctly treated as external-only.

Also replaces the redundant `typeof script.val === "string"` check with the trimmed value, aligning the inline-content branch with the same logic.

## Tests

Added `test/extensions/scenegraph/ComponentDefinition.test.js` with 7 test cases covering all script tag patterns:
- Self-closing `<script uri="..." />` → external only
- Non-self-closing with newline body → external only (was broken)
- Non-self-closing with whitespace body → external only (was broken)
- Inline CDATA only → internal content
- Both uri and CDATA → throws error (still caught)
- Whitespace-only with no uri → skipped (scripts empty)
- Empty body with no uri → skipped (scripts empty)