### PR TITLE
fix(brs): propagate optional state through dot-bracket chaining (?.[)

### DIFF
--- a/src/core/parser/Parser.ts
+++ b/src/core/parser/Parser.ts
@@ -1442,8 +1442,8 @@ export class Parser {
         function call(): Expression {
             let expr = primary();
 
-            function indexedGet() {
-                const optional = previous().text === "?[";
+            function indexedGet(dotOptional = false) {
+                const optional = previous().text === "?[" || dotOptional;
                 let elements: Expression[] = [];
 
                 while (match(Lexeme.Newline));
@@ -1482,10 +1482,10 @@ export class Parser {
                     name.kind = Lexeme.Identifier;
                     expr = new Expr.AtSignGet(expr, name as Identifier, optional);
                 } else if (match(Lexeme.Dot)) {
+                    const optionalDot = previous().text === "?.";
                     if (match(Lexeme.LeftSquare)) {
-                        indexedGet();
+                        indexedGet(optionalDot);
                     } else {
-                        const optional = previous().text === "?.";
                         while (match(Lexeme.Newline));
 
                         let name = consume("Expected property name after '.'", Lexeme.Identifier, ...allowedProperties);
@@ -1493,7 +1493,7 @@ export class Parser {
                         // force it into an identifier so the AST makes some sense
                         name.kind = Lexeme.Identifier;
                         countIdentifier(name.text);
-                        expr = new Expr.DottedGet(expr, name as Identifier, optional);
+                        expr = new Expr.DottedGet(expr, name as Identifier, optionalDot);
                     }
                 } else {
                     break;

--- a/test/e2e/Syntax.test.js
+++ b/test/e2e/Syntax.test.js
@@ -243,6 +243,8 @@ describe("end to end syntax", () => {
             "invalid",
             "invalid",
             "invalid",
+            "invalid",
+            "invalid",
             "error 244",
         ]);
     });

--- a/test/e2e/resources/optional-chaining-operators.brs
+++ b/test/e2e/resources/optional-chaining-operators.brs
@@ -11,7 +11,10 @@ sub Main()
  	print thing?[0]
  	print thing?[0]?.property
  	print thing?[0]?.functionCall2?()
-  	print thing?.functionCall?(thing?[0]?.property, thing?[0]?.functionCall2?())
+   	print thing?.functionCall?(thing?[0]?.property, thing?[0]?.functionCall2?())
+   	print thing?.["key"]
+   	testConfig = {}
+   	print testConfig?.notThere?.["test"]
 	di = CreateObject("roDeviceInfo")
 	try
 		print di.action()

--- a/test/parser/expression/Indexing.test.js
+++ b/test/parser/expression/Indexing.test.js
@@ -92,6 +92,24 @@ describe("parser indexing", () => {
                 expect(statements).toMatchSnapshot();
             });
 
+            test("optional dot", () => {
+                let { statements, errors } = parser.parse([
+                    identifier("_"),
+                    token(Lexeme.Equal, "="),
+                    identifier("foo"),
+                    token(Lexeme.Dot, "?."),
+                    token(Lexeme.LeftSquare, "["),
+                    token(Lexeme.Integer, "2", new Int32(2)),
+                    token(Lexeme.RightSquare, "]"),
+                    EOF,
+                ]);
+
+                expect(errors).toEqual([]);
+                expect(statements).toBeDefined();
+                expect(statements).not.toBeNull();
+                expect(statements).toMatchSnapshot();
+            });
+
             test("multiple dots", () => {
                 let { statements, errors } = parser.parse([
                     identifier("_"),

--- a/test/parser/expression/__snapshots__/Indexing.test.js.snap
+++ b/test/parser/expression/__snapshots__/Indexing.test.js.snap
@@ -561,6 +561,103 @@ exports[`parser indexing one level dotted 1`] = `
 ]
 `;
 
+exports[`parser indexing one level dotted and bracketed optional dot 1`] = `
+[
+  Assignment {
+    "name": {
+      "isReserved": false,
+      "kind": "Identifier",
+      "literal": undefined,
+      "location": {
+        "end": {
+          "column": -9,
+          "line": -9,
+        },
+        "start": {
+          "column": -9,
+          "line": -9,
+        },
+      },
+      "text": "_",
+    },
+    "tokens": {
+      "equals": {
+        "isReserved": false,
+        "kind": "Equal",
+        "literal": undefined,
+        "location": {
+          "end": {
+            "column": -9,
+            "line": -9,
+          },
+          "start": {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "text": "=",
+      },
+    },
+    "value": IndexedGet {
+      "closingSquare": {
+        "isReserved": false,
+        "kind": "RightSquare",
+        "literal": undefined,
+        "location": {
+          "end": {
+            "column": -9,
+            "line": -9,
+          },
+          "start": {
+            "column": -9,
+            "line": -9,
+          },
+        },
+        "text": "]",
+      },
+      "indexes": [
+        Literal {
+          "_location": {
+            "end": {
+              "column": -9,
+              "line": -9,
+            },
+            "start": {
+              "column": -9,
+              "line": -9,
+            },
+          },
+          "value": Int32 {
+            "inArray": false,
+            "kind": 4,
+            "value": 2,
+          },
+        },
+      ],
+      "obj": Variable {
+        "name": {
+          "isReserved": false,
+          "kind": "Identifier",
+          "literal": undefined,
+          "location": {
+            "end": {
+              "column": -9,
+              "line": -9,
+            },
+            "start": {
+              "column": -9,
+              "line": -9,
+            },
+          },
+          "text": "foo",
+        },
+      },
+      "optional": true,
+    },
+  },
+]
+`;
+
 exports[`parser indexing one level dotted and bracketed single dot 1`] = `
 [
   Assignment {


### PR DESCRIPTION
## Description

Fixes a bug where `?.["key"]` (optional dot followed by bracket indexing) always produced an `IndexedGet` AST node with `optional: false`, causing `"Array operation attempted on variable not DIM"` error instead of short-circuiting to `invalid`.

## Root Cause

In `src/core/parser/Parser.ts`, the `call()` function processes `?.[` through the Dot → LeftSquare path. The `indexedGet()` inner function determined optionality solely by checking `previous().text === "?["`, but when entered from the Dot branch, the `previous()` token was the LeftSquare (text `"["`), not the `?[` token. The optional state from the preceding `?.` Dot token was lost.

## Fix

- Save the optional state from the Dot token (`optionalDot = previous().text === "?."`) and pass it as a parameter to `indexedGet()`
- In `indexedGet()`, combine with existing check: `const optional = previous().text === "?[" || dotOptional`
- Also refactored the DottedGet branch to reuse the saved `optionalDot` value

## Testing

- **Parser unit test**: `foo?.[2]` verifies AST snapshot shows `"optional": true`
- **E2E test**: Added `thing?.["key"]` (invalid source) and `testConfig?.notThere?.["test"]` (AA with missing property) — both now correctly return `invalid`
- All 126 test suites pass (1861 tests, 178 snapshots)