### PR TITLE
fix(scenegraph): hug LabelList focus frame instead of overflowing rows

### DIFF
--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -10,6 +10,7 @@ import {
     isBrsString,
     IfDraw2D,
     Rect,
+    RoBitmap,
 } from "brs-engine";
 import { FieldKind, FieldModel } from "../SGTypes";
 import { Poster, SGNodeType } from ".";
@@ -358,14 +359,7 @@ export class ArrayGrid extends Group {
             return;
         }
         this.hasNinePatch = bmp.ninePatch;
-        // A 9-patch focus frame declares, via its content-margin markers, how far the framed item
-        // sits inside it. Honor those margins so the frame hugs the item the way it does on a device;
-        // fall back to the grid's marginX/marginY for frames that don't declare content margins.
-        const margins = bmp.ninePatch ? bmp.getPatchSizes()?.margins : undefined;
-        const left = margins?.left || this.marginX;
-        const right = margins?.right || this.marginX;
-        const top = margins?.top || this.marginY;
-        const bottom = margins?.bottom || this.marginY;
+        const { left, right, top, bottom } = this.focusMargins(bmp);
         let focusRect = bmp.ninePatch
             ? {
                   x: itemRect.x - left,
@@ -376,6 +370,23 @@ export class ArrayGrid extends Group {
             : itemRect;
         const blendColor = this.getValueJS(blendField) as number;
         this.drawImage(bmp, focusRect, 0, opacity, draw2D, blendColor);
+    }
+
+    /**
+     * Per-side outset (in pixels) applied to the item rect before drawing the focus 9-patch frame.
+     * Grids honor the 9-patch's own content-margin markers so the frame hugs large items, falling
+     * back to the grid's marginX/marginY for frames that don't declare content margins. List nodes
+     * (short rows) override this to keep the tighter marginX/marginY outset — the 9-patch's 19px
+     * margins would otherwise make the frame overflow into the neighbouring rows.
+     */
+    protected focusMargins(bmp: RoBitmap): { left: number; right: number; top: number; bottom: number } {
+        const margins = bmp.ninePatch ? bmp.getPatchSizes()?.margins : undefined;
+        return {
+            left: margins?.left || this.marginX,
+            right: margins?.right || this.marginX,
+            top: margins?.top || this.marginY,
+            bottom: margins?.bottom || this.marginY,
+        };
     }
 
     protected renderSectionDivider(

--- a/src/extensions/scenegraph/nodes/LabelList.ts
+++ b/src/extensions/scenegraph/nodes/LabelList.ts
@@ -210,6 +210,12 @@ export class LabelList extends ArrayGrid {
         this.hasNinePatch &&= drawFocus;
     }
 
+    protected focusMargins() {
+        // Short list rows must hug: use the grid's marginX/marginY, not the 9-patch's own 19px
+        // content margins (which would make the focus frame overflow into the neighbouring rows).
+        return { left: this.marginX, right: this.marginX, top: this.marginY, bottom: this.marginY };
+    }
+
     protected renderIcon(bmp: RoBitmap, rect: Rect, opacity: number, draw2D?: IfDraw2D, color?: number) {
         const iconY = rect.y + (rect.height / 2 - bmp.height / 2);
         const iconRect = { ...rect, y: iconY, width: bmp.width, height: bmp.height };

--- a/src/extensions/scenegraph/nodes/MarkupList.ts
+++ b/src/extensions/scenegraph/nodes/MarkupList.ts
@@ -157,4 +157,10 @@ export class MarkupList extends ArrayGrid {
         }
         this.updateRect(rect, displayRows, itemSize);
     }
+
+    protected focusMargins() {
+        // Like LabelList, a MarkupList is a short-row list: use the grid's marginX/marginY, not the
+        // 9-patch's own 19px content margins, so the focus frame hugs the row instead of overflowing.
+        return { left: this.marginX, right: this.marginX, top: this.marginY, bottom: this.marginY };
+    }
 }

--- a/test/extensions/scenegraph/ListFocusFeedback.test.js
+++ b/test/extensions/scenegraph/ListFocusFeedback.test.js
@@ -1,0 +1,51 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsDevice, Int32 } = core;
+
+describe("LabelList focus feedback rendering", () => {
+    beforeAll(() => {
+        // The default focus bitmap (common:/images/focus_list.9.png) lives in the common: volume.
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    // Regression for #970: a short list row must hug the focus frame using the grid's marginX/marginY,
+    // NOT the 9-patch's own 19px content margins (which made the frame overflow into neighbouring rows).
+    test("hugs the short row via marginX/marginY, not the 9-patch content margins, and keeps the blend color", () => {
+        const list = SGNodeFactory.createNode("LabelList"); // focus_list.9.png, hasNinePatch
+        const purple = 0x7b2ff7ff | 0;
+        list.setValue("focusBitmapBlendColor", new Int32(purple));
+
+        const calls = [];
+        const draw2D = {
+            drawNinePatch: (bmp, rect, rgba, opacity) => calls.push({ rect: { ...rect }, rgba }),
+        };
+
+        // Default LabelList itemSize height is short (48px HD / 72px FHD).
+        const itemRect = { x: 100, y: 100, width: 340, height: 48 };
+        list.renderFocus(itemRect, 1, true, draw2D);
+
+        expect(calls).toHaveLength(1);
+        // Blend color still reaches the draw (shared with the grid path).
+        expect(calls[0].rgba).toBe(list.getValueJS("focusBitmapBlendColor"));
+
+        // Outset is the grid's marginX/marginY, not the 9-patch's 19px content margins.
+        const mx = list.marginX;
+        const my = list.marginY;
+        // The reported regression was vertical (too-tall frame): marginY is tighter than the
+        // 9-patch's 19px content margin, so the row hugs instead of overflowing its neighbours.
+        expect(my).toBeLessThan(19);
+        expect(calls[0].rect.x).toBe(itemRect.x - mx);
+        expect(calls[0].rect.y).toBe(itemRect.y - my);
+        expect(calls[0].rect.width).toBe(itemRect.width + mx * 2);
+        expect(calls[0].rect.height).toBe(itemRect.height + my * 2);
+    });
+});


### PR DESCRIPTION
## Problem

Regression from #970. The focus frame on `LabelList` (and nodes extending it) became too tall — it overflowed into the neighbouring rows instead of hugging the focused item.

| Roku (target) | Simulator (before this PR) |
| --- | --- |
| focus box ≈ row height | focus box ~1.8× the row, overlapping neighbours |

## Root cause

#970 changed `ArrayGrid.renderFocus` to outset the focus 9-patch by the **bitmap's own content margins** (`RoBitmap.getPatchSizes().margins`) instead of the grid's `marginX`/`marginY`. The default focus bitmaps (`focus_list.9.png`, `focus_grid.9.png`) declare **19px content margins on all sides**.

- For **grids** (RowList items ~300px) a 19px frame is slim — the intended fix.
- For the **list family** the rows are short (`LabelList` `itemSize` = `[340,48]` HD / `[510,72]` FHD, rows spaced `itemSize.h + 1`). A 19px top+bottom outset made the frame `48 + 38 = 86px` (HD), overflowing the neighbouring rows. Pre-#970 the outset was `marginY` (4px HD / 6px FHD), giving a tight `56px` frame that matches a real Roku.

## Fix

- **`ArrayGrid.ts`** — extract the outset math into a protected, overridable `focusMargins(bmp)`. Base behavior (9-patch content margins → grids) is unchanged, and #970's `focusBitmapBlendColor` tint is preserved for everyone.
- **`LabelList.ts`** — override `focusMargins` to restore the tighter `marginX`/`marginY` outset. Covers **CheckList** and **RadioButtonList** via inheritance.
- **`MarkupList.ts`** — same override (also a short-row list using `focus_list.9.png`).

Grids (RowList, MarkupGrid, PosterGrid, TimeGrid, ZoomRowList) inherit the base and are unaffected.

## Tests

- New `test/extensions/scenegraph/ListFocusFeedback.test.js` — captures the drawn 9-patch rect and asserts the list frame uses `marginX`/`marginY` (not 19px) and that the blend color still reaches the draw.
- `GridFocusFeedback.test.js` stays green (RowList uses the base 9-patch behavior).
- `test/extensions/scenegraph` + `test/cli` suites pass (two pre-existing `r2d2-bitmaps` ECP failures are environmental — port 8060 already bound — and reproduce on the base tree).
- `npm run lint` clean; `npm run prettier:write` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)