### PR TITLE
feat(api): enable SceneGraph extension when running a single `brs` file with `roSGNode` or `roSGScreen`

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -47,6 +47,7 @@ import {
     setupDeepLink,
     getModelType,
     isMountedExt,
+    enableSceneGraphExtension,
 } from "./package";
 import {
     subscribeDisplay,
@@ -576,6 +577,7 @@ function loadSourceCode(fileName: string, fileData: any) {
     const reader = new FileReader();
     reader.onload = function (_) {
         if (typeof this.result === "string") {
+            const sourceCode = this.result;
             manifestMap.clear();
             manifestMap.set("title", "BRS File");
             manifestMap.set("major_version", "1");
@@ -584,10 +586,14 @@ function loadSourceCode(fileName: string, fileData: any) {
             manifestMap.set("splash_min_time", "0");
             currentApp.title = `BrightScript file: ${fileName}`;
             paths.length = 0;
-            source.push(this.result);
+            source.push(sourceCode);
             paths.push({ url: `source/${fileName}`, id: 0, type: "source" });
             clearDisplay(true);
             Atomics.store(sharedArray, DataType.EVE, isMountedExt() ? 1 : 0);
+            const lowSource = sourceCode.toLowerCase();
+            if (lowSource.includes("rosgnode") || lowSource.includes("rosgscreen")) {
+                enableSceneGraphExtension();
+            }
             runApp(createPayload(Date.now()));
         } else {
             apiException("error", `[api] Invalid data type in ${fileName}: ${typeof this.result}`);

--- a/src/api/package.ts
+++ b/src/api/package.ts
@@ -148,13 +148,20 @@ export async function loadAppZip(fileName: string, file: ArrayBuffer, callback: 
     // a component .xml; for an encrypted package the component .xml/.brs are folded into the blob and
     // stripped, so we rely on the preserved components/ folder marker instead.
     const hasSceneGraph = isEncrypted ? hasComponentsFolder : hasSGComponents;
-    if (hasSceneGraph && deviceData.extensions?.has(SupportedExtension.SceneGraph)) {
-        extensions.push(SupportedExtension.SceneGraph);
+    if (hasSceneGraph) {
+        enableSceneGraphExtension();
     }
     // Mount external storage if present
     notifyAll("mount", extMounted ? 1 : 0);
     // Create and return the payload
     callback(createPayload(launchTime));
+}
+
+export function enableSceneGraphExtension() {
+    const sgExt = SupportedExtension.SceneGraph;
+    if (deviceData.extensions?.has(sgExt) && !extensions.includes(sgExt)) {
+        extensions.push(sgExt);
+    }
 }
 
 /**


### PR DESCRIPTION
Enable running a single brs file with the SceneGraph enabled.