### PR TITLE
fix(scenegraph): give focus to a custom StandardDialog's buttons

### DIFF
--- a/src/extensions/scenegraph/components/RoSGScreen.ts
+++ b/src/extensions/scenegraph/components/RoSGScreen.ts
@@ -260,6 +260,12 @@ export class RoSGScreen extends BrsComponent implements BrsValue, BrsDraw2D {
         const dialog = sgRoot.scene.dialog;
         if ((dialog instanceof Dialog || dialog instanceof StandardDialog) && dialog.isVisible()) {
             handled = dialog.handleKey(key.value, press.toBoolean());
+            if (!handled && dialog instanceof StandardDialog) {
+                // The StandardDialog framework navigation didn't consume the key. Route it through
+                // the normal focus chain so a custom dialog component's focused content (e.g. a
+                // plain ButtonGroup) and its onKeyEvent get a chance to handle it, as on Roku.
+                handled = sgRoot.scene.handleOnKeyEvent(interpreter, key, press);
+            }
         } else {
             handled = sgRoot.scene.handleOnKeyEvent(interpreter, key, press);
         }

--- a/src/extensions/scenegraph/nodes/StandardDialog.ts
+++ b/src/extensions/scenegraph/nodes/StandardDialog.ts
@@ -187,14 +187,23 @@ export class StandardDialog extends Group {
     }
 
     setNodeFocus(focusOn: boolean): boolean {
-        if (focusOn && sgRoot.focused && this.lastFocus === undefined) {
-            // Initial focus goes to the button row when present, otherwise to the first focusable
-            // content widget (e.g. a scrollable text item).
+        if (focusOn && sgRoot.focused) {
             const targets = this.getFocusTargets();
             const target = this.buttonArea?.hasButtons ? this.buttonArea : targets[0];
             if (target) {
-                this.lastFocus = sgRoot.focused;
-                this.focusTarget(target);
+                // Framework dialog: focus the button row / first content widget once (one-shot so
+                // the per-frame render doesn't fight the user's navigation).
+                if (this.lastFocus === undefined) {
+                    this.lastFocus = sgRoot.focused;
+                    this.focusTarget(target);
+                }
+            } else if (!this.isChildrenFocused() && sgRoot.focused !== this) {
+                // Custom dialog with no framework target (e.g. its own ButtonGroup): act like a
+                // normal focusable node so it becomes focused and its `focusedChild` observer /
+                // `initialFocus` can route focus to the buttons. Re-grab while focus is outside it.
+                this.lastFocus ??= sgRoot.focused;
+                this.isDirty = true;
+                super.setNodeFocus(true);
             }
         }
         return true;

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -350,6 +350,31 @@ describe("cli", () => {
         ]);
     }, 10000);
 
+    it("StandardDialog forwards focus to a custom component's nested button group", async () => {
+        let command = ["node", brsCliPath, "-r dialog-buttongroup-focus-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        // Repro of the pplus-proxy ThemeDialog: a custom dialog on the StandardDialog framework whose
+        // interactive widget is a plain LayoutGroup-based button group (no StdDlgButtonArea). It drives
+        // focus via its own focusedChild observer + hasFocus(), with the dialog focused from inside a
+        // field-observer callback. setNodeFocus must make the dialog itself the focused node so that
+        // observer fires and forwards focus into the button group (otherwise no button is highlighted),
+        // and must re-deliver focus when the dialog is explicitly re-focused after focus moved away.
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "=== Dialog ButtonGroup Focus Repro ===",
+            "  ExButtons received focus -> highlight first button",
+            "after show: isInFocusChain = true",
+            "  ExButtons received focus -> highlight first button",
+            "after refocus: isInFocusChain = true",
+            "=== Dialog ButtonGroup Focus Complete ===",
+            "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+    }, 10000);
+
     it("Run App from Root Folder Only", async () => {
         // Issue #771: pointing the CLI at a folder with `--root` and no positional files
         // discovers source/*.brs and loads components/ from the root-mounted pkg:/ volume,

--- a/test/cli/resources/dialog-buttongroup-focus-app/components/BaseStdDialog.brs
+++ b/test/cli/resources/dialog-buttongroup-focus-app/components/BaseStdDialog.brs
@@ -1,0 +1,10 @@
+sub init()
+    m.top.observeField("focusedChild", "onFocusChanged")
+    ' HACK from the real app: strip the StandardDialog framework's auto-added children.
+    m.top.removeChildrenIndex(m.top.getChildCount(), 0)
+end sub
+
+' Base handler, overridden by the derived component (mirrors baseStandardDialog.brs).
+sub onFocusChanged(nodeEvent as object)
+    ' Overwrite by extend
+end sub

--- a/test/cli/resources/dialog-buttongroup-focus-app/components/BaseStdDialog.xml
+++ b/test/cli/resources/dialog-buttongroup-focus-app/components/BaseStdDialog.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Mirrors pplus-proxy BaseStandardDialog: removes the firmware dialog's auto children and drives
+     focus via a focusedChild observer (the handler is overridden by the derived component). -->
+<component name="BaseStdDialog" extends="StandardDialog">
+    <script type="text/brightscript" uri="./BaseStdDialog.brs" />
+</component>

--- a/test/cli/resources/dialog-buttongroup-focus-app/components/ExButtons.brs
+++ b/test/cli/resources/dialog-buttongroup-focus-app/components/ExButtons.brs
@@ -1,0 +1,14 @@
+sub init()
+    m.top.observeFieldScoped("focusedChild", "onFocusChanged")
+end sub
+
+sub addButton(label as string)
+    btn = m.top.createChild("Label")
+    btn.text = label
+end sub
+
+sub onFocusChanged(_nodeEvent as object)
+    if m.top.hasFocus() then
+        print "  ExButtons received focus -> highlight first button"
+    end if
+end sub

--- a/test/cli/resources/dialog-buttongroup-focus-app/components/ExButtons.xml
+++ b/test/cli/resources/dialog-buttongroup-focus-app/components/ExButtons.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Mirrors pplus-proxy ButtonExGroup: a LayoutGroup that highlights its first child only when it
+     itself receives focus, detected via its own focusedChild observer + hasFocus(). -->
+<component name="ExButtons" extends="LayoutGroup">
+    <script type="text/brightscript" uri="./ExButtons.brs" />
+    <interface>
+        <function name="addButton" />
+    </interface>
+</component>

--- a/test/cli/resources/dialog-buttongroup-focus-app/components/MainScene.brs
+++ b/test/cli/resources/dialog-buttongroup-focus-app/components/MainScene.brs
@@ -1,0 +1,14 @@
+sub init()
+    m.nullFocus = m.top.findNode("nullFocus")
+end sub
+
+' Mirrors pplus-proxy baseOnDialogChanged: runs inside the field observer, parks focus on the null
+' holder, assigns the dialog, then explicitly focuses it.
+sub onDialogChanged(nodeEvent as object)
+    dialog = nodeEvent.getData()
+    if dialog <> invalid then
+        m.nullFocus.setFocus(true)
+        m.top.dialog = dialog
+        m.top.dialog.setFocus(true)
+    end if
+end sub

--- a/test/cli/resources/dialog-buttongroup-focus-app/components/MainScene.xml
+++ b/test/cli/resources/dialog-buttongroup-focus-app/components/MainScene.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="MainScene" extends="Scene">
+    <script type="text/brightscript" uri="pkg:/components/MainScene.brs" />
+    <interface>
+        <!-- Mirrors pplus-proxy: the dialog is delivered through a global-like field whose observer
+             parks focus and then focuses the dialog (all inside the observer callback). -->
+        <field id="sceneDialog" type="node" onChange="onDialogChanged" />
+    </interface>
+    <children>
+        <Rectangle id="background" width="1280" height="720" color="0x101010FF" />
+        <Rectangle id="nullFocus" focusable="true" />
+    </children>
+</component>

--- a/test/cli/resources/dialog-buttongroup-focus-app/components/MyDialog.brs
+++ b/test/cli/resources/dialog-buttongroup-focus-app/components/MyDialog.brs
@@ -1,0 +1,17 @@
+sub init()
+    m.buttons = m.top.findNode("buttons")
+end sub
+
+sub setup()
+    ' Mirrors setupButtons: create the buttons dynamically.
+    m.buttons.callFunc("addButton", "Yes")
+    m.buttons.callFunc("addButton", "No")
+end sub
+
+' Overrides BaseStdDialog's focusedChild observer: once the dialog itself has focus, hand it to the
+' nested button group.
+sub onFocusChanged(_nodeEvent as object)
+    if m.top.hasFocus() then
+        m.buttons.setFocus(true)
+    end if
+end sub

--- a/test/cli/resources/dialog-buttongroup-focus-app/components/MyDialog.xml
+++ b/test/cli/resources/dialog-buttongroup-focus-app/components/MyDialog.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Mirrors pplus-proxy ThemeDialog/BaseThemeDialog: a custom dialog on the StandardDialog framework
+     whose interactive widget is a plain LayoutGroup-based button group (ExButtons) nested inside a
+     background/content layout. Focus is forwarded to the buttons from onFocusChanged once the dialog
+     itself has focus. -->
+<component name="MyDialog" extends="BaseStdDialog">
+    <script type="text/brightscript" uri="./MyDialog.brs" />
+    <interface>
+        <function name="setup" />
+    </interface>
+    <children>
+        <Rectangle id="background" width="1280" height="720" color="0x101010FF">
+            <LayoutGroup id="content" layoutDirection="vert">
+                <Label id="title" text="Exit?" />
+                <ExButtons id="buttons" layoutDirection="horiz" />
+            </LayoutGroup>
+        </Rectangle>
+    </children>
+</component>

--- a/test/cli/resources/dialog-buttongroup-focus-app/manifest
+++ b/test/cli/resources/dialog-buttongroup-focus-app/manifest
@@ -1,0 +1,4 @@
+title=Dialog ButtonGroup Focus Test
+major_version=1
+minor_version=0
+build_version=0

--- a/test/cli/resources/dialog-buttongroup-focus-app/source/main.brs
+++ b/test/cli/resources/dialog-buttongroup-focus-app/source/main.brs
@@ -1,0 +1,27 @@
+sub Main()
+    print "=== Dialog ButtonGroup Focus Repro ==="
+
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+
+    scene = screen.CreateScene("MainScene")
+    screen.show()
+    scene.setFocus(true)
+
+    dialog = CreateObject("roSGNode", "MyDialog")
+    dialog.callFunc("setup")
+
+    scene.sceneDialog = dialog
+
+    buttons = dialog.findNode("buttons")
+    print "after show: isInFocusChain = "; buttons.isInFocusChain()
+
+    ' Move focus away, then re-focus the dialog (the framework must re-deliver focus to the buttons).
+    nullFocus = scene.findNode("nullFocus")
+    nullFocus.setFocus(true)
+    dialog.setFocus(true)
+    print "after refocus: isInFocusChain = "; buttons.isInFocusChain()
+
+    print "=== Dialog ButtonGroup Focus Complete ==="
+end sub


### PR DESCRIPTION
## Problem

A SceneGraph dialog built on the **StandardDialog framework** whose interactive widget is a plain `ButtonGroup`/`LayoutGroup` (not a `StdDlgButtonArea`) showed correctly but **never highlighted a button** — focus was never delivered to the buttons.

Real-world case: pplus-proxy's `ThemeDialog` (`ThemeDialog ← BaseThemeDialog ← BaseStandardDialog ← StandardDialog`) routes focus to its `ButtonExGroup` from its own `focusedChild` observer (`if m.top.hasFocus() then m.buttons.setFocus(true)`). That observer only fires if the **dialog itself becomes the focused node**. The old `StandardDialog.setNodeFocus` returned without making the dialog focused when there was no `StdDlgButtonArea`, so the observer never fired.

## Fix

`StandardDialog.setNodeFocus` (`src/extensions/scenegraph/nodes/StandardDialog.ts`):
- When there's a framework button area / content widget, keep the existing one-shot auto-focus.
- Otherwise, fall back to the base `Node.setNodeFocus` so the dialog becomes the focused node and its `focusedChild` field is set — which both honors a declared `initialFocus` child and fires the component's own `focusedChild` observer. It re-grabs focus whenever focus is outside the dialog (so explicit re-focus and per-frame renders work) but skips while focus is already inside it, so button navigation isn't reset.

`RoSGScreen.handleNextKey` (`src/extensions/scenegraph/components/RoSGScreen.ts`):
- Route keys a StandardDialog's framework navigation didn't consume through the focus chain, so a custom dialog's focused content and its `onKeyEvent` can handle them.

## Tests

Adds `test/cli/resources/dialog-buttongroup-focus-app` and a `cli.test.js` case mirroring the real dialog: a custom component extending `StandardDialog` with the `removeChildrenIndex` HACK, a nested `LayoutGroup`-based button group that highlights via its own `focusedChild` observer, dynamic buttons, the `nullFocus` pattern, and the dialog focused from inside a field-observer callback. It fails without the fix (`isInFocusChain = false`) and passes with it, including re-focus after focus moves away.

All cli + scenegraph suites pass; lint/prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)