### PR TITLE
feat(scenegraph): implement Video bufferingBar and retrievingBar fields

### DIFF
--- a/src/extensions/scenegraph/factory/NodeFactory.ts
+++ b/src/extensions/scenegraph/factory/NodeFactory.ts
@@ -100,6 +100,7 @@ import {
     VoiceTextEditBox,
     Timer,
     TrickPlayBar,
+    ProgressBar,
     Video,
     ZoomRowList,
     Animation,
@@ -245,6 +246,8 @@ export class SGNodeFactory {
                 return new Video([], name);
             case SGNodeType.TrickPlayBar.toLowerCase():
                 return new TrickPlayBar([], name);
+            case SGNodeType.ProgressBar.toLowerCase():
+                return new ProgressBar([], name);
             case SGNodeType.Keyboard.toLowerCase():
                 return new Keyboard([], name);
             case SGNodeType.MiniKeyboard.toLowerCase():

--- a/src/extensions/scenegraph/nodes/ProgressBar.ts
+++ b/src/extensions/scenegraph/nodes/ProgressBar.ts
@@ -1,0 +1,26 @@
+import { AAMember } from "brs-engine";
+import { FieldModel } from "../SGTypes";
+import { SGNodeType } from ".";
+import { Group } from "./Group";
+
+export class ProgressBar extends Group {
+    readonly defaultFields: FieldModel[] = [
+        { name: "width", type: "float", value: "0.0" },
+        { name: "height", type: "float", value: "0.0" },
+        { name: "emptyBarBlendColor", type: "color", value: "0xffffffff" },
+        { name: "emptyBarImageUri", type: "uri", value: "" },
+        { name: "filledBarBlendColor", type: "color", value: "0xffffffff" },
+        { name: "filledBarImageUri", type: "uri", value: "" },
+        { name: "trackBlendColor", type: "color", value: "0xffffffff" },
+        { name: "trackImageUri", type: "uri", value: "" },
+        { name: "percentage", type: "integer", value: "0" },
+    ];
+
+    constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.ProgressBar) {
+        super([], name);
+        this.setExtendsType(name, SGNodeType.Group);
+
+        this.registerDefaultFields(this.defaultFields);
+        this.registerInitializedFields(initializedFields);
+    }
+}

--- a/src/extensions/scenegraph/nodes/Video.ts
+++ b/src/extensions/scenegraph/nodes/Video.ts
@@ -38,6 +38,7 @@ import { ScrollingLabel } from "./ScrollingLabel";
 import { Timer } from "./Timer";
 import { rotateTranslation } from "../SGUtil";
 import { TrickPlayBar } from "./TrickPlayBar";
+import { ProgressBar } from "./ProgressBar";
 
 export class Video extends Group {
     readonly defaultFields: FieldModel[] = [
@@ -133,6 +134,8 @@ export class Video extends Group {
     private readonly spinner: BusySpinner;
     private readonly pausedIcon: Poster;
     private readonly trickPlayBar: TrickPlayBar;
+    private readonly bufferingBar: ProgressBar;
+    private readonly retrievingBar: ProgressBar;
     private readonly backgroundOverlay: Poster;
     private lastPressHandled: string;
     private enableUI: boolean;
@@ -182,6 +185,12 @@ export class Video extends Group {
         this.clockText.setValueSilent("text", new BrsString(BrsDevice.getTime()));
         this.setValueSilent("trickPlayBar", this.trickPlayBar);
         this.appendChildToParent(this.trickPlayBar);
+        // Expose the internal default ProgressBar instances so apps can read/customize them.
+        // They are not appended to the render tree; the BusySpinner remains the visual indicator.
+        this.bufferingBar = new ProgressBar();
+        this.retrievingBar = new ProgressBar();
+        this.setValueSilent("bufferingBar", this.bufferingBar);
+        this.setValueSilent("retrievingBar", this.retrievingBar);
         this.showHeader = 0;
         this.showPaused = 0;
         this.showTrickPlay = 0;

--- a/src/extensions/scenegraph/nodes/index.ts
+++ b/src/extensions/scenegraph/nodes/index.ts
@@ -79,6 +79,7 @@ export * from "./TimeGrid";
 export * from "./VoiceTextEditBox";
 export * from "./Timer";
 export * from "./TrickPlayBar";
+export * from "./ProgressBar";
 export * from "./Video";
 export * from "./ZoomRowList";
 export * from "./AnimationBase";
@@ -175,6 +176,7 @@ export enum SGNodeType {
     Audio = "Audio",
     SoundEffect = "SoundEffect",
     TrickPlayBar = "TrickPlayBar",
+    ProgressBar = "ProgressBar",
     Animation = "Animation",
     AnimationBase = "AnimationBase",
     SequentialAnimation = "SequentialAnimation",

--- a/test/extensions/scenegraph/Video.test.js
+++ b/test/extensions/scenegraph/Video.test.js
@@ -1,0 +1,74 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsDevice, BrsString, Int32 } = core;
+
+describe("Video bufferingBar and retrievingBar fields", () => {
+    let originalPostMessage;
+
+    beforeAll(() => {
+        // Video builds labels/posters/spinner from the common: volume; mount it once.
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    beforeEach(() => {
+        // The Video constructor posts control/state messages to the render thread.
+        originalPostMessage = global.postMessage;
+        global.postMessage = jest.fn();
+    });
+
+    afterEach(() => {
+        global.postMessage = originalPostMessage;
+    });
+
+    test("both fields expose a default ProgressBar node instance (not invalid)", () => {
+        const video = SGNodeFactory.createNode("Video");
+        const bufferingBar = video.getValue("bufferingBar");
+        const retrievingBar = video.getValue("retrievingBar");
+
+        expect(bufferingBar).toBeDefined();
+        expect(retrievingBar).toBeDefined();
+        expect(bufferingBar.nodeSubtype).toBe("ProgressBar");
+        expect(retrievingBar.nodeSubtype).toBe("ProgressBar");
+    });
+
+    test("the default ProgressBar sub-fields match the spec", () => {
+        const video = SGNodeFactory.createNode("Video");
+        const bar = video.getValue("bufferingBar");
+
+        expect(bar.getValueJS("width")).toBe(0);
+        expect(bar.getValueJS("height")).toBe(0);
+        expect(bar.getValueJS("emptyBarBlendColor") >>> 0).toBe(0xffffffff);
+        expect(bar.getValueJS("emptyBarImageUri")).toBe("");
+        expect(bar.getValueJS("filledBarBlendColor") >>> 0).toBe(0xffffffff);
+        expect(bar.getValueJS("filledBarImageUri")).toBe("");
+        expect(bar.getValueJS("trackBlendColor") >>> 0).toBe(0xffffffff);
+        expect(bar.getValueJS("trackImageUri")).toBe("");
+        expect(bar.getValueJS("percentage")).toBe(0);
+    });
+
+    test("customizing a bar's fields round-trips", () => {
+        const video = SGNodeFactory.createNode("Video");
+        const bar = video.getValue("retrievingBar");
+
+        bar.setValue("filledBarImageUri", new BrsString("pkg:/images/fill.9.png"));
+        bar.setValue("percentage", new Int32(42));
+
+        expect(bar.getValueJS("filledBarImageUri")).toBe("pkg:/images/fill.9.png");
+        expect(bar.getValueJS("percentage")).toBe(42);
+    });
+
+    test("ProgressBar is wired into the factory as its own subtype", () => {
+        const bar = SGNodeFactory.createNode("ProgressBar");
+        expect(bar).toBeDefined();
+        expect(bar.nodeSubtype).toBe("ProgressBar");
+    });
+
+    afterAll(() => {
+        sgRoot.setVideo();
+    });
+});


### PR DESCRIPTION
## Summary

The `Video` node declared `bufferingBar` and `retrievingBar` as bare `{ type: "node" }` fields with **no instance**, so reading them returned `invalid`. Any app that read or customized them (e.g. `video.bufferingBar.filledBarImageUri = ...`) hit a dot-on-invalid crash.

Per Roku's spec (`scenegraph/media-playback-nodes/video.md`), each of these is a **ProgressBar node** with an *internal default instance* and a fixed set of sub-fields — exactly analogous to how the sibling `trickPlayBar` field exposes a `TrickPlayBar` node instance.

## Changes

- **New node type** `ProgressBar` (`nodes/ProgressBar.ts`), extends `Group`, with `defaultFields` mirroring the spec's internal ProgressBar table (`width`, `height`, `emptyBar*`, `filledBar*`, `track*`, `percentage`).
- **Registered** the type in the `SGNodeType` enum (`nodes/index.ts`) and `SGNodeFactory` switch (`factory/NodeFactory.ts`), so `CreateObject("roSGNode", "ProgressBar")` and XML `<ProgressBar>` resolve.
- **Wired default instances** into `Video` (`nodes/Video.ts`): each field is assigned a `ProgressBar` via `setValueSilent`. The bars are **not** appended to the render tree — the existing `BusySpinner` remains the on-screen loading indicator (node-field fidelity only, no visual bar rendering).

> Note: the Roku doc lists the `percentage` default as `top`, which is a copy/paste error in that table; an integer percentage defaults to `0`.

## Scope

Node-field fidelity only. On-screen rendering of the bars / driving `percentage` from real buffering progress is intentionally **out of scope**; the `bufferingStatus` AA flow is unchanged.

## Testing

- New suite `test/extensions/scenegraph/Video.test.js`: both fields expose a `ProgressBar` instance (not `invalid`), default sub-fields match the spec, customization round-trips, and the factory wiring resolves `ProgressBar`.
- `npm run lint` clean, `npm run prettier:write` applied.
- Full suite green: **133 suites, 1905 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)