### PR TITLE
fix(brs): handle edge case for numeric values in Type()

### DIFF
--- a/src/core/brsTypes/Boxing.ts
+++ b/src/core/brsTypes/Boxing.ts
@@ -12,9 +12,9 @@ export interface Unboxable {
 }
 
 export function isBoxable(value: BrsType): value is BrsType & Boxable {
-    return "box" in value && "literal" in value && "legacy" in value;
+    return value !== undefined && "box" in value && "literal" in value && "legacy" in value;
 }
 
 export function isUnboxable(value: BrsType): value is BrsType & Unboxable {
-    return "unbox" in value && "copy" in value;
+    return value !== undefined && "unbox" in value && "copy" in value;
 }

--- a/src/core/brsTypes/components/RoArray.ts
+++ b/src/core/brsTypes/components/RoArray.ts
@@ -10,6 +10,7 @@ import {
     isBrsBoolean,
     isAnyNumber,
     jsValueOf,
+    isNumberKind,
 } from "..";
 import { BrsValue, ValueKind, BrsString, BrsBoolean, BrsInvalid, Comparable } from "../BrsType";
 import { BrsComponent } from "./BrsComponent";
@@ -36,6 +37,10 @@ export class RoArray extends BrsComponent implements BrsValue, BrsArray {
         this.elements = [];
         if (args.length === 1 && Array.isArray(args[0])) {
             for (const element of args[0]) {
+                if (isBoxable(element) && isNumberKind(element.kind) && element.legacy) {
+                    // set the literal flag of numeric values, when legacy was already set, to cover a Roku edge case for Type()
+                    element.literal = true;
+                }
                 this.addChildRef(element);
                 this.elements.push(element);
             }

--- a/src/core/brsTypes/components/RoAssociativeArray.ts
+++ b/src/core/brsTypes/components/RoAssociativeArray.ts
@@ -1,6 +1,6 @@
 import { BrsValue, ValueKind, BrsString, BrsBoolean, BrsInvalid } from "../BrsType";
 import { BrsComponent, BrsIterable } from "./BrsComponent";
-import { BrsType, isBoxable, isUnboxable, RoFunction } from "..";
+import { BrsType, isBoxable, isNumberKind, isUnboxable, RoFunction } from "..";
 import { isSceneGraphNode } from "../../extensions";
 import { Callable, StdlibArgument } from "../Callable";
 import { Interpreter } from "../../interpreter";
@@ -31,8 +31,13 @@ export class RoAssociativeArray extends BrsComponent implements BrsValue, BrsIte
         super("roAssociativeArray");
         this.modeCaseSensitive = cs;
         for (const member of elements) {
-            this.addChildRef(member.value);
-            this.set(member.name, member.value, true);
+            const element = member.value;
+            if (isBoxable(element) && isNumberKind(element.kind) && element.legacy) {
+                // set the literal flag of numeric values, when legacy was already set, to cover a Roku edge case for Type()
+                element.literal = true;
+            }
+            this.addChildRef(element);
+            this.set(member.name, element, true);
         }
         this.enumIndex = elements.length ? 0 : -1;
         const ifEnum = new IfEnum(this);


### PR DESCRIPTION
Continuing the saga of trying to simulate the behavior of Roku `Type()` function results on every edge case.