### PR TITLE
fix: make bs-const lookups case-insensitive in #if/#elseif conditions

### DIFF
--- a/src/core/preprocessor/Preprocessor.ts
+++ b/src/core/preprocessor/Preprocessor.ts
@@ -44,9 +44,7 @@ export class Preprocessor implements CC.Visitor {
      *          compilation directives included within
      */
     filter(chunks: readonly CC.Chunk[], bsConst?: Map<string, boolean>): FilterResults {
-        this.constants = new Map(
-            [...(bsConst ?? [])].map(([key, value]) => [key.toLowerCase(), value])
-        );
+        this.constants = new Map([...(bsConst ?? [])].map(([key, value]) => [key.toLowerCase(), value]));
         return {
             processedTokens: chunks
                 .map((chunk) => chunk.accept(this))

--- a/src/core/preprocessor/Preprocessor.ts
+++ b/src/core/preprocessor/Preprocessor.ts
@@ -43,8 +43,10 @@ export class Preprocessor implements CC.Visitor {
      * @returns an object containing an array of `errors` and an array of `processedTokens` filtered by conditional
      *          compilation directives included within
      */
-    filter(chunks: readonly CC.Chunk[], bsConst: Map<string, boolean>): FilterResults {
-        this.constants = new Map(bsConst);
+    filter(chunks: readonly CC.Chunk[], bsConst?: Map<string, boolean>): FilterResults {
+        this.constants = new Map(
+            [...(bsConst ?? [])].map(([key, value]) => [key.toLowerCase(), value])
+        );
         return {
             processedTokens: chunks
                 .map((chunk) => chunk.accept(this))
@@ -69,7 +71,8 @@ export class Preprocessor implements CC.Visitor {
      * @returns an empty array, since `#const` directives are always removed from the evaluated script.
      */
     visitDeclaration(chunk: CC.Declaration) {
-        if (this.constants.has(chunk.name.text)) {
+        const nameKey = chunk.name.text.toLowerCase();
+        if (this.constants.has(nameKey)) {
             return this.addError(
                 new BrsError(`Attempting to re-declare #const with name '${chunk.name.text}'`, chunk.name.location)
             );
@@ -84,8 +87,9 @@ export class Preprocessor implements CC.Visitor {
                 value = false;
                 break;
             case Lexeme.Identifier:
-                if (this.constants.has(chunk.value.text)) {
-                    value = this.constants.get(chunk.value.text) as boolean;
+                const valueKey = chunk.value.text.toLowerCase();
+                if (this.constants.has(valueKey)) {
+                    value = this.constants.get(valueKey) as boolean;
                     break;
                 }
 
@@ -104,7 +108,7 @@ export class Preprocessor implements CC.Visitor {
                 );
         }
 
-        this.constants.set(chunk.name.text, value);
+        this.constants.set(nameKey, value);
 
         return [];
     }
@@ -168,8 +172,9 @@ export class Preprocessor implements CC.Visitor {
             case Lexeme.False:
                 return false;
             case Lexeme.Identifier:
-                if (this.constants.has(token.text)) {
-                    return this.constants.get(token.text) as boolean;
+                const lookupKey = token.text.toLowerCase();
+                if (this.constants.has(lookupKey)) {
+                    return this.constants.get(lookupKey) as boolean;
                 }
 
                 return this.addError(

--- a/test/e2e/ConditionalCompilation.test.js
+++ b/test/e2e/ConditionalCompilation.test.js
@@ -39,10 +39,7 @@ describe("end to end conditional compilation", () => {
 
     test("case-insensitive-consts/main.brs", async () => {
         await execute(
-            [
-                resourceFile("case-insensitive-consts", "manifest"),
-                resourceFile("case-insensitive-consts", "main.brs"),
-            ],
+            [resourceFile("case-insensitive-consts", "manifest"), resourceFile("case-insensitive-consts", "main.brs")],
             outputStreams
         );
 

--- a/test/e2e/ConditionalCompilation.test.js
+++ b/test/e2e/ConditionalCompilation.test.js
@@ -37,6 +37,22 @@ describe("end to end conditional compilation", () => {
         ]);
     });
 
+    test("case-insensitive-consts/main.brs", async () => {
+        await execute(
+            [
+                resourceFile("case-insensitive-consts", "manifest"),
+                resourceFile("case-insensitive-consts", "main.brs"),
+            ],
+            outputStreams
+        );
+
+        expect(allArgs(outputStreams.stdout.write).map((arg) => arg.trimEnd())).toEqual([
+            "All uppercase",
+            "All lowercase",
+            "Mixed case",
+        ]);
+    });
+
     describe("(with sterr captured)", () => {
         test("conditional-compilation/compile-error.brs", async () => {
             await execute(

--- a/test/e2e/resources/case-insensitive-consts/main.brs
+++ b/test/e2e/resources/case-insensitive-consts/main.brs
@@ -1,0 +1,13 @@
+sub main()
+#if DEBUG
+    print "All uppercase"
+#end if
+
+#if debug
+    print "All lowercase"
+#end if
+
+#if deBUG
+    print "Mixed case"
+#end if
+end sub

--- a/test/e2e/resources/case-insensitive-consts/manifest
+++ b/test/e2e/resources/case-insensitive-consts/manifest
@@ -1,0 +1,2 @@
+name=Case insensitivity test
+bs_const=DEBUG=true

--- a/test/preprocessor/preprocessor.test.js
+++ b/test/preprocessor/preprocessor.test.js
@@ -267,12 +267,7 @@ describe("preprocessor", () => {
             it("matches #if with different case than #const declaration (lowercase)", () => {
                 new Preprocessor().filter([
                     new Chunk.Declaration(identifier("DEBUG"), token(Lexeme.True, "true", BrsBoolean.True)),
-                    new Chunk.If(
-                        identifier("debug"),
-                        false,
-                        [ifChunk],
-                        []
-                    ),
+                    new Chunk.If(identifier("debug"), false, [ifChunk], []),
                 ]);
 
                 expect(ifChunk.accept).toHaveBeenCalledTimes(1);
@@ -283,12 +278,7 @@ describe("preprocessor", () => {
             it("matches #if with different case than #const declaration (mixed case)", () => {
                 new Preprocessor().filter([
                     new Chunk.Declaration(identifier("DEBUG"), token(Lexeme.True, "true", BrsBoolean.True)),
-                    new Chunk.If(
-                        identifier("deBUG"),
-                        false,
-                        [ifChunk],
-                        []
-                    ),
+                    new Chunk.If(identifier("deBUG"), false, [ifChunk], []),
                 ]);
 
                 expect(ifChunk.accept).toHaveBeenCalledTimes(1);
@@ -298,17 +288,7 @@ describe("preprocessor", () => {
 
             it("uses bsConst values case-insensitively", () => {
                 let bsConst = new Map([["DEBUG", true]]);
-                new Preprocessor().filter(
-                    [
-                        new Chunk.If(
-                            identifier("debug"),
-                            false,
-                            [ifChunk],
-                            []
-                        ),
-                    ],
-                    bsConst
-                );
+                new Preprocessor().filter([new Chunk.If(identifier("debug"), false, [ifChunk], [])], bsConst);
 
                 expect(ifChunk.accept).toHaveBeenCalledTimes(1);
                 expect(elseIfChunk.accept).not.toHaveBeenCalled();
@@ -328,12 +308,7 @@ describe("preprocessor", () => {
                 new Preprocessor().filter([
                     new Chunk.Declaration(identifier("DEBUG"), token(Lexeme.True, "true", BrsBoolean.True)),
                     new Chunk.Declaration(identifier("MY_FLAG"), identifier("debug")),
-                    new Chunk.If(
-                        identifier("MY_FLAG"),
-                        false,
-                        [ifChunk],
-                        []
-                    ),
+                    new Chunk.If(identifier("MY_FLAG"), false, [ifChunk], []),
                 ]);
 
                 expect(ifChunk.accept).toHaveBeenCalledTimes(1);
@@ -343,17 +318,7 @@ describe("preprocessor", () => {
 
             it("negates bsConst value with 'not' and different case", () => {
                 let bsConst = new Map([["DEBUG", false]]);
-                new Preprocessor().filter(
-                    [
-                        new Chunk.If(
-                            identifier("DEBUG"),
-                            true,
-                            [ifChunk],
-                            []
-                        ),
-                    ],
-                    bsConst
-                );
+                new Preprocessor().filter([new Chunk.If(identifier("DEBUG"), true, [ifChunk], [])], bsConst);
 
                 expect(ifChunk.accept).toHaveBeenCalledTimes(1);
                 expect(elseIfChunk.accept).not.toHaveBeenCalled();

--- a/test/preprocessor/preprocessor.test.js
+++ b/test/preprocessor/preprocessor.test.js
@@ -263,6 +263,104 @@ describe("preprocessor", () => {
             expect(elseChunk.accept).not.toHaveBeenCalled();
         });
 
+        describe("case-insensitive lookups", () => {
+            it("matches #if with different case than #const declaration (lowercase)", () => {
+                new Preprocessor().filter([
+                    new Chunk.Declaration(identifier("DEBUG"), token(Lexeme.True, "true", BrsBoolean.True)),
+                    new Chunk.If(
+                        identifier("debug"),
+                        false,
+                        [ifChunk],
+                        []
+                    ),
+                ]);
+
+                expect(ifChunk.accept).toHaveBeenCalledTimes(1);
+                expect(elseIfChunk.accept).not.toHaveBeenCalled();
+                expect(elseChunk.accept).not.toHaveBeenCalled();
+            });
+
+            it("matches #if with different case than #const declaration (mixed case)", () => {
+                new Preprocessor().filter([
+                    new Chunk.Declaration(identifier("DEBUG"), token(Lexeme.True, "true", BrsBoolean.True)),
+                    new Chunk.If(
+                        identifier("deBUG"),
+                        false,
+                        [ifChunk],
+                        []
+                    ),
+                ]);
+
+                expect(ifChunk.accept).toHaveBeenCalledTimes(1);
+                expect(elseIfChunk.accept).not.toHaveBeenCalled();
+                expect(elseChunk.accept).not.toHaveBeenCalled();
+            });
+
+            it("uses bsConst values case-insensitively", () => {
+                let bsConst = new Map([["DEBUG", true]]);
+                new Preprocessor().filter(
+                    [
+                        new Chunk.If(
+                            identifier("debug"),
+                            false,
+                            [ifChunk],
+                            []
+                        ),
+                    ],
+                    bsConst
+                );
+
+                expect(ifChunk.accept).toHaveBeenCalledTimes(1);
+                expect(elseIfChunk.accept).not.toHaveBeenCalled();
+                expect(elseChunk.accept).not.toHaveBeenCalled();
+            });
+
+            it("rejects re-declaration of #const with different case", () => {
+                expect(() =>
+                    new Preprocessor().filter([
+                        new Chunk.Declaration(identifier("FOO"), token(Lexeme.True, "true", BrsBoolean.True)),
+                        new Chunk.Declaration(identifier("foo"), token(Lexeme.False, "false", BrsBoolean.False)),
+                    ])
+                ).toThrow("Attempting to re-declare");
+            });
+
+            it("resolves #const alias case-insensitively", () => {
+                new Preprocessor().filter([
+                    new Chunk.Declaration(identifier("DEBUG"), token(Lexeme.True, "true", BrsBoolean.True)),
+                    new Chunk.Declaration(identifier("MY_FLAG"), identifier("debug")),
+                    new Chunk.If(
+                        identifier("MY_FLAG"),
+                        false,
+                        [ifChunk],
+                        []
+                    ),
+                ]);
+
+                expect(ifChunk.accept).toHaveBeenCalledTimes(1);
+                expect(elseIfChunk.accept).not.toHaveBeenCalled();
+                expect(elseChunk.accept).not.toHaveBeenCalled();
+            });
+
+            it("negates bsConst value with 'not' and different case", () => {
+                let bsConst = new Map([["DEBUG", false]]);
+                new Preprocessor().filter(
+                    [
+                        new Chunk.If(
+                            identifier("DEBUG"),
+                            true,
+                            [ifChunk],
+                            []
+                        ),
+                    ],
+                    bsConst
+                );
+
+                expect(ifChunk.accept).toHaveBeenCalledTimes(1);
+                expect(elseIfChunk.accept).not.toHaveBeenCalled();
+                expect(elseChunk.accept).not.toHaveBeenCalled();
+            });
+        });
+
         it("enters #else if branch with negated condition", () => {
             new Preprocessor().filter([
                 new Chunk.If(


### PR DESCRIPTION
## Description

Roku treats bs-const names in `#if` / `#elseif` conditional compilation directives as **case-insensitive**, but brs-engine was performing case-sensitive lookups. This caused errors like:

```
Invalid #If/#ElseIf expression (<CONST-NAME> not defined) 'debug' (compile error
```

when a bs-const `DEBUG=true` was referenced as `#if debug` or `#if deBUG`.

## Changes

**`src/core/preprocessor/Preprocessor.ts`** — Normalized all const key operations to lowercase:
- `filter()`: bsConst manifest keys lowercased when building the internal map
- `visitDeclaration()`: `#const` names and alias targets lowercased for re-declaration checks, alias resolution, and storage
- `evaluateCondition()`: `#if` / `#elseif` condition identifiers lowercased before lookup

## Tests

- **Unit tests** (`test/preprocessor/preprocessor.test.js`): 6 new tests covering lowercase, uppercase, mixed-case lookups, re-declaration rejection with different case, alias resolution with different case, and negated bsConst with different case
- **E2E tests** (`test/e2e/ConditionalCompilation.test.js`): New resource files + test exercising `#if DEBUG`, `#if debug`, and `#if deBUG` from manifest `bs_const=DEBUG=true`

All 98 related tests pass.
