### PR TITLE
fix(scenegraph): add support for "associativearray" in FieldKind and value type checks

### DIFF
--- a/src/extensions/scenegraph/SGTypes.ts
+++ b/src/extensions/scenegraph/SGTypes.ts
@@ -111,6 +111,7 @@ export namespace FieldKind {
             case "rect2d":
                 return FieldKind.Rect2D;
             case "roassociativearray":
+            case "associativearray":
             case "assocarray":
                 return FieldKind.AssocArray;
             case "font":

--- a/src/extensions/scenegraph/factory/NodeFactory.ts
+++ b/src/extensions/scenegraph/factory/NodeFactory.ts
@@ -977,6 +977,7 @@ export function getValueKindFromFieldType(type: string) {
         case "roarray":
         case "array":
         case "roassociativearray":
+        case "associativearray":
         case "assocarray":
         case "rect2d":
         case "vector2d":
@@ -1069,6 +1070,7 @@ export function getBrsValueFromFieldType(type: string, value?: string, defaultVa
             returnValue = parseColorArray(value ?? "", defaultValue);
             break;
         case "roassociativearray":
+        case "associativearray":
         case "assocarray": {
             returnValue = parseAA(value ?? "", defaultValue);
             break;

--- a/test/e2e/SceneGraph.test.js
+++ b/test/e2e/SceneGraph.test.js
@@ -286,4 +286,22 @@ describe("SceneGraph node tests", () => {
             "final",
         ]);
     });
+
+    test("add-field-types.brs", async () => {
+        await execute([resourceFile("scenegraph", "add-field-types.brs")], outputStreams);
+
+        expect(allArgs(outputStreams.stdout.write).map((arg) => arg.trimEnd())).toEqual([
+            // addField returns true for every AssocArray spelling
+            "true",
+            "true",
+            "true",
+            // every field is actually created on the node
+            "true",
+            "true",
+            "true",
+            // the field behaves as a writable AssocArray
+            "roAssociativeArray",
+            "bar",
+        ]);
+    });
 });

--- a/test/e2e/resources/scenegraph/add-field-types.brs
+++ b/test/e2e/resources/scenegraph/add-field-types.brs
@@ -1,0 +1,20 @@
+sub main()
+    node = createObject("roSGNode", "Node")
+
+    ' addField must accept all three spellings of the AssocArray field type.
+    ' Before the fix only "assocarray" / "roassociativearray" worked, so the
+    ' "associativeArray" field was silently never created.
+    print node.addField("aaCamel", "associativeArray", true)
+    print node.addField("aaShort", "assocarray", true)
+    print node.addField("aaRo", "roAssociativeArray", true)
+
+    ' Each field must now exist on the node
+    print node.hasField("aaCamel")
+    print node.hasField("aaShort")
+    print node.hasField("aaRo")
+
+    ' ...and behave as a writable AssocArray field
+    node.aaCamel = { foo: "bar" }
+    print type(node.aaCamel)
+    print node.aaCamel.foo
+end sub


### PR DESCRIPTION
Using `associativeArray` as type was not working, only `assocarray` and `roassociativearray`, the example below would fail:

```brs
    node = createObject("roSGNOde", "Node")
    node.addField("test", "associativeArray", true)
```