### PR TITLE
fix(scenegraph): Issues rendering Task-loaded content in grids

### DIFF
--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -114,7 +114,9 @@ export class ArrayGrid extends Group {
         this.registerDefaultFields(this.defaultFields);
         this.registerInitializedFields(initializedFields);
 
-        this.setValueSilent("content", new ContentNode());
+        // Roku leaves the `content` node field invalid until the app assigns it; apps rely on
+        // `content = invalid` to detect "not loaded yet" (e.g. SGDEX's lazy content managers).
+        // Do NOT seed an empty ContentNode here — all readers guard with `instanceof ContentNode`.
         if (this.resolution === "FHD") {
             this.marginX = 36;
             this.marginY = 6;

--- a/src/extensions/scenegraph/nodes/ContentNode.ts
+++ b/src/extensions/scenegraph/nodes/ContentNode.ts
@@ -14,6 +14,7 @@ import { Node } from "./Node";
 import type { Field } from "./Field";
 import { FieldKind, FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";
+import { sgRoot } from "../SGRoot";
 import { toAssociativeArray } from "../factory/Serializer";
 
 export class ContentNode extends Node {
@@ -330,4 +331,20 @@ export class ContentNode extends Node {
             }
         },
     });
+
+    /**
+     * Marks this node as dirty and notifies the SceneGraph root.
+     */
+    protected makeDirty() {
+        this.changed = true;
+        // Propagate the dirty flag up to the content root so an ancestor ArrayGrid/TimeGrid
+        // re-parses its model when a descendant ContentNode changes. This must happen on any
+        // thread — in particular for mutations applied on the render thread on behalf of a Task
+        // (rendezvous), where inTaskThread() is false but the parent grid still needs to refresh.
+        if (this.parent instanceof Node) {
+            const root = this.findRootNode();
+            root.changed = true;
+        }
+        sgRoot.makeDirty();
+    }
 }

--- a/src/extensions/scenegraph/nodes/Field.ts
+++ b/src/extensions/scenegraph/nodes/Field.ts
@@ -27,6 +27,7 @@ import {
     isStringComp,
     RuntimeError,
     DebugMode,
+    Uninitialized,
 } from "brs-engine";
 import { Node } from "./Node";
 import { RoSGNodeEvent } from "../events/RoSGNodeEvent";
@@ -476,7 +477,22 @@ export class Field {
                 });
                 try {
                     if (signature.args.length > 0) {
-                        subInterpreter.environment.define(Scope.Function, signature.args[0].name.text, event);
+                        // Roku invokes an observer callback with only the event as its first
+                        // argument; any remaining declared parameters fall back to their default
+                        // values. Bind them all here — previously only the first parameter was
+                        // defined, leaving later ones <uninitialized> (e.g. a timer `fire`
+                        // callback declared as `sub cb(event, opt = true)` crashed reading `opt`).
+                        for (const [index, param] of signature.args.entries()) {
+                            let paramValue: BrsType;
+                            if (index === 0) {
+                                paramValue = event;
+                            } else if (param.defaultValue) {
+                                paramValue = subInterpreter.evaluate(param.defaultValue);
+                            } else {
+                                paramValue = Uninitialized.Instance;
+                            }
+                            subInterpreter.environment.define(Scope.Function, param.name.text, paramValue);
+                        }
                         impl(subInterpreter, event);
                     } else {
                         impl(subInterpreter);

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -1598,11 +1598,7 @@ export class Node extends RoSGNode implements BrsValue {
      */
     protected makeDirty() {
         this.changed = true;
-        // Propagate the dirty flag up to the content root so an ancestor ArrayGrid/TimeGrid
-        // re-parses its model when a descendant ContentNode changes. This must happen on any
-        // thread — in particular for mutations applied on the render thread on behalf of a Task
-        // (rendezvous), where inTaskThread() is false but the parent grid still needs to refresh.
-        if (this.parent instanceof Node) {
+        if (sgRoot.inTaskThread() && this.parent instanceof Node) {
             const root = this.findRootNode();
             root.changed = true;
         }

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -1598,7 +1598,11 @@ export class Node extends RoSGNode implements BrsValue {
      */
     protected makeDirty() {
         this.changed = true;
-        if (sgRoot.inTaskThread() && this.parent instanceof Node) {
+        // Propagate the dirty flag up to the content root so an ancestor ArrayGrid/TimeGrid
+        // re-parses its model when a descendant ContentNode changes. This must happen on any
+        // thread — in particular for mutations applied on the render thread on behalf of a Task
+        // (rendezvous), where inTaskThread() is false but the parent grid still needs to refresh.
+        if (this.parent instanceof Node) {
             const root = this.findRootNode();
             root.changed = true;
         }

--- a/src/extensions/scenegraph/nodes/RowList.ts
+++ b/src/extensions/scenegraph/nodes/RowList.ts
@@ -77,6 +77,10 @@ export class RowList extends ArrayGrid {
     protected readonly rowItemComps: Group[][] = [[]];
     protected readonly rowFocus: number[];
     protected readonly rowScrollOffset: number[] = []; // Track scroll offset per row for floating focus
+    // Identity of the content node last parsed by refreshContent. Used to reset per-row horizontal
+    // focus/scroll only when a NEW content tree is assigned — a plain re-parse (triggered whenever a
+    // descendant ContentNode is marked changed) must preserve each row's focused column/scroll.
+    private parsedContentNode?: ContentNode;
     private readonly titleHeight: number;
 
     constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.RowList) {
@@ -781,7 +785,16 @@ export class RowList extends ArrayGrid {
         this.content.length = 0;
         const content = this.getValue("content");
         if (!(content instanceof ContentNode)) {
+            this.parsedContentNode = undefined;
             return;
+        }
+        // Reset per-row horizontal focus/scroll only when a genuinely new content tree is assigned.
+        // A plain re-parse (any descendant ContentNode marked changed) must preserve them, otherwise
+        // horizontal navigation is wiped back to column 0 on the next render.
+        if (content !== this.parsedContentNode) {
+            this.parsedContentNode = content;
+            this.rowFocus.length = 0;
+            this.rowScrollOffset.length = 0;
         }
         const rows = this.getContentChildren(content);
         let itemIndex = 0;
@@ -790,8 +803,8 @@ export class RowList extends ArrayGrid {
             if (content.length === 0) {
                 continue;
             }
-            this.rowFocus[itemIndex] = 0;
-            this.rowScrollOffset[itemIndex] = 0; // Initialize scroll offset
+            this.rowFocus[itemIndex] ??= 0;
+            this.rowScrollOffset[itemIndex] ??= 0; // Initialize scroll offset (preserve existing)
             itemIndex++;
             this.content.push(row);
         }

--- a/src/extensions/scenegraph/nodes/TimeGrid.ts
+++ b/src/extensions/scenegraph/nodes/TimeGrid.ts
@@ -260,7 +260,7 @@ export class TimeGrid extends ArrayGrid {
             // Reuse the cached parse while the channel's child count is unchanged — only re-parse
             // (and re-allocate its gap nodes) a channel that actually gained/lost programs.
             let parse = this.channelParseCache.get(channelNode);
-            if (!parse || parse.childCount !== childCount) {
+            if (parse?.childCount !== childCount) {
                 parse = this.parseChannel(channelNode, childCount, fillGaps, noDataText);
                 this.channelParseCache.set(channelNode, parse);
             }

--- a/src/extensions/scenegraph/nodes/TimeGrid.ts
+++ b/src/extensions/scenegraph/nodes/TimeGrid.ts
@@ -128,6 +128,12 @@ export class TimeGrid extends ArrayGrid {
     protected channelIndex: number = 0;
     protected viewStartTime: number = 0;
     protected inChannelInfoColumn: boolean = false;
+    // True until focus has been resolved to a real program. The initial focus is often set while
+    // the focused channel is still empty (SGDEX assigns `content` before its rows lazy-load their
+    // programs), leaving focus on a placeholder program 0. Once the channel gains programs we snap
+    // focus to the program at the current view time so the highlight is visible and the grid scrolls
+    // to it — matching Roku, instead of leaving focus on an off-screen program until the user moves.
+    protected initialFocusPending: boolean = true;
 
     // Per-render layout caches (read by navigation between renders)
     protected gridX: number = 0;
@@ -162,6 +168,32 @@ export class TimeGrid extends ArrayGrid {
         this.programIndexByChannel[0] = 0;
     }
 
+    /**
+     * On gaining focus, (re)emit the focus event so observers fire — matching Roku, where
+     * focusing the grid notifies channelFocused/programFocused (both alwaysNotify) even
+     * before content has loaded. SGDEX's TimeGrid content manager relies on this to start
+     * lazy content loading when `content` was assigned before the view was shown.
+     *
+     * The base ArrayGrid.setNodeFocus only re-focuses when `itemFocused >= 0`, but TimeGrid
+     * tracks channel/program focus separately and never sets `itemFocused` (it stays -1), so
+     * without this override an empty TimeGrid stays silent on focus and never triggers loading.
+     */
+    setNodeFocus(focusOn: boolean): boolean {
+        const focus = super.setNodeFocus(focusOn);
+        if (focus) {
+            const ch = this.channelIndex;
+            const prog = this.programIndexByChannel[ch] ?? 0;
+            if (this.channels.length > 0) {
+                this.focusCell(ch, prog);
+            } else {
+                // No content yet: still notify so observers (e.g. the lazy loader) fire.
+                super.setValue("channelFocused", new Int32(ch));
+                super.setValue("programFocused", new Int32(prog));
+            }
+        }
+        return focus;
+    }
+
     setValue(index: string, value: BrsType, alwaysNotify?: boolean, kind?: FieldKind) {
         const fieldName = index.toLowerCase();
         if ((fieldName === "jumptochannel" || fieldName === "animatetochannel") && isNumberComp(value)) {
@@ -184,6 +216,9 @@ export class TimeGrid extends ArrayGrid {
             super.setValue(index, value, alwaysNotify, kind);
             this.scrollToTime(jsValueOf(value) as number);
             return;
+        } else if (fieldName === "content") {
+            // A newly assigned content tree needs its focus (re)resolved once programs are present.
+            this.initialFocusPending = true;
         }
         // `content` falls through to ArrayGrid.setValue, which calls refreshContent()
         // (overridden below) then setFocusedItem(0) (overridden below).
@@ -240,6 +275,13 @@ export class TimeGrid extends ArrayGrid {
         if (this.viewStartTime === 0) {
             const cst = (this.getValueJS("contentStartTime") as number) ?? 0;
             this.viewStartTime = cst > 0 ? cst : this.nowEpoch();
+        }
+        // If focus is still on the placeholder (content was assigned while the focused channel was
+        // empty), now that its programs have loaded, snap focus to the program at the view time.
+        // This scrolls the grid to the focused program and makes its highlight visible, instead of
+        // leaving focus on program 0 (which usually starts before the visible window).
+        if (this.initialFocusPending && (this.programs[this.channelIndex]?.length ?? 0) > 0) {
+            this.focusCell(this.channelIndex, this.programIndexAtTime(this.channelIndex, this.viewStartTime));
         }
     }
 
@@ -302,14 +344,23 @@ export class TimeGrid extends ArrayGrid {
         this.focusCell(ch, this.programIndexAtTime(ch, this.viewStartTime));
     }
 
-    /** Central focus mutator: updates channel/program focus and fires the read-only events. */
-    protected focusCell(newChannel: number, newProgram: number) {
+    /**
+     * Central focus mutator: updates channel/program focus and fires the read-only events.
+     * @param scroll When true (default, horizontal moves and jumps) the time window scrolls to
+     *   reveal the focused program. Vertical moves pass false to keep the window fixed — Roku does
+     *   not scroll the grid horizontally when changing rows.
+     */
+    protected focusCell(newChannel: number, newProgram: number, scroll: boolean = true) {
         if (this.channels.length === 0) {
             return;
         }
         newChannel = this.clamp(newChannel, 0, this.channels.length - 1);
         const progs = this.programs[newChannel] ?? [];
         newProgram = progs.length > 0 ? this.clamp(newProgram, 0, progs.length - 1) : 0;
+        if (progs.length > 0) {
+            // Focus is now on a real program; no longer a placeholder awaiting content.
+            this.initialFocusPending = false;
+        }
         const oldChannel = this.channelIndex;
         const oldProgram = this.programIndexByChannel[oldChannel] ?? 0;
         if (oldProgram !== newProgram || oldChannel !== newChannel) {
@@ -327,7 +378,9 @@ export class TimeGrid extends ArrayGrid {
         super.setValue("programFocusedDetails", brsValueOf({ focusChannelIndex: newChannel, focusIndex: newProgram }));
         super.setValue("channelFocused", new Int32(newChannel));
         super.setValue("programFocused", new Int32(newProgram));
-        this.ensureProgramVisible(newChannel, newProgram);
+        if (scroll) {
+            this.ensureProgramVisible(newChannel, newProgram);
+        }
         this.updateTopRow();
         this.isDirty = true;
     }
@@ -430,8 +483,12 @@ export class TimeGrid extends ArrayGrid {
             return false;
         }
         const curProg = this.programIndexByChannel[this.channelIndex] ?? 0;
-        const focusTime = this.programStart[this.channelIndex]?.[curProg] ?? this.viewStartTime;
-        this.focusCell(next, this.programIndexAtTime(next, focusTime));
+        const curStart = this.programStart[this.channelIndex]?.[curProg] ?? this.viewStartTime;
+        // Anchor to the focused program's start, clamped into the visible window, so the program
+        // airing at that time in the next channel is always at least partially on screen (the
+        // focused program often starts before the left edge). Keep the window fixed (scroll=false).
+        const anchorTime = this.clamp(curStart, this.viewStartTime, this.viewStartTime + this.getDurationSec());
+        this.focusCell(next, this.programIndexAtTime(next, anchorTime), false);
         return true;
     }
 

--- a/src/extensions/scenegraph/nodes/TimeGrid.ts
+++ b/src/extensions/scenegraph/nodes/TimeGrid.ts
@@ -18,6 +18,15 @@ import { Font } from "./Font";
 import { sgRoot } from "../SGRoot";
 import { brsValueOf, jsValueOf } from "../factory/Serializer";
 
+/** Cached parse of one channel's programs (see TimeGrid.channelParseCache). */
+interface ChannelParse {
+    childCount: number;
+    programs: ContentNode[];
+    starts: number[];
+    durations: number[];
+    gaps: boolean[];
+}
+
 /**
  * TimeGrid — Electronic Program Guide (EPG) node.
  *
@@ -123,6 +132,12 @@ export class TimeGrid extends ArrayGrid {
     protected readonly programDuration: number[][] = [];
     protected readonly gapFlags: boolean[][] = [];
     protected readonly programIndexByChannel: number[] = [];
+    // Cache of each channel's parsed program model, keyed by the channel ContentNode. refreshContent
+    // reuses a channel's parse while its child count is unchanged, so re-parsing (and the gap-node
+    // allocation it does) only happens for channels that actually gained programs — not the whole
+    // tree on every content change. Without this, incrementally loading N channels re-parses the
+    // entire tree N times (O(N²) allocation), which OOMs V8 on large EPG data.
+    private readonly channelParseCache = new WeakMap<ContentNode, ChannelParse>();
 
     // Navigation / time-domain state
     protected channelIndex: number = 0;
@@ -241,35 +256,20 @@ export class TimeGrid extends ArrayGrid {
         const noDataText = (this.getValueJS("channelNoDataText") as string) ?? "No Data Available";
         const channelNodes = this.getContentChildren(content);
         for (const [ch, channelNode] of channelNodes.entries()) {
-            const programNodes = this.getContentChildren(channelNode);
-            const progs: ContentNode[] = [];
-            const starts: number[] = [];
-            const durs: number[] = [];
-            const gaps: boolean[] = [];
-            let prevEnd: number | null = null;
-            for (const program of programNodes) {
-                const start = this.readEpoch(program, "PLAYSTART");
-                const dur = this.readSeconds(program, "PLAYDURATION");
-                if (fillGaps && prevEnd !== null && start > prevEnd) {
-                    const gapNode = new ContentNode("_nodata_");
-                    gapNode.setValueSilent("title", new BrsString(noDataText));
-                    progs.push(gapNode);
-                    starts.push(prevEnd);
-                    durs.push(start - prevEnd);
-                    gaps.push(true);
-                }
-                progs.push(program);
-                starts.push(start);
-                durs.push(dur);
-                gaps.push(false);
-                prevEnd = start + dur;
+            const childCount = channelNode.getNodeChildren().length;
+            // Reuse the cached parse while the channel's child count is unchanged — only re-parse
+            // (and re-allocate its gap nodes) a channel that actually gained/lost programs.
+            let parse = this.channelParseCache.get(channelNode);
+            if (!parse || parse.childCount !== childCount) {
+                parse = this.parseChannel(channelNode, childCount, fillGaps, noDataText);
+                this.channelParseCache.set(channelNode, parse);
             }
             this.content.push(channelNode);
             this.channels.push(channelNode);
-            this.programs.push(progs);
-            this.programStart.push(starts);
-            this.programDuration.push(durs);
-            this.gapFlags.push(gaps);
+            this.programs.push(parse.programs);
+            this.programStart.push(parse.starts);
+            this.programDuration.push(parse.durations);
+            this.gapFlags.push(parse.gaps);
             this.programIndexByChannel[ch] ??= 0;
         }
         if (this.viewStartTime === 0) {
@@ -283,6 +283,39 @@ export class TimeGrid extends ArrayGrid {
         if (this.initialFocusPending && (this.programs[this.channelIndex]?.length ?? 0) > 0) {
             this.focusCell(this.channelIndex, this.programIndexAtTime(this.channelIndex, this.viewStartTime));
         }
+    }
+
+    /** Parses one channel's program children into the cached model (with optional gap fill). */
+    private parseChannel(
+        channelNode: ContentNode,
+        childCount: number,
+        fillGaps: boolean,
+        noDataText: string
+    ): ChannelParse {
+        const programNodes = this.getContentChildren(channelNode);
+        const programs: ContentNode[] = [];
+        const starts: number[] = [];
+        const durations: number[] = [];
+        const gaps: boolean[] = [];
+        let prevEnd: number | null = null;
+        for (const program of programNodes) {
+            const start = this.readEpoch(program, "PLAYSTART");
+            const dur = this.readSeconds(program, "PLAYDURATION");
+            if (fillGaps && prevEnd !== null && start > prevEnd) {
+                const gapNode = new ContentNode("_nodata_");
+                gapNode.setValueSilent("title", new BrsString(noDataText));
+                programs.push(gapNode);
+                starts.push(prevEnd);
+                durations.push(start - prevEnd);
+                gaps.push(true);
+            }
+            programs.push(program);
+            starts.push(start);
+            durations.push(dur);
+            gaps.push(false);
+            prevEnd = start + dur;
+        }
+        return { childCount, programs, starts, durations, gaps };
     }
 
     /** Reads a unix-epoch (seconds) field, tolerating either an integer or roDateTime value. */
@@ -311,18 +344,26 @@ export class TimeGrid extends ArrayGrid {
         return Number.isFinite(duration) && duration > 0 ? duration : 9000;
     }
 
-    /** Index of the last program in `ch` starting at or before `time` (clamped to range). */
+    /**
+     * Index of the last program in `ch` starting at or before `time` (clamped to range).
+     * `programStart[ch]` is ascending, so this is a binary search — called per channel every
+     * render to skip straight to the first visible program (avoids scanning off-screen programs).
+     */
     protected programIndexAtTime(ch: number, time: number): number {
         const starts = this.programStart[ch] ?? [];
-        if (starts.length === 0) {
+        if (starts.length === 0 || starts[0] > time) {
             return 0;
         }
+        let lo = 0;
+        let hi = starts.length - 1;
         let idx = 0;
-        for (let i = 0; i < starts.length; i++) {
-            if (starts[i] <= time) {
-                idx = i;
+        while (lo <= hi) {
+            const mid = (lo + hi) >> 1;
+            if (starts[mid] <= time) {
+                idx = mid;
+                lo = mid + 1;
             } else {
-                break;
+                hi = mid - 1;
             }
         }
         return idx;
@@ -783,7 +824,15 @@ export class TimeGrid extends ArrayGrid {
 
             const progs = this.programs[ch] ?? [];
             const focusedProgram = this.programIndexByChannel[ch] ?? 0;
-            for (let p = 0; p < progs.length; p++) {
+            // Start at the first program touching the visible window (binary search) instead of
+            // scanning every off-screen program each frame; include the focused cell so its
+            // highlight always draws even if it starts just before the left edge.
+            let startP = this.programIndexAtTime(ch, this.viewStartTime);
+            if (ch === this.channelIndex) {
+                startP = Math.min(startP, focusedProgram);
+            }
+            startP = Math.max(0, startP);
+            for (let p = startP; p < progs.length; p++) {
                 const pStart = this.programStart[ch][p];
                 const pDuration = this.programDuration[ch][p];
                 const cellX = this.gridX + (pStart - this.viewStartTime) * secToPx;

--- a/test/extensions/scenegraph/RowList.test.js
+++ b/test/extensions/scenegraph/RowList.test.js
@@ -4,7 +4,7 @@ const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
 const core = require("../../../packages/node/bin/brs.node.js");
 
 const { SGNodeFactory, sgRoot } = scenegraph;
-const { BrsDevice, BrsString } = core;
+const { BrsDevice, BrsString, Int32, RoArray } = core;
 
 /**
  * Builds a root → rows → items ContentNode tree.
@@ -63,5 +63,27 @@ describe("RowList key handling", () => {
         expect(list.getValueJS("itemFocused")).toBe(0);
         expect(list.handleKey("up", true)).toBe(true);
         expect(list.getValueJS("itemFocused")).toBe(2);
+    });
+
+    test("a content re-parse preserves per-row column focus (regression: horizontal navigation)", () => {
+        // Regression: ContentNode.makeDirty now marks the content root "changed" on any mutation, so
+        // ArrayGrid.renderNode re-parses via refreshContent far more often. RowList.refreshContent used
+        // to unconditionally zero rowFocus/rowScrollOffset for every row, wiping the just-set column
+        // back to 0 every frame — breaking horizontal navigation while vertical (row) focus survived.
+        const list = SGNodeFactory.createNode("RowList");
+        list.setValue("content", buildContent([["A", "B", "C", "D"]]));
+
+        // Move column focus within row 0 to item 2 (render-geometry-independent path).
+        list.setValue("jumpToRowItem", new RoArray([new Int32(0), new Int32(2)]));
+        expect(list.rowFocus[0]).toBe(2);
+
+        // A plain re-parse of the SAME content tree (what a spurious content.changed triggers) must
+        // preserve the focused column.
+        list.refreshContent();
+        expect(list.rowFocus[0]).toBe(2);
+
+        // Assigning a genuinely NEW content tree does reset column focus to 0.
+        list.setValue("content", buildContent([["X", "Y", "Z"]]));
+        expect(list.rowFocus[0]).toBe(0);
     });
 });


### PR DESCRIPTION
## Summary

Makes SceneGraph grids correctly render content that is loaded on **Task threads**, reproduced end‑to‑end with the SGDEX **TimeGridView** sample (an EPG whose channels/programs are populated by `Task` nodes). The content flowed across the rendezvous transport the whole time — the failures were a chain of render‑side behaviors that diverged from Roku, so nothing was drawn until the app was poked with a key press. Also includes the follow‑up TimeGrid focus/efficiency work and a RowList regression fix surfaced by the dirty‑flag change.

None of these are the rendezvous transport itself; that works once the content flow reaches it.

## Fixes

### 1. `ArrayGrid` — `content` defaults to `invalid`, not an empty `ContentNode`
Roku leaves an unset `node` field `invalid`; apps rely on `content = invalid` to mean "not loaded yet" (SGDEX's content managers gate their initial load on it). Seeding an empty `ContentNode` made that check fail so the load never started. All `content` readers already guard with `instanceof ContentNode`.
- `src/extensions/scenegraph/nodes/ArrayGrid.ts`

### 2. `TimeGrid` — emit the focus event on focus‑gain even when empty
`ArrayGrid.setNodeFocus` only re‑emitted a focus event when `itemFocused >= 0`, but `TimeGrid` tracks `channelFocused`/`programFocused` separately (`itemFocused` stays `-1`). A grid focused **before** its content loads (SGDEX assigns `content` before the view is shown) stayed silent, so the lazy‑load chain never kicked off.
- `src/extensions/scenegraph/nodes/TimeGrid.ts` (`setNodeFocus`)

### 3. `Field` — observer callbacks bind every declared parameter
Only the first (event) parameter was defined; trailing declared params never got their defaults, so e.g. a Timer `fire` callback `sub cb(event, opt = true)` crashed reading `opt` (`<uninitialized>`). Now every param is bound, applying defaults for the ones the caller omits (matching `Callable.call`).
- `src/extensions/scenegraph/nodes/Field.ts` (`executeCallbacks`)

### 4. `ContentNode.makeDirty` — propagate `changed` to the content root on any thread
The dirty‑to‑root propagation was gated on `inTaskThread()`, but Task content updates are applied via **rendezvous on the render thread** (where `inTaskThread()` is false). So child `ContentNode` mutations never marked the root dirty and the grid never re‑parsed. Now a descendant change marks the content root dirty regardless of thread, so an ancestor `ArrayGrid`/`TimeGrid` re‑parses when a Task fills its content subtree.
- `src/extensions/scenegraph/nodes/ContentNode.ts`

### 5. `TimeGrid` — resolve initial focus, keep it on screen, and render efficiently
- **Initial focus resolution:** the first focus is set while the focused channel is still empty (content assigned before rows lazy‑load). Once the channel gains programs, focus snaps to the program at the current view time and scrolls to it — so the grid shows the correct content immediately instead of only after a key press, and the focus highlight is visible rather than stuck on an off‑screen program 0.
- **Vertical navigation:** anchor the up/down move to a time inside the visible window (so the focused program in the next channel is always at least partially visible, clipped to the grid) and keep the time window fixed on row changes, matching Roku.
- **Efficiency:** cache each channel's parsed program model (re‑parse only a channel whose child count changed, not the whole tree on every content change), binary‑search the program‑at‑time lookup, and start the per‑row render loop at the first visible program instead of scanning every off‑screen program each frame.
- `src/extensions/scenegraph/nodes/TimeGrid.ts`

### 6. `RowList` — preserve per‑row column focus across a content re‑parse (regression fix)
The dirty‑flag change (#4) makes `ArrayGrid.renderNode` re‑parse via `refreshContent()` far more often. `RowList.refreshContent` was the only grid that **destructively** zeroed each row's focused column (`rowFocus`) and horizontal scroll offset on every re‑parse, so horizontal navigation was wiped back to column 0 each frame while the vertical (row) focus survived — breaking left/right movement in older SGDEX grids that use `RowList`. `ZoomRowList`/`TimeGrid` were immune because they already use the idempotent `??= 0` pattern. Made `RowList.refreshContent` idempotent: reset per‑row horizontal focus/scroll only when a genuinely new content tree is assigned (tracked by content‑node identity), and initialize existing rows with `??= 0`.
- `src/extensions/scenegraph/nodes/RowList.ts`

## Testing

- `npx jest test/extensions/scenegraph` — **285/285 pass**, including `TimeGrid`, `RowList` (with a new regression test for column‑focus preservation), `Focus`, and the list/grid suites.
- ContentNode‑recursion regression suites in `test/cli` pass (the `makeDirty` change is on a hot path).
- `npm run lint` / `npm run prettier` clean.
- Verified end‑to‑end in the browser with the SGDEX TimeGridView sample: the grid loads, renders all channels/programs, finalizes without a key press, and keeps the focus highlight visible during up/down navigation — matching a real Roku device.
