### PR TITLE
feat(brs): add roUtils.hasComponent (OS 15.2)

### DIFF
--- a/src/core/brsTypes/components/RoUtils.ts
+++ b/src/core/brsTypes/components/RoUtils.ts
@@ -1,6 +1,15 @@
-import { BrsValue, ValueKind, BrsBoolean } from "../BrsType";
+import { BrsValue, ValueKind, BrsBoolean, BrsString } from "../BrsType";
 import { BrsComponent } from "./BrsComponent";
-import { BrsType, RoArray, RoAssociativeArray, RoInvalid, isAnyNumber, isBrsString, isBoxedNumber } from "..";
+import {
+    BrsType,
+    BrsObjects,
+    RoArray,
+    RoAssociativeArray,
+    RoInvalid,
+    isAnyNumber,
+    isBrsString,
+    isBoxedNumber,
+} from "..";
 import { Callable, StdlibArgument } from "../Callable";
 import { Interpreter } from "../../interpreter";
 import { isSceneGraphNode } from "../../extensions";
@@ -11,7 +20,14 @@ export class RoUtils extends BrsComponent implements BrsValue {
     constructor() {
         super("roUtils");
         this.registerMethods({
-            ifUtils: [this.deepCopy, this.isSameObject, this.isNumber, this.isString, this.isFloatingPoint],
+            ifUtils: [
+                this.deepCopy,
+                this.isSameObject,
+                this.hasComponent,
+                this.isNumber,
+                this.isString,
+                this.isFloatingPoint,
+            ],
         });
     }
 
@@ -47,6 +63,17 @@ export class RoUtils extends BrsComponent implements BrsValue {
         },
         impl: (_: Interpreter, data1: BrsComponent, data2: BrsComponent) => {
             return BrsBoolean.from(data1 === data2);
+        },
+    });
+
+    /** Verifies whether a component name is already registered (creatable via CreateObject). */
+    private readonly hasComponent = new Callable("hasComponent", {
+        signature: {
+            args: [new StdlibArgument("componentName", ValueKind.String)],
+            returns: ValueKind.Boolean,
+        },
+        impl: (_: Interpreter, componentName: BrsString) => {
+            return BrsBoolean.from(BrsObjects.has(componentName.value));
         },
     });
 

--- a/test/brsTypes/components/RoUtils.test.js
+++ b/test/brsTypes/components/RoUtils.test.js
@@ -17,6 +17,26 @@ describe("RoUtils", () => {
         });
     });
 
+    describe("hasComponent", () => {
+        let hasComponent;
+        beforeEach(() => {
+            hasComponent = utils.getMethod("hasComponent");
+        });
+
+        it("returns true for registered components, case-insensitively", () => {
+            expect(hasComponent.call(interpreter, new BrsString("roDeviceInfo"))).toBe(BrsBoolean.True);
+            expect(hasComponent.call(interpreter, new BrsString("rodeviceinfo"))).toBe(BrsBoolean.True);
+            expect(hasComponent.call(interpreter, new BrsString("roArray"))).toBe(BrsBoolean.True);
+        });
+
+        it("returns false for unregistered component names", () => {
+            expect(hasComponent.call(interpreter, new BrsString("roNotAThing"))).toBe(BrsBoolean.False);
+            // roSGNode is only registered once the SceneGraph extension is loaded,
+            // which does not happen in this unit-test harness.
+            expect(hasComponent.call(interpreter, new BrsString("roSGNode"))).toBe(BrsBoolean.False);
+        });
+    });
+
     describe("isNumber", () => {
         let isNumber;
         beforeEach(() => {

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -815,6 +815,10 @@ describe("end to end brightscript functions", () => {
             "isFloatingPoint boxed float: true",
             "isFloatingPoint double: true",
             "isFloatingPoint int: false",
+            "hasComponent roArray: true",
+            "hasComponent rodeviceinfo: true",
+            "hasComponent roSGNode: true",
+            "hasComponent roBogus: false",
         ]);
     });
 });

--- a/test/e2e/resources/components/roUtils.brs
+++ b/test/e2e/resources/components/roUtils.brs
@@ -114,4 +114,10 @@ sub main()
     print "isFloatingPoint boxed float: "; utils.isFloatingPoint(box(3.14))
     print "isFloatingPoint double: "; utils.isFloatingPoint(3.14#)
     print "isFloatingPoint int: "; utils.isFloatingPoint(42)
+
+    ' Roku OS 15.2 - hasComponent
+    print "hasComponent roArray: "; utils.hasComponent("roArray")
+    print "hasComponent rodeviceinfo: "; utils.hasComponent("rodeviceinfo")
+    print "hasComponent roSGNode: "; utils.hasComponent("roSGNode")
+    print "hasComponent roBogus: "; utils.hasComponent("roBogus")
 end sub


### PR DESCRIPTION
## Summary

Adds `roUtils.hasComponent(componentName as String) as Boolean`, the `ifUtils` method introduced in **Roku OS 15.2**. Per the [official spec](https://developer.roku.com/docs/references/brightscript/interfaces/ifutils.md), it "verifies whether a component name is already registered. Developers can call this method before trying to create an instance."

The method delegates to the existing case-insensitive `BrsObjects` registry (the same one backing `CreateObject()`), so it needs no new data source and correctly reflects SceneGraph components (`roSGNode`, `roSGScreen`, …) once the extension is loaded — and only core components when it isn't, matching a real device's registration state.

```brightscript
utils = CreateObject("roUtils")
? utils.hasComponent("roArray")      ' true
? utils.hasComponent("rodeviceinfo") ' true (case-insensitive)
? utils.hasComponent("roSGNode")     ' true when SceneGraph is enabled
? utils.hasComponent("roBogus")      ' false
```

## Changes

- **`src/core/brsTypes/components/RoUtils.ts`** — new `hasComponent` Callable → `BrsObjects.has(...)`, registered under `ifUtils`.
- **`test/brsTypes/components/RoUtils.test.js`** — unit tests: true for registered components (case-insensitive), false for unknown names / `roSGNode` when SG isn't loaded.
- **`test/e2e/resources/components/roUtils.brs`** + **`BrsComponents.test.js`** — end-to-end coverage (SG active, so `roSGNode: true` is validated live).

## Verification

- `npm run build:cli` ✅
- `npx jest test/brsTypes/components/RoUtils.test.js` — 10/10 ✅
- `npx jest -t "components/roUtils"` (e2e) ✅
- `npm run lint` clean · `npm run prettier:write` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)