### PR TITLE
feat(brs): add roDeviceInfo isHDMIConnected/isPassthruCodecActive

### DIFF
--- a/src/core/brsTypes/components/RoDeviceInfo.ts
+++ b/src/core/brsTypes/components/RoDeviceInfo.ts
@@ -89,8 +89,10 @@ export class RoDeviceInfo extends BrsComponent implements BrsValue {
                 this.getCaptionsOption,
                 this.canDecodeAudio,
                 this.getAudioOutputChannel,
+                this.isPassthruCodecActive,
                 this.getAudioDecodeInfo, // deprecated
                 this.getVideoDecodeInfo, // deprecated
+                this.isHDMIConnected, // deprecated
                 this.canDecodeVideo,
                 this.isAudioGuideEnabled,
                 this.isAutoPlayEnabled, // since OS 13.0
@@ -747,6 +749,18 @@ export class RoDeviceInfo extends BrsComponent implements BrsValue {
         },
     });
 
+    /** Indicates whether an external passthrough device (TV/receiver/soundbar) is rendering audio. */
+    private readonly isPassthruCodecActive = new Callable("isPassthruCodecActive", {
+        signature: {
+            args: [],
+            returns: ValueKind.Boolean,
+        },
+        impl: (_: Interpreter) => {
+            // The engine decodes audio locally; no external passthrough device is active.
+            return BrsBoolean.False;
+        },
+    });
+
     /** Lists each audio decoder supported by the device.*/
     private readonly getAudioDecodeInfo = new Callable("getAudioDecodeInfo", {
         signature: {
@@ -778,6 +792,21 @@ export class RoDeviceInfo extends BrsComponent implements BrsValue {
         impl: (_: Interpreter) => {
             // This method is deprecated in Roku
             return toAssociativeArray({ H264: "", MPEG2: "", MPEG4: "" });
+        },
+    });
+
+    /** Checks for an HDMI connection to a TV. */
+    private readonly isHDMIConnected = new Callable("isHDMIConnected", {
+        signature: {
+            args: [],
+            returns: ValueKind.Boolean,
+        },
+        impl: (_: Interpreter) => {
+            BrsDevice.stderr.write(
+                `warning,BRIGHTSCRIPT: WARNING: roDeviceInfo.IsHDMIConnected: This function is deprecated`
+            );
+            // A simulated player is treated as connected to a display.
+            return BrsBoolean.True;
         },
     });
 

--- a/test/brsTypes/components/RoDeviceInfo.test.js
+++ b/test/brsTypes/components/RoDeviceInfo.test.js
@@ -623,5 +623,23 @@ describe("RoDeviceInfo", () => {
                 expect(method.call(interpreter)).toEqual(BrsBoolean.False);
             });
         });
+        describe("isHDMIConnected", () => {
+            it("should return true as a simulated player is treated as connected", () => {
+                let deviceInfo = new RoDeviceInfo(interpreter);
+                let method = deviceInfo.getMethod("isHDMIConnected");
+
+                expect(method).toBeTruthy();
+                expect(method.call(interpreter)).toEqual(BrsBoolean.True);
+            });
+        });
+        describe("isPassthruCodecActive", () => {
+            it("should return false as audio is decoded locally", () => {
+                let deviceInfo = new RoDeviceInfo(interpreter);
+                let method = deviceInfo.getMethod("isPassthruCodecActive");
+
+                expect(method).toBeTruthy();
+                expect(method.call(interpreter)).toEqual(BrsBoolean.False);
+            });
+        });
     });
 });


### PR DESCRIPTION
## Overview

Comparing `roDeviceInfo` against the Roku `ifDeviceInfo` spec (`external/dev-doc/.../ifdeviceinfo.md`), the component was missing exactly **two** documented methods. Both describe real hardware state the simulator cannot observe, so they are implemented as mocks — consistent with how the rest of the component handles unsupportable device state (e.g. `getAudioOutputChannel`, the `enable*Event` stubs).

| Method | Behavior | Rationale |
| --- | --- | --- |
| `IsHDMIConnected()` | Returns `true` + deprecation warning | Deprecated in Roku (→ `ifHdmiStatus`); a simulated player is treated as connected to a display. |
| `IsPassthruCodecActive()` | Returns `false` | The engine decodes audio locally — there is no external passthrough device rendering audio. |

## Changes

- `src/core/brsTypes/components/RoDeviceInfo.ts` — added the two `Callable`s and registered them in `ifDeviceInfo` (audio/video groupings).
- `test/brsTypes/components/RoDeviceInfo.test.js` — added two `describe` blocks.

## Verification

- `npm run lint` clean, `prettier:write` applied.
- `RoDeviceInfo.test.js` passes 62/62 (including the two new cases).
- CLI runtime check confirms `IsHDMIConnected()` → `true` (with warning) and `IsPassthruCodecActive()` → `false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)