### PR TITLE
fix(scenegraph): Only prevent duplicate fields when those are defined in XML

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -151,6 +151,15 @@ Key pieces:
 
 External consumers can also register node types at runtime without editing the factory via `SGNodeFactory.addNodeTypes([["mynode", (name) => new MyNode([], name)]])`.
 
+### XML `<interface>` field redeclaration — system vs. XML-defined (`addFields`)
+
+When `addFields` (in `factory/NodeFactory.ts`) builds a custom component's fields, a `<field>` whose name already exists on the node is handled by **who defined the existing field**, not merely that it collides:
+
+- A field inherited from a **built-in base type** (`Group`, `Label`, …) is a **system** field — created by `registerDefaultFields` with the `Field` `system` flag set (`field.isSystem()`). Roku lets a component **redeclare** such a field: the redeclaration re-applies the XML default/type and `addFields` continues, so a field declared *after* it is still added. Do **not** treat this as a duplicate — the guard is `else if (field && !field.isSystem())`.
+- A field defined in an **ancestor XML component's** `<interface>` is *not* a system field (added via `addNodeField`, `system=false`). Redeclaring it **is** a genuine duplicate: `addFields` writes the `Attempt to add duplicate field "…"` warning to `BrsDevice.stderr` and **returns early**, so the trailing fields in that component are never added (they read back as `invalid`).
+
+Because `addNodeField` is a no-op when the field already exists, a redeclared system field keeps its existing `Field` instance; the XML default is applied by the subsequent `setValueSilent`. Regression coverage: the `duplicate-system-field-app` fixture + test in `test/cli/cli.test.js` (system-field redeclaration applies the new default and adds the trailing field; an ancestor-XML-field redeclaration still warns and drops the trailing field).
+
 ### Stack-overflow hot paths (fragile — read before touching)
 
 Two distinct SceneGraph code paths can recurse until the JS call stack overflows; both surface to BrightScript as `roSGNode.Set (unhandled exception): "...": Maximum call stack size exceeded`. They are unrelated — diagnose which one before "fixing" the other. A real overflow's BrightScript backtrace is misleading (it often shows a single frame, because `Field.executeCallbacks` pops stack frames as the error unwinds); capture the **native JS stack** mid-recursion (a temporary depth tripwire dumping `new Error().stack` via `BrsDevice.stderr`) to see the real cycle.

--- a/src/extensions/scenegraph/factory/NodeFactory.ts
+++ b/src/extensions/scenegraph/factory/NodeFactory.ts
@@ -789,7 +789,7 @@ function addFields(interpreter: Interpreter, node: Node, typeDef: ComponentDefin
                     ? getBrsValueFromFieldType(fieldValue.type, fieldValue.value)
                     : undefined;
                 node.replaceField(fieldName, fieldValue.type, defaultValue, fieldValue.alwaysNotify === "true");
-            } else if (field) {
+            } else if (field && !field.isSystem()) {
                 let msg = `warning,Error creating XML component ${node.nodeSubtype}\n`;
                 msg += `-- Attempt to add duplicate field "${fieldName}" to RokuML component "${node.nodeSubtype}"\n`;
                 msg += `---- Extends node type "${typeDef.extends}" already has a field named ${fieldName}\n`;

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -350,6 +350,33 @@ describe("cli", () => {
         ]);
     }, 10000);
 
+    it("Allows redeclaring an inherited system field but still blocks XML duplicate fields", async () => {
+        let command = ["node", brsCliPath, "-r duplicate-system-field-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout, stderr } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        // A field inherited from a built-in base type (a "system" field) may be redeclared in
+        // XML: the redeclared default is re-applied (opacity -> 0.5) and any field declared after
+        // it (customField) is still added. Before the fix the duplicate-field guard fired on the
+        // inherited "opacity", aborting addFields so both were lost.
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "=== Duplicate System Field Repro ===",
+            "opacity =  0.5",
+            "customField = hello",
+            "sharedField = base",
+            "afterField type = Invalid",
+            "=== Duplicate System Field Repro Complete ===",
+            "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+        // Redeclaring the inherited system field must NOT warn...
+        expect(stderr).not.toContain('duplicate field "opacity"');
+        // ...but redeclaring a field defined in an ancestor XML component still must.
+        expect(stderr).toContain('Attempt to add duplicate field "sharedField" to RokuML component "XmlChildComp"');
+    }, 10000);
+
     it("List item component can read its parent list during init()", async () => {
         let command = ["node", brsCliPath, "-r list-item-parent-app", "source/main.brs", "-c 0"].join(" ");
 

--- a/test/cli/resources/duplicate-system-field-app/components/SystemFieldGroup.xml
+++ b/test/cli/resources/duplicate-system-field-app/components/SystemFieldGroup.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Redeclares "opacity", a system field inherited from the built-in Group base type,
+    then declares a brand-new "customField". Roku allows redeclaring an inherited
+    system field (it just re-applies the default), so addFields must NOT abort here:
+    both the redeclared opacity default (0.5) and the trailing customField must apply.
+-->
+<component name="SystemFieldGroup" extends="Group">
+    <interface>
+        <field id="opacity" type="float" value="0.5" />
+        <field id="customField" type="string" value="hello" />
+    </interface>
+</component>

--- a/test/cli/resources/duplicate-system-field-app/components/XmlBaseComp.xml
+++ b/test/cli/resources/duplicate-system-field-app/components/XmlBaseComp.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    An XML component that declares "sharedField" in its own interface. A derived XML
+    component that redeclares this (non-system) field must still trigger the duplicate
+    field guard.
+-->
+<component name="XmlBaseComp" extends="Group">
+    <interface>
+        <field id="sharedField" type="string" value="base" />
+    </interface>
+</component>

--- a/test/cli/resources/duplicate-system-field-app/components/XmlChildComp.xml
+++ b/test/cli/resources/duplicate-system-field-app/components/XmlChildComp.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Redeclares "sharedField", which is defined in the ANCESTOR XML component XmlBaseComp
+    (not a built-in system field). This is still a genuine duplicate: the guard fires,
+    addFields aborts, and the trailing "afterField" is never added (stays invalid).
+-->
+<component name="XmlChildComp" extends="XmlBaseComp">
+    <interface>
+        <field id="sharedField" type="string" value="child" />
+        <field id="afterField" type="string" value="never" />
+    </interface>
+</component>

--- a/test/cli/resources/duplicate-system-field-app/manifest
+++ b/test/cli/resources/duplicate-system-field-app/manifest
@@ -1,0 +1,4 @@
+title=Duplicate System Field Test
+major_version=1
+minor_version=0
+build_version=0

--- a/test/cli/resources/duplicate-system-field-app/source/main.brs
+++ b/test/cli/resources/duplicate-system-field-app/source/main.brs
@@ -1,0 +1,20 @@
+sub Main()
+    print "=== Duplicate System Field Repro ==="
+
+    ' Redeclaring a field inherited from a built-in base type (a "system" field) is
+    ' allowed on a real Roku: the XML declaration re-applies its default and any fields
+    ' declared after it are still added. Before the fix, the duplicate-field guard fired
+    ' for the inherited "opacity" field, aborting addFields early so both the new default
+    ' and the trailing "customField" were lost.
+    sysNode = CreateObject("roSGNode", "SystemFieldGroup")
+    print "opacity = "; sysNode.opacity
+    print "customField = "; sysNode.customField
+
+    ' Redeclaring a field defined in an ANCESTOR XML component is still a duplicate error:
+    ' the guard must remain for non-system fields, so "afterField" is never added.
+    xmlNode = CreateObject("roSGNode", "XmlChildComp")
+    print "sharedField = "; xmlNode.sharedField
+    print "afterField type = "; type(xmlNode.afterField)
+
+    print "=== Duplicate System Field Repro Complete ==="
+end sub


### PR DESCRIPTION
Roku allows you to redefine fields that are intrinsic from the extended core nodes, so you can set the default value for a custom component, or add event handlers.