### PR TITLE
fix(scenegraph): attach list item component to its parent before init()

### DIFF
--- a/src/extensions/scenegraph/factory/NodeFactory.ts
+++ b/src/extensions/scenegraph/factory/NodeFactory.ts
@@ -367,15 +367,15 @@ export class SGNodeFactory {
  * @param interpreter Optional interpreter instance for component initialization
  * @returns Created node instance or BrsInvalid if creation fails
  */
-export function createNode(type: string, interpreter?: Interpreter): Node | BrsInvalid {
+export function createNode(type: string, interpreter?: Interpreter, parent?: Node): Node | BrsInvalid {
     // If this is a built-in node component, then return it.
     let node = SGNodeFactory.createNode(type) ?? BrsInvalid.Instance;
     if (node instanceof BrsInvalid) {
         let typeDef = sgRoot.nodeDefMap.get(type.toLowerCase());
         if (typeDef && interpreter instanceof Interpreter) {
-            node = initializeNode(interpreter, type, typeDef);
+            node = initializeNode(interpreter, type, typeDef, undefined, parent);
         } else if (typeDef && sgRoot.inTaskThread() && sgRoot.interpreter) {
-            node = initializeNode(sgRoot.interpreter, type, typeDef);
+            node = initializeNode(sgRoot.interpreter, type, typeDef, undefined, parent);
         } else if (typeDef) {
             node = createNodeByTypeDef(typeDef, type);
             if (node instanceof BrsInvalid) {
@@ -497,7 +497,13 @@ export function customNodeExists(node: string) {
  * @param node Optional pre-created node instance to initialize
  * @returns Initialized node instance or BrsInvalid if initialization fails
  */
-export function initializeNode(interpreter: Interpreter, type: string, typeDef?: ComponentDefinition, node?: Node) {
+export function initializeNode(
+    interpreter: Interpreter,
+    type: string,
+    typeDef?: ComponentDefinition,
+    node?: Node,
+    parent?: Node
+) {
     if (typeDef) {
         //use typeDef object to tack on all the bells & whistles of a custom node
         const typeDefStack = updateTypeDefHierarchy(typeDef);
@@ -510,6 +516,12 @@ export function initializeNode(interpreter: Interpreter, type: string, typeDef?:
         node ??= SGNodeFactory.createNode(typeDef!.extends as SGNodeType, type);
         // Default to Node as parent.
         node ??= new Node([], type);
+        // Attach the parent before running init() so a custom component's init() can read its
+        // parent (e.g. m.top.getParent().itemSize on a list item), matching a real device where
+        // the item component is already a child of its list when init() runs.
+        if (parent && isInvalid(node.getNodeParent())) {
+            node.setNodeParent(parent);
+        }
         const mPointer = new RoAssociativeArray([]);
         if (currentEnv) {
             currentEnv.setM(new RoAssociativeArray([]));

--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -476,7 +476,7 @@ export class ArrayGrid extends Group {
             return new Group();
         }
         const itemCompName = this.getValueJS("itemComponentName") ?? "";
-        const itemComp = itemCompName ? createNode(itemCompName, interpreter) : new ArrayGridItem();
+        const itemComp = itemCompName ? createNode(itemCompName, interpreter, this) : new ArrayGridItem();
         if (itemComp instanceof Group) {
             itemComp.setNodeParent(this);
             itemComp.setValue("width", brsValueOf(itemRect.width), false);

--- a/src/extensions/scenegraph/nodes/TargetGroup.ts
+++ b/src/extensions/scenegraph/nodes/TargetGroup.ts
@@ -282,7 +282,7 @@ export class TargetGroup extends Group {
 
     protected createItemComponent(interpreter: Interpreter, itemRect: Rect, content: ContentNode) {
         const itemCompName = (this.getValueJS("itemComponentName") as string) ?? "";
-        const itemComp = itemCompName ? createNode(itemCompName, interpreter) : new Group();
+        const itemComp = itemCompName ? createNode(itemCompName, interpreter, this) : new Group();
         if (itemComp instanceof Group) {
             itemComp.setNodeParent(this);
             itemComp.setValue("width", new Float(itemRect.width), false);

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -350,6 +350,27 @@ describe("cli", () => {
         ]);
     }, 10000);
 
+    it("List item component can read its parent list during init()", async () => {
+        let command = ["node", brsCliPath, "-r list-item-parent-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        // Repro of the JellyRock JRServer item: a custom list item sizes its focus border from
+        // m.top.getParent().itemSize in init(). The item must already be attached to its list when
+        // init() runs (as on a real device), so getParent() resolves the list and itemSize is read.
+        // Before the fix the parent was attached after init(), so getParent() was invalid and the
+        // border stayed 0x0 (rendered tiny in the corner).
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "=== List Item Parent Repro ===",
+            "ServerItem init: focusBorder = 1520x 100",
+            "=== List Item Parent Repro Complete ===",
+            "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+    }, 10000);
+
     it("StandardDialog forwards focus to a custom component's nested button group", async () => {
         let command = ["node", brsCliPath, "-r dialog-buttongroup-focus-app", "source/main.brs", "-c 0"].join(" ");
 

--- a/test/cli/resources/list-item-parent-app/components/ServerItem.brs
+++ b/test/cli/resources/list-item-parent-app/components/ServerItem.brs
@@ -1,0 +1,15 @@
+sub init()
+    ' A custom list item commonly sizes itself from the parent list's itemSize, read via
+    ' getParent() in init(). This only works if the item is already attached to its list when
+    ' init() runs (as on a real device) - otherwise getParent() is invalid and the size stays 0.
+    m.focusBorder = m.top.findNode("focusBorder")
+    parentList = m.top.getParent()
+    if parentList <> invalid and parentList.hasField("itemSize")
+        itemSize = parentList.itemSize
+        if itemSize <> invalid and itemSize.Count() = 2
+            m.focusBorder.width = itemSize[0]
+            m.focusBorder.height = itemSize[1]
+        end if
+    end if
+    print "ServerItem init: focusBorder ="; m.focusBorder.width; "x"; m.focusBorder.height
+end sub

--- a/test/cli/resources/list-item-parent-app/components/ServerItem.xml
+++ b/test/cli/resources/list-item-parent-app/components/ServerItem.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="ServerItem" extends="Group">
+    <interface>
+        <field id="itemContent" type="node" />
+    </interface>
+    <script type="text/brightscript" uri="pkg:/components/ServerItem.brs" />
+    <children>
+        <Poster id="focusBorder" visible="false" />
+    </children>
+</component>

--- a/test/cli/resources/list-item-parent-app/components/ServerScene.xml
+++ b/test/cli/resources/list-item-parent-app/components/ServerScene.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="ServerScene" extends="Scene">
+    <children>
+        <MarkupList
+            id="serverPicker"
+            itemComponentName="ServerItem"
+            itemSize="[1520, 100]"
+            numRows="3"
+            drawFocusFeedback="false" />
+    </children>
+</component>

--- a/test/cli/resources/list-item-parent-app/manifest
+++ b/test/cli/resources/list-item-parent-app/manifest
@@ -1,0 +1,4 @@
+title=List Item Parent Test
+major_version=1
+minor_version=0
+build_version=0

--- a/test/cli/resources/list-item-parent-app/source/main.brs
+++ b/test/cli/resources/list-item-parent-app/source/main.brs
@@ -1,0 +1,21 @@
+sub Main()
+    print "=== List Item Parent Repro ==="
+
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+
+    scene = screen.CreateScene("ServerScene")
+    screen.show()
+
+    list = scene.findNode("serverPicker")
+    content = CreateObject("roSGNode", "ContentNode")
+    item = content.createChild("ContentNode")
+    item.title = "Server 1"
+    list.content = content
+
+    ' Force a layout pass so the list creates its item components and their init() runs.
+    list.boundingRect()
+
+    print "=== List Item Parent Repro Complete ==="
+end sub


### PR DESCRIPTION
## Problem

A custom list item component commonly sizes itself from the parent list's `itemSize`, read via `m.top.getParent()` in `init()`. The JellyRock **JRServer** screen does exactly this to size its focus-border 9-patch:

```brightscript
parentList = m.top.getParent()
if isValid(parentList) and parentList.hasField("itemSize")
    itemSize = parentList.itemSize
    if isValid(itemSize) and itemSize.Count() = 2
        m.focusBorder.width = itemSize[0]
        m.focusBorder.height = itemSize[1]
    end if
end if
```

On a real Roku device the item is already a child of its list when `init()` runs, so `getParent()` resolves the list. In the simulator, `ArrayGrid.createItemComponent` called `createNode(...)` — which runs the component's `init()` internally — and only **afterward** called `setNodeParent(this)`. So during `init()`, `getParent()` returned `invalid`, the `itemSize` block was skipped, and the focus border kept its default `[0,0]` size — rendering the 9-patch at its intrinsic pixel size in the top-left corner instead of framing the item.

## Fix

Thread an optional `parent` through `createNode` → `initializeNode` and attach it right after the node is constructed, **before** the `init()` loop runs (guarded so it won't clobber an existing parent). `ArrayGrid` and `TargetGroup` now pass the list as the parent when creating item components — covering `MarkupList`, `MarkupGrid`, `LabelList`, `RowList`, etc. (all inherit `createItemComponent`).

## Testing

- Added CLI regression fixture `test/cli/resources/list-item-parent-app/` + a test in `cli.test.js` asserting the item reads its parent's `itemSize` (`1520x100`) during `init()`. Confirmed it reads `0x0` without the fix.
- All CLI + SceneGraph suites pass (315 tests), including the existing `FocusBeforeAttach` focus-chain coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)