### PR TITLE
test(preprocessor): exercise different case in negated bsConst test

### DIFF
--- a/test/preprocessor/preprocessor.test.js
+++ b/test/preprocessor/preprocessor.test.js
@@ -318,7 +318,7 @@ describe("preprocessor", () => {
 
             it("negates bsConst value with 'not' and different case", () => {
                 let bsConst = new Map([["DEBUG", false]]);
-                new Preprocessor().filter([new Chunk.If(identifier("DEBUG"), true, [ifChunk], [])], bsConst);
+                new Preprocessor().filter([new Chunk.If(identifier("deBUG"), true, [ifChunk], [])], bsConst);
 
                 expect(ifChunk.accept).toHaveBeenCalledTimes(1);
                 expect(elseIfChunk.accept).not.toHaveBeenCalled();


### PR DESCRIPTION
## Description

Follow-up to #962. The case-insensitive bs-const fix added a test named *"negates bsConst value with 'not' and different case"*, but it used `identifier("DEBUG")` against a `bsConst` map keyed `"DEBUG"` — the **same** case. It would pass even without the case-insensitivity fix, so it didn't actually guard the negated different-case lookup path.

## Change

Use `identifier("deBUG")` so the test genuinely exercises a different-case identifier on the negated condition path.

## Verification

`npx jest test/preprocessor/preprocessor.test.js -t "case-insensitive"` — all 6 case-insensitive tests pass. Confirmed the updated test hits the real `evaluateCondition` lookup (it fails against a pre-fix build and passes against the fixed build).

> Note: the other minor item raised in review of #962 — a silent key collision when a manifest defines the same const in two cases (`bs_const=DEBUG=true;debug=false`) — was intentionally left alone, as that is an invalid manifest a real Roku device would reject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)