### PR TITLE
chore: update dev-doc submodule to latest v2.0 + add docs:update script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "release": "npm run release --workspaces",
     "start": "npm run start -w brs-engine",
     "clean": "npm run clean --workspaces",
+    "docs:update": "git submodule update --init --remote external/dev-doc",
     "test": "jest",
     "lint": "eslint -c .eslintrc.js --ext .ts ./src",
     "prettier:write": "prettier --write \"{packages,src,test}/**/*.{js,ts}\"",


### PR DESCRIPTION
## Summary

- Bump the `external/dev-doc` Roku reference-docs submodule from `828812e2` → `45bbc651`, the current `v2.0` tip (it was 89 commits behind).
- Add an `npm run docs:update` script so refreshing the vendored docs is a one-liner.

The submodule wasn't broken — the pinned pointer had simply never been advanced. The `.gitmodules` config (`url`, `branch = v2.0`) was already correct.

## Changes

- `external/dev-doc` gitlink bumped to `45bbc651` ("Update doc `ifdeviceinfo`", 2026-07-08).
- `package.json`: new script
  ```json
  "docs:update": "git submodule update --init --remote external/dev-doc"
  ```
  Fetches + fast-forwards the submodule to the `v2.0` tip; `--init` also handles a fresh clone. After running it, commit the new pointer to share it.

## Notes

Reference-only content used by the `brs-reference` skill — no build/runtime impact.

## Verification

- `git submodule status external/dev-doc` → `45bbc651… (heads/v2.0)`.
- Local HEAD == GitHub `v2.0` tip (`git ls-remote`).
- `npm run docs:update` runs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)