### PR TITLE
fix(scenegraph): RowList rendering fixes — item sizing, counter, spacing, labels, wrap & clipping

### DIFF
--- a/src/extensions/scenegraph/factory/NodeFactory.ts
+++ b/src/extensions/scenegraph/factory/NodeFactory.ts
@@ -1064,11 +1064,23 @@ export function getBrsValueFromFieldType(type: string, value?: string, defaultVa
         case "font":
             returnValue = parseFont(value ?? "", defaultValue);
             break;
+        case "boolarray": {
+            // Roku accepts a scalar shorthand for boolean arrays (e.g. showRowLabel="true" or
+            // variableWidthItems="true"), meaning "this value for every row". A bare true/false that is
+            // not an array literal becomes a single-element array so per-row resolution repeats it —
+            // otherwise parseArray would yield an empty array and the flag would read as unset.
+            const trimmed = value?.trim();
+            if (trimmed && !trimmed.startsWith("[")) {
+                returnValue = new RoArray([BrsBoolean.from(trimmed.toLowerCase() === "true")]);
+            } else {
+                returnValue = parseArray(value ?? "", defaultValue);
+            }
+            break;
+        }
         case "roarray":
         case "array":
         case "vector2d":
         case "rect2d":
-        case "boolarray":
         case "floatarray":
         case "intarray":
         case "timearray":

--- a/src/extensions/scenegraph/factory/Serializer.ts
+++ b/src/extensions/scenegraph/factory/Serializer.ts
@@ -96,14 +96,14 @@ export function brsValueOf(value: any, cs?: boolean, nodeMap?: Map<string, Node>
         case "boolean":
             return BrsBoolean.from(value);
         case "string":
-            return new BrsString(value);
+            return new BrsString(value, true, true);
         case "number":
             if (Number.isInteger(value)) {
-                return value >= -maxInt && value < maxInt ? new Int32(value) : new Int64(value);
+                return value >= -maxInt && value < maxInt ? new Int32(value, true, true) : new Int64(value, true, true);
             } else if (Number.isNaN(value)) {
-                return new Float(value);
+                return new Float(value, true, true);
             }
-            return value >= -3.4e38 && value <= 3.4e38 ? new Float(value) : new Double(value);
+            return value >= -3.4e38 && value <= 3.4e38 ? new Float(value, true, true) : new Double(value, true, true);
         case "object":
             return fromObject(value, cs, nodeMap);
         case "undefined":

--- a/src/extensions/scenegraph/nodes/RowList.ts
+++ b/src/extensions/scenegraph/nodes/RowList.ts
@@ -589,7 +589,27 @@ export class RowList extends ArrayGrid {
         const xOffset = this.getRowXOffset(rowIndex);
         context.itemRect.x = context.rect.x + xOffset;
 
+        // Clip the row items to the list's own horizontal bounds (x .. x + itemSize.width) ONLY when the
+        // row content is wider than the row — otherwise everything already fits and no clip is needed.
+        // When clipping, matching a real device: a poster that extends past the row's right edge is cut
+        // off there (aligned with the row counter) instead of bleeding over the screen, and a wrapped
+        // partial item on the left is cut at the list's left edge. The bounds are widened by the focus
+        // feedback margin so the focused item's indicator (which outsets the poster) is not clipped. The
+        // label and counter are drawn outside this clip.
+        const clip = xOffset + rowWidth > context.itemSize[0];
+        if (clip) {
+            const focusMargin = this.getValueJS("drawFocusFeedback") ? this.marginX : 0;
+            context.draw2D?.pushClip({
+                x: context.rect.x - focusMargin,
+                y: this.sceneRect.y,
+                width: context.itemSize[0] + focusMargin * 2,
+                height: this.sceneRect.height,
+            });
+        }
         this.renderRowContent(rowIndex, cols, numCols, context.rowItemWidth, spacing, context.itemRect, context);
+        if (clip) {
+            context.draw2D?.popClip();
+        }
 
         // Render the "N of M" row counter in the label band at the row top, AFTER the items.
         this.renderRowCounter(rowIndex, numCols, rowTopY, context);
@@ -694,12 +714,14 @@ export class RowList extends ArrayGrid {
 
         // In wrap mode the focused item sits at the fixed focus offset; the row wraps in BOTH
         // directions, so the tail end of the preceding (wrapped) item is partially visible in the
-        // margin to the LEFT of the focused item — matching a real device's fixedFocusWrap. Render
-        // those preceding items first (at decreasing x) until one falls fully off the left edge.
+        // margin to the LEFT of the focused item — matching a real device's fixedFocusWrap. This only
+        // happens when the focus offset leaves room to the left of the focused item: the preceding item
+        // is clipped to the LIST's own left edge (context.rect.x), not the scene's. With the default
+        // focusXOffset of 0 the focused item sits at the list's left edge, so no preceding item shows.
         if (renderMode === "wrapMode") {
             const pitch = rowItemWidth + spacing[0];
             let leftX = itemRect.x - pitch;
-            for (let k = 1; pitch > 0 && k <= numCols && leftX + rowItemWidth > this.sceneRect.x; k++) {
+            for (let k = 1; pitch > 0 && k <= numCols && leftX + rowItemWidth > context.rect.x; k++) {
                 const colIndex = (((startCol - k) % numCols) + numCols) % numCols;
                 this.renderRowItemComponent(
                     context.interpreter,

--- a/src/extensions/scenegraph/nodes/RowList.ts
+++ b/src/extensions/scenegraph/nodes/RowList.ts
@@ -862,7 +862,18 @@ export class RowList extends ArrayGrid {
         if (title.length !== 0) {
             const font = this.getValue("rowLabelFont") as Font;
             const color = this.getValueJS("rowLabelColor");
-            this.drawText(title, font, color, opacity, divRect, "left", "center", 0, draw2D, "...", rowIndex);
+            // Draw directly rather than via `drawText`: that helper caches the measured text in
+            // `cachedLines` keyed by row index and only refreshes it when the RowList node itself is
+            // marked dirty. The label text comes from the row's ContentNode `title`, which can change
+            // without dirtying the RowList, so a title updated after the first render would keep drawing
+            // the stale cached value. Re-measuring every frame keeps the label in sync with the content
+            // (and matches how the row counter is drawn).
+            const drawFont = font.createDrawFont();
+            if (drawFont instanceof RoFont) {
+                const measured = drawFont.measureText(title, divRect.width, "...");
+                const textY = divRect.y + Math.max(0, (this.titleHeight - measured.height) / 2);
+                draw2D?.doDrawRotatedText(measured.text, divRect.x, textY, color, opacity, drawFont, 0);
+            }
         }
 
         // Return height of title plus vertical offset (spacing between title and items)

--- a/src/extensions/scenegraph/nodes/RowList.ts
+++ b/src/extensions/scenegraph/nodes/RowList.ts
@@ -547,8 +547,14 @@ export class RowList extends ArrayGrid {
         const spacing = this.getRowItemSpacing(rowIndex);
         const rowWidth = numCols * context.rowItemWidth + (numCols - 1) * spacing[0];
 
+        // Per Roku, `itemSize`/`rowHeights` size the entire ROW; `rowItemSize` sizes the individual
+        // poster. The item rect carries the poster dimensions (drives the item component's width/height
+        // and the focus 9-patch); the row's own height only advances the next row down. `rowHeights`
+        // falls back to `itemSize.y` for rows beyond the array (NOT the poster height) — using the
+        // poster height would leave no room above it and make short rows (e.g. a grid row) overlap.
         context.itemRect.width = context.rowItemWidth;
-        context.itemRect.height = context.rowHeights[rowIndex] ?? context.rowItemHeight;
+        context.itemRect.height = context.rowItemHeight;
+        const rowHeight = context.rowHeights[rowIndex] ?? context.itemSize[1] ?? context.rowItemHeight;
 
         // Render wrap divider if needed
         if (this.wrap && rowIndex === 0 && displayRowIndex > 0) {
@@ -558,15 +564,26 @@ export class RowList extends ArrayGrid {
             context.itemRect.y += divHeight + spacing[1];
         }
 
-        // Render row label if needed
+        // The row label (left) and the "N of M" counter (right) sit in a band at the TOP of the row,
+        // and the poster items are pushed down below it. When the band fits within the row's natural
+        // slack (rowHeight - posterHeight), the row keeps its height (hero/standard rows). When it does
+        // NOT fit — a dense grid row whose rowHeight falls back to itemSize.y — the row is grown by the
+        // band height (see the advance below) so the pushed-down poster still never spills into the next
+        // row, while the label/counter stay at the row top with the row's normal spacing above them.
         const title = row.getValueJS("title") ?? "";
         const rowTopY = context.itemRect.y;
-        context.showRowLabel = this.getValueJS("showRowLabel")?.[rowIndex] ?? context.showRowLabel;
-        if (title.length !== 0 && context.showRowLabel) {
-            const divRect = { ...context.itemRect, width: rowWidth };
-            const divHeight = this.renderRowDivider(title, divRect, context.opacity, rowIndex, context.draw2D);
-            context.itemRect.y += divHeight;
+        const showLabel = this.resolveBoolean(this.getValueJS("showRowLabel"), rowIndex, false);
+        const showCounter = this.resolveBoolean(this.getValueJS("showRowCounter"), rowIndex, false);
+        context.showRowLabel = showLabel;
+        const labelOffset = this.resolveVector(this.getValueJS("rowLabelOffset"), rowIndex, [0, 0]);
+        const hasLabel = showLabel && title.length !== 0;
+        const bandHeight = hasLabel || showCounter ? this.titleHeight + (labelOffset[1] ?? 0) : 0;
+        const bandFits = bandHeight <= Math.max(0, rowHeight - context.rowItemHeight);
+        if (hasLabel) {
+            const divRect = { ...context.itemRect, y: rowTopY, width: rowWidth };
+            this.renderRowDivider(title, divRect, context.opacity, rowIndex, context.draw2D);
         }
+        context.itemRect.y = rowTopY + bandHeight;
 
         // Apply horizontal offset and render items
         const xOffset = this.getRowXOffset(rowIndex);
@@ -574,14 +591,15 @@ export class RowList extends ArrayGrid {
 
         this.renderRowContent(rowIndex, cols, numCols, context.rowItemWidth, spacing, context.itemRect, context);
 
-        // Render the "N of M" row counter on the right edge of the focused row, AFTER the items so it
-        // stays visible on rows without a label whose items reach the row top (e.g. a tall hero row).
+        // Render the "N of M" row counter in the label band at the row top, AFTER the items.
         this.renderRowCounter(rowIndex, numCols, rowTopY, context);
 
-        // Prepare for next row
+        // Prepare for next row: advance by the ROW height (not the poster height) from the row top,
+        // grown by the band height when the band did not fit in the row's slack so a labeled short row
+        // (e.g. the first "The Grid" row) does not overlap the next.
         context.itemRect.x = context.rect.x;
         const rowSpacing = this.calculateRowSpacing(rowIndex, context.rowSpacings, context.globalSpacing);
-        context.itemRect.y += context.itemRect.height + rowSpacing;
+        context.itemRect.y = rowTopY + rowHeight + (bandFits ? 0 : bandHeight) + rowSpacing;
 
         return RectRect(this.sceneRect, context.itemRect);
     }
@@ -618,9 +636,11 @@ export class RowList extends ArrayGrid {
     }
 
     private calculateRowSpacing(rowIndex: number, rowSpacings: number[], globalSpacing: number[]): number {
-        const rowSpacing = rowSpacings[rowIndex] ?? globalSpacing[1];
-        const defaultRowSpacing = this.resolution === "FHD" ? 60 : 40;
-        return rowSpacing !== undefined && rowSpacing !== 0 ? rowSpacing : defaultRowSpacing;
+        // Per Roku, the vertical gap between rows is rowSpacings[row], falling back to itemSpacing.y
+        // (globalSpacing[1]) for rows beyond the array — and defaults to 0. The full row height
+        // (rowHeights / itemSize.y) already accounts for each row's visual extent, so no implicit
+        // spacing is added on top of it.
+        return rowSpacings[rowIndex] ?? globalSpacing[1] ?? 0;
     }
 
     private calculateActualRowIndex(displayRowIndex: number): number {

--- a/test/extensions/scenegraph/RowList.test.js
+++ b/test/extensions/scenegraph/RowList.test.js
@@ -3,7 +3,7 @@ const path = require("path");
 const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
 const core = require("../../../packages/node/bin/brs.node.js");
 
-const { SGNodeFactory, sgRoot } = scenegraph;
+const { SGNodeFactory, sgRoot, getBrsValueFromFieldType } = scenegraph;
 const { BrsDevice, BrsString, Int32, RoArray } = core;
 
 /**
@@ -180,6 +180,83 @@ describe("RowList key handling", () => {
         render();
         expect(drawn).toContain("My Row");
         expect(drawn.some((t) => /of 15/.test(t))).toBe(false);
+    });
+
+    test("a row label updated after the first render is redrawn (not served stale from the cache)", () => {
+        // Regression: the row label was drawn via the drawText line cache keyed by row index, which is
+        // only refreshed when the RowList node itself is marked dirty. A title updated later on the
+        // row's ContentNode (e.g. after a Task loads) did not dirty the RowList, so the label kept
+        // rendering the stale cached text (or never appeared). The label is now drawn directly.
+        const list = SGNodeFactory.createNode("RowList");
+        const content = buildContent([["A", "B"]]);
+        const rowNode = content.getNodeChildren()[0];
+        rowNode.setValue("title", new BrsString("Old"));
+        list.setValue("content", content);
+        list.setValue("itemSize", new RoArray([new Int32(1280), new Int32(220)]));
+        list.setValue("numRows", new Int32(1));
+        list.setValue("rowItemSize", new RoArray([new RoArray([new Int32(375), new Int32(197)])]));
+        list.setValue("showRowLabel", new RoArray([core.BrsBoolean.True]));
+
+        const drawn = [];
+        const draw2D = new Proxy(
+            {},
+            { get: (_t, prop) => (prop === "doDrawRotatedText" ? (text) => drawn.push(text) : () => 0) }
+        );
+        const render = () => {
+            drawn.length = 0;
+            list.renderNode({}, [0, 0], 0, 1, draw2D);
+        };
+
+        render();
+        expect(drawn).toContain("Old");
+
+        // Update the title on the row's ContentNode only (the RowList's own fields are untouched).
+        rowNode.setValue("title", new BrsString("New"));
+        render();
+        expect(drawn).toContain("New");
+        expect(drawn).not.toContain("Old");
+    });
+
+    test("showRowLabel scalar shorthand ('true') shows row labels (regression: Home screen titles)", () => {
+        // Regression (jellyfin-roku Home): showRowLabel="true" is Roku shorthand for "all rows show
+        // labels". The XML loader must parse the scalar to [true], not [] — an empty array reads as
+        // unset (no labels), so the row titles never rendered.
+        expect(
+            getBrsValueFromFieldType("boolarray", "true")
+                .getValue()
+                .map((b) => b.toBoolean())
+        ).toEqual([true]);
+        expect(
+            getBrsValueFromFieldType("boolarray", "false")
+                .getValue()
+                .map((b) => b.toBoolean())
+        ).toEqual([false]);
+        // An array literal is still parsed as-is, and an unset value stays empty (no labels).
+        expect(
+            getBrsValueFromFieldType("boolarray", "[false,true]")
+                .getValue()
+                .map((b) => b.toBoolean())
+        ).toEqual([false, true]);
+        expect(getBrsValueFromFieldType("boolarray", undefined).getValue()).toEqual([]);
+
+        const list = SGNodeFactory.createNode("RowList");
+        const content = buildContent([["A", "B"]]);
+        content.getNodeChildren()[0].setValue("title", new BrsString("Continue Watching"));
+        list.setValue("content", content);
+        list.setValue("itemSize", new RoArray([new Int32(1280), new Int32(220)]));
+        list.setValue("numRows", new Int32(1));
+        list.setValue("rowItemSize", new RoArray([new RoArray([new Int32(375), new Int32(197)])]));
+        // Apply showRowLabel exactly as the XML loader does for showRowLabel="true".
+        list.setValue("showRowLabel", getBrsValueFromFieldType("boolarray", "true"));
+        expect(list.getValueJS("showRowLabel")).toEqual([true]);
+
+        const drawn = [];
+        const draw2D = new Proxy(
+            {},
+            { get: (_t, prop) => (prop === "doDrawRotatedText" ? (text) => drawn.push(text) : () => 0) }
+        );
+        list.renderNode({}, [0, 0], 0, 1, draw2D);
+        expect(drawn).toContain("Continue Watching");
     });
 
     test("item uses rowItemSize (not rowHeights) and sits below the counter band on a label-less row", () => {

--- a/test/extensions/scenegraph/RowList.test.js
+++ b/test/extensions/scenegraph/RowList.test.js
@@ -129,6 +129,83 @@ describe("RowList key handling", () => {
         expect(wrapped.x + 375).toBeGreaterThan(0);
     });
 
+    test("fixedFocusWrap draws no preceding item when focusXOffset is 0 (item at the list's left edge)", () => {
+        // Regression (SceneGraphTutorial rowlist): with the default focusXOffset (0) the focused item
+        // sits at the RowList's OWN left edge, so there is no room for a partial preceding item. The
+        // wrapped tail must be clipped to the list's left edge (translation.x), not the scene's (0) —
+        // otherwise a partial item bleeds into the margin to the left of the list.
+        const list = SGNodeFactory.createNode("RowList");
+        const items = [];
+        for (let i = 0; i < 15; i++) {
+            items.push("A" + i);
+        }
+        list.setValue("content", buildContent([items]));
+        list.setValue("itemSize", new RoArray([new Int32(536 * 3), new Int32(308)]));
+        list.setValue("numRows", new Int32(1));
+        // The list is translated right; its left edge (and the focused item) is at x = 130.
+        list.setValue("translation", new RoArray([new Int32(130), new Int32(0)]));
+        list.setValue("rowItemSize", new RoArray([new RoArray([new Int32(536), new Int32(308)])]));
+        list.setValue("rowFocusAnimationStyle", new BrsString("FixedFocusWrap"));
+        // focusXOffset left at its default of 0.
+
+        const positions = [];
+        const original = list.createItemComponent.bind(list);
+        list.createItemComponent = (interp, itemRect, content) => {
+            const comp = original(interp, itemRect, content);
+            const render = comp.renderNode.bind(comp);
+            comp.renderNode = (i2, origin, angle, opacity, draw2D) => {
+                positions.push({ title: content.getValueJS("title"), x: Math.round(origin[0]) });
+                return render(i2, origin, angle, opacity, draw2D);
+            };
+            return comp;
+        };
+        list.renderNode({}, [0, 0], 0, 1);
+
+        // The focused item A0 sits at the list's left edge, and nothing is drawn to its left.
+        expect(positions.find((p) => p.title === "A0").x).toBe(130);
+        expect(Math.min(...positions.map((p) => p.x))).toBe(130);
+    });
+
+    test("clips row items to the list's own bounds when the content overflows the row width", () => {
+        // Regression (jellyfin Home): items whose row is narrower than the screen (itemSize width set to
+        // cut off at the safe zone) must be clipped at the LIST's right edge — aligned with the row
+        // counter — not bleed to the screen border. The clip is widened by the focus-feedback margin so
+        // the focused item's indicator is not cut, and is only applied when the content overflows.
+        function makeList(itemCount) {
+            const list = SGNodeFactory.createNode("RowList");
+            const items = [];
+            for (let i = 0; i < itemCount; i++) {
+                items.push("A" + i);
+            }
+            list.setValue("content", buildContent([items]));
+            list.setValue("itemSize", new RoArray([new Int32(1703), new Int32(300)]));
+            list.setValue("numRows", new Int32(1));
+            list.setValue("translation", new RoArray([new Int32(100), new Int32(0)]));
+            list.setValue("rowItemSize", new RoArray([new RoArray([new Int32(300), new Int32(300)])]));
+            return list;
+        }
+        const capture = (list) => {
+            const clips = [];
+            const draw2D = new Proxy(
+                {},
+                { get: (_t, prop) => (prop === "pushClip" ? (rect) => clips.push({ ...rect }) : () => 0) }
+            );
+            list.renderNode({}, [0, 0], 0, 1, draw2D);
+            return clips;
+        };
+
+        // 10 items of 300 (3000+) overflow the 1703 row → clipped to the list's bounds, widened by the
+        // focus margin so the focused item's indicator (which outsets the poster) is not cut.
+        const wide = makeList(10);
+        const wideClips = capture(wide);
+        expect(wideClips.length).toBeGreaterThan(0);
+        expect(wideClips[0].x).toBe(100 - wide.marginX);
+        expect(wideClips[0].width).toBe(1703 + wide.marginX * 2);
+
+        // 3 items of 300 (900) fit within the 1703 row → no clip is pushed (optimization).
+        expect(capture(makeList(3))).toEqual([]);
+    });
+
     test("renders the 'N of M' row counter for the focused row without clobbering the row label", () => {
         const list = SGNodeFactory.createNode("RowList");
         const items = [];

--- a/test/extensions/scenegraph/RowList.test.js
+++ b/test/extensions/scenegraph/RowList.test.js
@@ -181,4 +181,94 @@ describe("RowList key handling", () => {
         expect(drawn).toContain("My Row");
         expect(drawn.some((t) => /of 15/.test(t))).toBe(false);
     });
+
+    test("item uses rowItemSize (not rowHeights) and sits below the counter band on a label-less row", () => {
+        // Regression: the hero row of a RowList (showRowLabel=false, showRowCounter=true) rendered its
+        // items at rowHeights (the ROW height) instead of rowItemSize (the poster height), and drew the
+        // "N of M" counter on top of the items instead of in a band above them.
+        const list = SGNodeFactory.createNode("RowList");
+        list.setValue("content", buildContent([["A", "B", "C"]]));
+        list.setValue("numRows", new Int32(1));
+        // itemSize.y (220) and rowHeights (800) both differ from the poster height (700).
+        list.setValue("itemSize", new RoArray([new Int32(1920), new Int32(220)]));
+        list.setValue("rowHeights", new RoArray([new Int32(800)]));
+        list.setValue("rowItemSize", new RoArray([new RoArray([new Int32(1600), new Int32(700)])]));
+        list.setValue("rowLabelOffset", new RoArray([new RoArray([new Int32(165), new Int32(8)])]));
+        list.setValue("showRowLabel", new RoArray([core.BrsBoolean.False]));
+        list.setValue("showRowCounter", new RoArray([core.BrsBoolean.True]));
+
+        const items = [];
+        const original = list.createItemComponent.bind(list);
+        list.createItemComponent = (interp, itemRect, content) => {
+            const comp = original(interp, itemRect, content);
+            const render = comp.renderNode.bind(comp);
+            comp.renderNode = (i2, origin, angle, opacity, draw2D) => {
+                items.push({
+                    height: comp.getValueJS("height"),
+                    width: comp.getValueJS("width"),
+                    y: Math.round(origin[1]),
+                });
+                return render(i2, origin, angle, opacity, draw2D);
+            };
+            return comp;
+        };
+        list.renderNode({}, [0, 0], 0, 1);
+
+        // The item takes the poster size, not the row height...
+        expect(items[0].height).toBe(700);
+        expect(items[0].width).toBe(1600);
+        // ...and is pushed below the counter/label band (titleHeight + rowLabelOffset.y) even though
+        // this row has no visible label, so the counter (drawn at the row top) does not overlap it.
+        expect(items[0].y).toBe(Math.round(list.titleHeight + 8));
+    });
+
+    test("short rows (rowHeights fallback to itemSize.y) do not overlap — grid rows", () => {
+        // Regression ("The Grid" section of hero-grid-channel): rows beyond the rowHeights array take
+        // itemSize.y as their height. When that row is too short to fit the label band above the poster,
+        // the row is grown by the band height so the pushed-down poster never spills into the next
+        // (unlabeled) row, while the label stays at the row top with normal spacing above it.
+        const list = SGNodeFactory.createNode("RowList");
+        // Row 0 has a title (label shown), row 1 does not — mirroring the first "The Grid" row.
+        const content = buildContent([
+            ["A", "B"],
+            ["C", "D"],
+        ]);
+        content.getNodeChildren()[0].setValue("title", new BrsString("The Grid"));
+        list.setValue("content", content);
+        list.setValue("numRows", new Int32(2));
+        // itemSize.y (220) is the row-height fallback; no rowHeights set. Poster is 375x197.
+        list.setValue("itemSize", new RoArray([new Int32(1920), new Int32(220)]));
+        list.setValue("rowItemSize", new RoArray([new RoArray([new Int32(375), new Int32(197)])]));
+        list.setValue("showRowLabel", new RoArray([core.BrsBoolean.True]));
+
+        const rows = [];
+        const original = list.createItemComponent.bind(list);
+        list.createItemComponent = (interp, itemRect, content) => {
+            const comp = original(interp, itemRect, content);
+            const render = comp.renderNode.bind(comp);
+            comp.renderNode = (i2, origin, angle, opacity, draw2D) => {
+                rows.push({
+                    title: content.getValueJS("title"),
+                    y: Math.round(origin[1]),
+                    h: comp.getValueJS("height"),
+                });
+                return render(i2, origin, angle, opacity, draw2D);
+            };
+            return comp;
+        };
+        list.renderNode({}, [0, 0], 0, 1);
+
+        const row0 = rows.find((r) => r.title === "A");
+        const row1 = rows.find((r) => r.title === "C");
+        const band = Math.round(list.titleHeight); // rowLabelOffset.y defaults to 0
+        // The band (titleHeight) is taller than the 23px slack above the poster, so the labeled row is
+        // grown by the band: the poster is pushed down below the label...
+        expect(row0.h).toBe(197);
+        expect(list.titleHeight).toBeGreaterThan(220 - 197);
+        expect(row0.y).toBe(band);
+        // ...and the next row advances by the row height PLUS the band, clearing the first row's poster
+        // and preserving the natural 23px gap (rowHeight 220 - poster 197) below it.
+        expect(row1.y).toBe(220 + band);
+        expect(row1.y - (row0.y + row0.h)).toBe(220 - 197);
+    });
 });


### PR DESCRIPTION
## Overview

A series of `RowList` rendering fixes so SceneGraph list/grid screens match a real Roku, driven by the **hero-grid-channel**, **SceneGraphTutorial**, and **jellyfin-roku** samples. Several are follow-ups to regressions from #984.

## What's fixed

**Item sizing & row/section spacing** (hero-grid-channel)
- Item rect now carries the **poster** size (`rowItemSize`), not the row height — fixing the stretched aspect ratio and the focus 9-patch border.
- `rowHeights` falls back to `itemSize.y` (per the Roku spec) for rows beyond the array, not the poster height.
- The label/counter band sits at the row top with the poster pushed below it; when the band doesn't fit the row's slack (`rowHeight − posterHeight`), the row is grown by the band height so short/grid rows ("The Grid") don't overlap and keep proper spacing above the label.
- Row spacing defaults to `itemSpacing.y` (0), not a hardcoded 60/40px.

**Row labels**
- A row label updated **after** the first render (e.g. once a Task loads) was drawn stale from the `isDirty`-gated `drawText` line cache; the label is now drawn directly (re-measured each frame), like the counter.
- `showRowLabel="true"` (Roku scalar shorthand) parsed to an empty `boolarray` and hid the labels — the XML loader now parses a scalar `true`/`false` on a `boolarray` field to `[true]`/`[false]` (also fixes `showRowCounter`, `variableWidthItems`).

**fixedFocusWrap & clipping** (SceneGraphTutorial, jellyfin Home)
- The preceding wrapped item is clipped to the RowList's **own** left edge (`rect.x`), so a translated list with the default `focusXOffset` (0) no longer draws a partial item bleeding into the left margin.
- RowList content is clipped to its own horizontal bounds (`x .. x + itemSize.width`) so posters no longer bleed past the row's right edge to the screen border. The clip is widened by the focus-feedback margin (so the focused item's indicator isn't cut) and is applied only when the row content actually overflows the row width. Label and counter draw outside the clip.

## Testing

`test/extensions/scenegraph/RowList.test.js` gains regression coverage for each fix (item sizing/counter band, short-row no-overlap, label updated-after-render, `showRowLabel="true"` shorthand, wrap partial-item at the list edge, and item clipping with the focus margin / no clip when content fits). Full SceneGraph suite green (309 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)