### PR TITLE
fix(scenegraph): SceneGraph list/animation/format fixes

### DIFF
--- a/src/core/brsTypes/components/RoString.ts
+++ b/src/core/brsTypes/components/RoString.ts
@@ -5,7 +5,7 @@ import { BrsValue, ValueKind, BrsString, BrsBoolean, BrsInvalid, Comparable } fr
 import { Callable, StdlibArgument } from "../Callable";
 import { Interpreter } from "../../interpreter";
 import { BrsType, isBrsNumber, isBrsString, isStringComp } from "..";
-import { Unboxable } from "../Boxing";
+import { isUnboxable, Unboxable } from "../Boxing";
 import { Int32 } from "../Int32";
 import { Float } from "../Float";
 import { RuntimeError, RuntimeErrorDetail } from "../../error/BrsError";
@@ -567,7 +567,10 @@ export class RoString extends BrsComponent implements BrsValue, Comparable, Unbo
             // Documentation: https://developer.roku.com/docs/references/brightscript/language/format-strings.md
             let args: any[] = [];
             if (additionalArgs.length > 0) {
-                for (const element of additionalArgs) {
+                for (let element of additionalArgs) {
+                    if (isUnboxable(element)) {
+                        element = element.unbox();
+                    }
                     if (isBrsNumber(element)) {
                         args.push(element.getValue());
                     } else if (element instanceof BrsString) {

--- a/src/extensions/scenegraph/nodes/Animation.ts
+++ b/src/extensions/scenegraph/nodes/Animation.ts
@@ -313,7 +313,17 @@ export class Animation extends AnimationBase {
         if (!searchRoot) {
             return undefined;
         }
-        const found = this.findNodeById(searchRoot, nodeId);
+        // Prefer a DESCENDANT match first: the search root may be a custom-component instance whose
+        // own `id` is assigned in the parent's scope (e.g. `<FadingBackground id="Background">` around
+        // a child `<Poster id="background">`). Because ids match case-insensitively, that external id
+        // must not shadow a same-named child — otherwise the animation drives the wrong node.
+        let found = this.findNodeById(searchRoot, nodeId, true);
+        if (!(found instanceof Node)) {
+            // No descendant matched: fall back to the search root itself, which covers an animation
+            // whose target is its own enclosing node (e.g. `fieldToInterp="loadingIndicatorGroup.opacity"`
+            // on an Animation nested inside `<Group id="loadingIndicatorGroup">`).
+            found = this.findNodeById(searchRoot, nodeId, false);
+        }
         return found instanceof Node ? found : undefined;
     }
 

--- a/src/extensions/scenegraph/nodes/Poster.ts
+++ b/src/extensions/scenegraph/nodes/Poster.ts
@@ -55,6 +55,13 @@ export class Poster extends Group {
             const uri = jsValueOf(value);
             if (typeof uri === "string" && uri.trim() !== "" && this.uri !== uri) {
                 super.setValue("loadStatus", new BrsString("loading"));
+                // On a real device bitmapWidth/bitmapHeight read 0 until the image finishes loading.
+                // Reset them here (silently) so the post-load values are always seen as a change and
+                // notify observers on every load — even when the new image has the same dimensions as
+                // the previous one (e.g. fixed loadWidth/loadHeight). Without this, an observer on
+                // bitmapWidth (a common cross-fade trigger) never fires for same-size images.
+                this.setValueSilent("bitmapWidth", new Float(0));
+                this.setValueSilent("bitmapHeight", new Float(0));
                 this.uri = uri;
                 const loadStatus = this.loadUri(uri);
                 if (loadStatus !== "ready") {

--- a/src/extensions/scenegraph/nodes/RowList.ts
+++ b/src/extensions/scenegraph/nodes/RowList.ts
@@ -560,6 +560,7 @@ export class RowList extends ArrayGrid {
 
         // Render row label if needed
         const title = row.getValueJS("title") ?? "";
+        const rowTopY = context.itemRect.y;
         context.showRowLabel = this.getValueJS("showRowLabel")?.[rowIndex] ?? context.showRowLabel;
         if (title.length !== 0 && context.showRowLabel) {
             const divRect = { ...context.itemRect, width: rowWidth };
@@ -572,6 +573,10 @@ export class RowList extends ArrayGrid {
         context.itemRect.x = context.rect.x + xOffset;
 
         this.renderRowContent(rowIndex, cols, numCols, context.rowItemWidth, spacing, context.itemRect, context);
+
+        // Render the "N of M" row counter on the right edge of the focused row, AFTER the items so it
+        // stays visible on rows without a label whose items reach the row top (e.g. a tall hero row).
+        this.renderRowCounter(rowIndex, numCols, rowTopY, context);
 
         // Prepare for next row
         context.itemRect.x = context.rect.x;
@@ -667,6 +672,29 @@ export class RowList extends ArrayGrid {
         const maxVisibleItems = Math.ceil((this.sceneRect.width + spacing[0]) / (rowItemWidth + spacing[0]));
         const endCol = renderMode === "wrapMode" ? numCols : Math.min(startCol + maxVisibleItems, numCols);
 
+        // In wrap mode the focused item sits at the fixed focus offset; the row wraps in BOTH
+        // directions, so the tail end of the preceding (wrapped) item is partially visible in the
+        // margin to the LEFT of the focused item — matching a real device's fixedFocusWrap. Render
+        // those preceding items first (at decreasing x) until one falls fully off the left edge.
+        if (renderMode === "wrapMode") {
+            const pitch = rowItemWidth + spacing[0];
+            let leftX = itemRect.x - pitch;
+            for (let k = 1; pitch > 0 && k <= numCols && leftX + rowItemWidth > this.sceneRect.x; k++) {
+                const colIndex = (((startCol - k) % numCols) + numCols) % numCols;
+                this.renderRowItemComponent(
+                    context.interpreter,
+                    rowIndex,
+                    colIndex,
+                    cols,
+                    { ...itemRect, x: leftX },
+                    context.rotation,
+                    context.opacity,
+                    context.draw2D
+                );
+                leftX -= pitch;
+            }
+        }
+
         for (let c = 0; c < (renderMode === "wrapMode" ? numCols : endCol - startCol); c++) {
             let colIndex = startCol + c;
 
@@ -761,6 +789,46 @@ export class RowList extends ArrayGrid {
         if (focused && drawFocus && drawFocusOnTop) {
             this.renderFocus(itemRect, opacity, nodeFocus, draw2D);
         }
+    }
+
+    /**
+     * Renders the "current_item of total_items" counter on the right edge of the row. Per Roku, the
+     * counter is only shown for the FOCUSED row, and only when `showRowCounter` is true for that row
+     * (an empty array means no counters). `showRowCounterForShortRows` (default true) suppresses it on
+     * rows whose items all fit on screen. The counter uses the same font/color as the row label.
+     */
+    private renderRowCounter(rowIndex: number, numCols: number, topY: number, context: RowListRenderContext): void {
+        if (rowIndex !== this.focusIndex || numCols === 0) {
+            return;
+        }
+        if (!this.resolveBoolean(this.getValueJS("showRowCounter"), rowIndex, false)) {
+            return;
+        }
+        const showShortRows = (this.getValueJS("showRowCounterForShortRows") as boolean) ?? true;
+        if (!showShortRows && this.checkIfAllItemsFitOnScreen(numCols, context.rowItemWidth)) {
+            return;
+        }
+        const font = this.getValue("rowLabelFont") as Font;
+        const color = this.getValueJS("rowLabelColor");
+        const labelOffset = this.resolveVector(this.getValueJS("rowLabelOffset"), rowIndex, [0, 0]);
+        // Right edge is inset from the list's right edge by rowCounterRightOffset, or (when unset) by the
+        // row label's left offset so the counter mirrors the title's margin.
+        const rightInset = (this.getValueJS("rowCounterRightOffset") as number) || (labelOffset[0] ?? 0);
+        const listWidth = context.itemSize[0] || this.sceneRect.width;
+        const rightEdge = context.rect.x + listWidth - rightInset;
+        const counterText = `${(this.rowFocus[rowIndex] ?? 0) + 1} of ${numCols}`;
+        const drawFont = font.createDrawFont();
+        if (!(drawFont instanceof RoFont)) {
+            return;
+        }
+        // Draw directly rather than via `drawText`: that helper caches measured text in `cachedLines`
+        // keyed by row index, which the row label already uses for the SAME index — sharing it makes the
+        // counter overwrite the label (and vice-versa). The counter text also changes as the focused
+        // column moves, so it must be re-measured every frame, not cached.
+        const measured = drawFont.measureText(counterText);
+        const textX = rightEdge - measured.width;
+        const textY = topY + Math.max(0, (this.titleHeight - measured.height) / 2);
+        context.draw2D?.doDrawRotatedText(counterText, textX, textY, color, context.opacity, drawFont, 0);
     }
 
     protected renderRowDivider(title: string, itemRect: Rect, opacity: number, rowIndex: number, draw2D?: IfDraw2D) {

--- a/src/extensions/scenegraph/nodes/ZoomRowList.ts
+++ b/src/extensions/scenegraph/nodes/ZoomRowList.ts
@@ -120,8 +120,8 @@ export class ZoomRowList extends ArrayGrid {
         } else {
             this.marginX = 12;
             this.marginY = 12;
-            this.defaultRowHeight = 214;
-            this.defaultRowZoomHeight = 136;
+            this.defaultRowHeight = 136;
+            this.defaultRowZoomHeight = 214;
             this.defaultRowSpacing = 53;
             this.defaultItemSpacing = 14;
             this.setValueSilent("wrapDividerHeight", new Float(36));
@@ -702,10 +702,7 @@ export class ZoomRowList extends ArrayGrid {
         const show = this.resolveBoolean(this.getValueJS("showRowCounter"), rowIndex, false);
         const row = this.content[rowIndex];
         const items = row.getNodeChildren().length;
-        if (!show && rowIndex !== this.focusIndex) {
-            return 0;
-        }
-        if (items === 0) {
+        if (!show || items === 0 || rowIndex !== this.focusIndex) {
             return 0;
         }
         const showShortRows = (this.getValueJS("showRowCounterForShortRows") as boolean) ?? true;

--- a/test/brsTypes/components/RoString.test.js
+++ b/test/brsTypes/components/RoString.test.js
@@ -153,6 +153,33 @@ describe("RoString", () => {
             });
         });
 
+        describe("format", () => {
+            it("formats primitive string and number arguments", () => {
+                let s = new RoString(new BrsString("%s | %d"));
+                let format = s.getMethod("format");
+                const result = format.call(interpreter, new BrsString("A"), new Int32(5));
+                expect(result).toEqual(new BrsString("A | 5"));
+            });
+
+            it("unboxes boxed string arguments instead of rendering `undefined`", () => {
+                let s = new RoString(new BrsString("%s | %s"));
+                let format = s.getMethod("format");
+                const result = format.call(
+                    interpreter,
+                    new RoString(new BrsString("A")),
+                    new RoString(new BrsString("B"))
+                );
+                expect(result).toEqual(new BrsString("A | B"));
+            });
+
+            it("unboxes boxed number arguments", () => {
+                let s = new RoString(new BrsString("%d"));
+                let format = s.getMethod("format");
+                const result = format.call(interpreter, new Int32(42).box());
+                expect(result).toEqual(new BrsString("42"));
+            });
+        });
+
         describe("appendString", () => {
             let s, appendString;
 

--- a/test/extensions/scenegraph/Animation.test.js
+++ b/test/extensions/scenegraph/Animation.test.js
@@ -1,0 +1,66 @@
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory } = scenegraph;
+const { BrsString, Float, RoArray } = core;
+
+const floatArray = (nums) => new RoArray(nums.map((n) => new Float(n)));
+
+/**
+ * Animation target scoping: an interpolator's `fieldToInterp` (e.g. "background.opacity") is resolved
+ * among the DESCENDANTS of the animation's component scope, not the component root itself. The root's
+ * own `id` is assigned by the parent component (a different scope), so it must not shadow a same-named
+ * child — otherwise a `<FadingBackground id="Background">` with a child `<Poster id="background">`
+ * would drive the container instead of the inner poster (ids match case-insensitively), so a cross-fade
+ * would animate the wrong node and the new image would never become visible.
+ */
+describe("Animation target resolution", () => {
+    test("interpolator targets the child, not a same-named (case-folded) component root", () => {
+        // Container id "Background" mirrors the parent-assigned id; inner poster id "background".
+        const container = SGNodeFactory.createNode("Rectangle");
+        container.setValue("id", new BrsString("Background"));
+        const inner = SGNodeFactory.createNode("Poster");
+        inner.setValue("id", new BrsString("background"));
+        inner.setValue("opacity", new Float(0)); // starts hidden, like the FadingBackground's new poster
+        container.appendChildToParent(inner);
+
+        const animation = SGNodeFactory.createNode("Animation");
+        animation.setValue("duration", new Float(0.5));
+        const interp = SGNodeFactory.createNode("FloatFieldInterpolator");
+        interp.setValue("fieldToInterp", new BrsString("background.opacity"));
+        interp.setValue("key", floatArray([0.0, 1.0]));
+        interp.setValue("keyValue", floatArray([0.0, 0.5])); // distinctive end value (not the default opacity 1)
+        animation.appendChildToParent(interp);
+        container.appendChildToParent(animation);
+
+        expect(inner.getValueJS("opacity")).toBe(0);
+        expect(container.getValueJS("opacity")).toBe(1);
+
+        // Jump to the final frame; this drives the resolved target field to keyValue[1] = 0.5.
+        animation.setValue("control", new BrsString("finish"));
+
+        // The INNER poster was animated (0 -> 0.5); the container's opacity is untouched.
+        expect(inner.getValueJS("opacity")).toBeCloseTo(0.5, 5);
+        expect(container.getValueJS("opacity")).toBe(1);
+    });
+
+    test("interpolator resolves to its own enclosing node when no descendant matches", () => {
+        // Mirrors LoadingIndicator's fade: an Animation nested inside <Group id="loadingIndicatorGroup">
+        // targets "loadingIndicatorGroup.opacity" — its own parent. The target must still resolve.
+        const group = SGNodeFactory.createNode("Group");
+        group.setValue("id", new BrsString("loadingIndicatorGroup"));
+
+        const animation = SGNodeFactory.createNode("Animation");
+        animation.setValue("duration", new Float(0.5));
+        const interp = SGNodeFactory.createNode("FloatFieldInterpolator");
+        interp.setValue("fieldToInterp", new BrsString("loadingIndicatorGroup.opacity"));
+        interp.setValue("key", floatArray([0.0, 1.0]));
+        interp.setValue("keyValue", floatArray([1.0, 0.0])); // fade out
+        animation.appendChildToParent(interp);
+        group.appendChildToParent(animation);
+
+        expect(group.getValueJS("opacity")).toBe(1);
+        animation.setValue("control", new BrsString("finish"));
+        expect(group.getValueJS("opacity")).toBeCloseTo(0, 5);
+    });
+});

--- a/test/extensions/scenegraph/Poster.test.js
+++ b/test/extensions/scenegraph/Poster.test.js
@@ -1,0 +1,53 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory } = scenegraph;
+const { BrsDevice, BrsString, Float, RoMessagePort } = core;
+
+/**
+ * Minimal fake interpreter accepted by Node.addObserver for a port observer (mirrors HiddenFields.test.js).
+ */
+const fakeInterpreter = { environment: {}, inSubEnv: () => {} };
+
+/**
+ * Poster load notifications: on a real device bitmapWidth/bitmapHeight read 0 until an image finishes
+ * loading, so every load transitions 0 -> N and fires observers. Our loader is synchronous, so without
+ * resetting these fields a new image with the SAME loaded dimensions (common when loadWidth/loadHeight
+ * are fixed) would set bitmapWidth N -> N — no change, no notification. That silently breaks a very common
+ * cross-fade pattern (observe bitmapWidth to start a fade-in when the next background finishes loading).
+ */
+describe("Poster bitmap load notifications", () => {
+    beforeAll(() => {
+        // Poster loads images from the common: volume; mount it once.
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    test("bitmapWidth re-notifies on every load, even when the new image has identical dimensions", () => {
+        const poster = SGNodeFactory.createNode("Poster");
+        // Force both images to the same loaded dimensions so bitmapWidth would otherwise be unchanged.
+        poster.setValue("loadWidth", new Float(48));
+        poster.setValue("loadHeight", new Float(48));
+
+        const port = new RoMessagePort();
+        const received = [];
+        const originalPush = port.pushMessage.bind(port);
+        port.pushMessage = (event) => {
+            received.push(event);
+            originalPush(event);
+        };
+        poster.addObserver(fakeInterpreter, "unscoped", new BrsString("bitmapWidth"), port);
+
+        poster.setValue("uri", new BrsString("common:/images/icon_options.png"));
+        const firstWidth = poster.getValueJS("bitmapWidth");
+        expect(firstWidth).toBeGreaterThan(0);
+        expect(received.length).toBe(1);
+
+        // A different image that scales to the same dimensions must still fire the observer.
+        poster.setValue("uri", new BrsString("common:/images/icon_options_off.png"));
+        expect(poster.getValueJS("bitmapWidth")).toBe(firstWidth);
+        expect(received.length).toBe(2);
+    });
+});

--- a/test/extensions/scenegraph/RowList.test.js
+++ b/test/extensions/scenegraph/RowList.test.js
@@ -86,4 +86,99 @@ describe("RowList key handling", () => {
         list.setValue("content", buildContent([["X", "Y", "Z"]]));
         expect(list.rowFocus[0]).toBe(0);
     });
+
+    test("fixedFocusWrap renders the preceding wrapped item in the left margin", () => {
+        // Regression: in fixedFocusWrap the row wraps in BOTH directions, so the tail end of the
+        // preceding (wrapped) item must be partially visible in the margin to the LEFT of the focused
+        // item. The renderer used to draw nothing left of the focus offset, leaving a blank margin.
+        const list = SGNodeFactory.createNode("RowList");
+        const items = [];
+        for (let i = 0; i < 15; i++) {
+            items.push("A" + i);
+        }
+        list.setValue("content", buildContent([items]));
+        list.setValue("itemSize", new RoArray([new Int32(375), new Int32(197)]));
+        list.setValue("numRows", new Int32(1));
+        list.setValue("focusXOffset", new RoArray([new Int32(165)]));
+        list.setValue("rowFocusAnimationStyle", new BrsString("FixedFocusWrap"));
+        list.setValue("rowItemSize", new RoArray([new RoArray([new Int32(375), new Int32(197)])]));
+        list.setValue("rowItemSpacing", new RoArray([new RoArray([new Int32(30), new Int32(0)])]));
+
+        // Capture the x-origin each item component is rendered at.
+        const positions = [];
+        const original = list.createItemComponent.bind(list);
+        list.createItemComponent = (interp, itemRect, content) => {
+            const comp = original(interp, itemRect, content);
+            const render = comp.renderNode.bind(comp);
+            comp.renderNode = (i2, origin, angle, opacity, draw2D) => {
+                positions.push({ title: content.getValueJS("title"), x: Math.round(origin[0]) });
+                return render(i2, origin, angle, opacity, draw2D);
+            };
+            return comp;
+        };
+        list.renderNode({}, [0, 0], 0, 1);
+
+        // Focused item (A0) sits exactly at the focus offset...
+        const focused = positions.find((p) => p.title === "A0");
+        expect(focused.x).toBe(165);
+        // ...and the previous (wrapped) item A14 is drawn partly into the left margin: its origin is
+        // left of the focus offset (negative here) but its right edge is still on screen (x + width > 0).
+        const wrapped = positions.find((p) => p.title === "A14");
+        expect(wrapped).toBeDefined();
+        expect(wrapped.x).toBeLessThan(165);
+        expect(wrapped.x + 375).toBeGreaterThan(0);
+    });
+
+    test("renders the 'N of M' row counter for the focused row without clobbering the row label", () => {
+        const list = SGNodeFactory.createNode("RowList");
+        const items = [];
+        for (let i = 0; i < 15; i++) {
+            items.push("A" + i);
+        }
+        // A titled row with BOTH a visible label and a counter: the counter must not overwrite the
+        // label's cached text (regression: the left label rendered the counter's "N of M" string).
+        const content = buildContent([items]);
+        content.getNodeChildren()[0].setValue("title", new BrsString("My Row"));
+        list.setValue("content", content);
+        list.setValue("itemSize", new RoArray([new Int32(1280), new Int32(197)]));
+        list.setValue("numRows", new Int32(1));
+        list.setValue("rowFocusAnimationStyle", new BrsString("FixedFocusWrap"));
+        list.setValue("rowItemSize", new RoArray([new RoArray([new Int32(375), new Int32(197)])]));
+        list.setValue("showRowLabel", new RoArray([core.BrsBoolean.True]));
+        list.setValue("showRowCounter", new RoArray([core.BrsBoolean.True]));
+
+        // Record every string drawn to the screen (labels via drawText, counter drawn directly — both
+        // funnel through draw2D.doDrawRotatedText).
+        const drawn = [];
+        const draw2D = new Proxy(
+            {},
+            {
+                get: (_t, prop) => (prop === "doDrawRotatedText" ? (text) => drawn.push(text) : () => 0),
+            }
+        );
+
+        const render = () => {
+            drawn.length = 0;
+            list.renderNode({}, [0, 0], 0, 1, draw2D);
+        };
+
+        // First render, then a SECOND render (the cache-collision bug only surfaced once isDirty cleared).
+        render();
+        render();
+        expect(drawn).toContain("My Row"); // label survives...
+        expect(drawn).toContain("1 of 15"); // ...alongside the counter.
+
+        // After moving right, the counter reflects the new focused column (and the label is intact).
+        list.handleKey("right", true);
+        render();
+        expect(drawn).toContain("My Row");
+        expect(drawn).toContain("2 of 15");
+        expect(drawn).not.toContain("1 of 15");
+
+        // With showRowCounter empty (the default), no counter is drawn but the label remains.
+        list.setValue("showRowCounter", new RoArray([]));
+        render();
+        expect(drawn).toContain("My Row");
+        expect(drawn.some((t) => /of 15/.test(t))).toBe(false);
+    });
 });

--- a/test/extensions/scenegraph/ZoomRowList.test.js
+++ b/test/extensions/scenegraph/ZoomRowList.test.js
@@ -1,0 +1,28 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory } = scenegraph;
+const { BrsDevice } = core;
+
+/**
+ * ZoomRowList zoom sizing: the focused row uses `rowZoomHeight` and must render LARGER than the
+ * unfocused rows (which use `rowHeight`). When an app does not set these fields (as in the
+ * living_room_devices sample), the node falls back to resolution-specific defaults. A regression
+ * had the HD defaults swapped (base 214 / zoom 136), which made the focused row shrink instead of
+ * grow. These defaults also back the item-height fallbacks in getRowMetrics.
+ */
+describe("ZoomRowList zoom defaults", () => {
+    beforeAll(() => {
+        // ZoomRowList resolves fonts/focus bitmap from the common: volume; mount it once.
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    test("HD zoom-height default is larger than the base row-height default", () => {
+        // A bare node defaults to HD resolution (Group falls back to "HD").
+        const node = SGNodeFactory.createNode("ZoomRowList");
+        expect(node.defaultRowZoomHeight).toBeGreaterThan(node.defaultRowHeight);
+    });
+});


### PR DESCRIPTION
## Overview

Fixes a batch of SceneGraph rendering/behavior mismatches surfaced while running the `living_room_devices` and `hero-grid-channel` sample apps against a real Roku. Each fix has focused regression coverage.

## ZoomRowList
- **Inverted zoom.** The HD `defaultRowHeight`/`defaultRowZoomHeight` were swapped (`214`/`136`), so the focused row *shrank* instead of growing. Swapped to `136`/`214`, matching the FHD ratio (`204`/`321`).
- **Row counter default.** Only show the "N of M" counter when `showRowCounter` is explicitly `true` for the focused row (it was forced on for the focused row even when set to `[false]`).

## `roString.Format`
- Unbox boxed arguments before formatting. `%s`/`%d` on a boxed `roString`/`roInt` were silently dropped, so `sprintf` emitted the literal `"undefined"` — the source of the `undefined | undefined` title label.

## RowList
- **fixedFocusWrap left margin.** Render the preceding wrapped item into the margin left of the focused item, so the tail of the previous poster is visible (matches the device).
- **Row counter.** Implemented the counter (fields were declared but never rendered): shown only for the focused row when `showRowCounter` is set, right-aligned, honoring `rowCounterRightOffset`/`showRowCounterForShortRows`. Rendered *after* the row items so it stays visible on a label-less tall hero row, and drawn directly (not via the row-index-keyed text cache) so it never clobbers the row label and re-measures as the focused column changes.

## Poster
- Reset `bitmapWidth`/`bitmapHeight` to `0` when a new `uri` load begins (matching a device where they read `0` until load completes). Without this, a same-size reload never notified `bitmapWidth` observers — breaking the common cross-fade trigger, so the background never faded in / persisted.

## Animation target resolution
- Resolve an interpolator's `fieldToInterp` node id against the search root's **descendants first** (so a custom-component instance's externally-assigned `id` can't shadow a same-named child), then **fall back to the search root itself** (so an animation targeting its own enclosing group still resolves). Fixes the background fade driving the wrong node while keeping `LoadingIndicator`'s fade-out and spinner working.

## Tests
New/updated regression tests:
- `RoString.test.js` — boxed-arg `Format`
- `ZoomRowList.test.js` — HD zoom default (zoom > base)
- `RowList.test.js` — fixedFocusWrap left-margin item + row counter (label not clobbered across renders/navigation)
- `Poster.test.js` — `bitmapWidth` re-notifies on same-size reload
- `Animation.test.js` — interpolator target scoping (descendant vs. enclosing node)

`npm run lint` + `npm run prettier` clean; all SceneGraph extension suites (303 tests), the `RoString` suite, and the CLI suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)