### PR TITLE
fix(rsg): resolve cross-thread nodes by address via a registry

### DIFF
--- a/src/extensions/scenegraph/SGRoot.ts
+++ b/src/extensions/scenegraph/SGRoot.ts
@@ -21,7 +21,7 @@ import { ThreadInfo } from "./SGTypes";
 import type { SoundEffect } from "./nodes/SoundEffect";
 import type { RoSGNode } from "./components/RoSGNode";
 import type { RoSGScreen } from "./components/RoSGScreen";
-import type { AnimationBase, Audio, Dialog, Scene, StandardDialog, Task, Timer, Video } from "./nodes";
+import type { AnimationBase, Audio, Dialog, Node, Scene, StandardDialog, Task, Timer, Video } from "./nodes";
 import type { RoRenderThreadQueue } from "./components/RoRenderThreadQueue";
 
 /**
@@ -73,6 +73,20 @@ export class SGRoot {
     rendezvousTimeout: number = 10000;
     /** The render thread's roRenderThreadQueue singleton (holds handlers), drained each frame. */
     private _renderQueue?: RoRenderThreadQueue;
+    /**
+     * Nodes that have crossed the thread boundary (serialized to, or rebuilt from, another thread),
+     * keyed by address. A rendezvous update targets a node by this address, and on a real Roku any
+     * node the other thread holds a reference to stays reachable — even when it is no longer part of
+     * the task/scene/global trees (e.g. a per-request callback node that a field stopped pointing
+     * at). WeakRefs keep the registry from retaining nodes; the FinalizationRegistry prunes entries
+     * once a node is collected.
+     */
+    private readonly _crossThreadNodes = new Map<string, WeakRef<Node>>();
+    private readonly _crossThreadCleanup = new FinalizationRegistry((address: string) => {
+        if (this._crossThreadNodes.get(address)?.deref() === undefined) {
+            this._crossThreadNodes.delete(address);
+        }
+    });
 
     get interpreter(): Interpreter | undefined {
         return this._interpreter;
@@ -316,6 +330,29 @@ export class SGRoot {
      */
     setFocused(node?: RoSGNode) {
         this._focused = node;
+    }
+
+    /**
+     * Records a node whose address has crossed the thread boundary, so later rendezvous
+     * updates can resolve it even when it is unreachable from the task/scene/global trees.
+     * @param node Node being serialized to (or rebuilt from) another thread
+     */
+    registerCrossThreadNode(node: Node) {
+        const address = node.getAddress();
+        if (this._crossThreadNodes.get(address)?.deref() === node) {
+            return;
+        }
+        this._crossThreadNodes.set(address, new WeakRef(node));
+        this._crossThreadCleanup.register(node, address);
+    }
+
+    /**
+     * Resolves a previously registered cross-thread node by address.
+     * @param address Node address to look up
+     * @returns The live node, or undefined if never registered or already collected
+     */
+    getCrossThreadNode(address: string): Node | undefined {
+        return this._crossThreadNodes.get(address)?.deref();
     }
 
     /**

--- a/src/extensions/scenegraph/factory/Serializer.ts
+++ b/src/extensions/scenegraph/factory/Serializer.ts
@@ -251,6 +251,7 @@ export function toSGNode(obj: any, type: string, subtype: string, child?: boolea
     newNode.setAddress(obj["_address_"] || newNode.getAddress());
     newNode.setOwner(obj["_owner_"] ?? 0);
     nodeMap.set(newNode.getAddress(), newNode);
+    sgRoot.registerCrossThreadNode(newNode);
 
     const fieldTypes = obj["_fieldtypes_"] ?? {};
     for (const key in obj) {
@@ -330,6 +331,7 @@ export function updateSGNode(obj: any, targetNode: Node, nodeMap?: Map<string, N
     targetNode.setOwner(obj["_owner_"] ?? targetNode.getOwner());
     // Register/update in nodeMap
     nodeMap.set(targetNode.getAddress(), targetNode);
+    sgRoot.registerCrossThreadNode(targetNode);
     // Update fields
     const fieldTypes = obj["_fieldtypes_"] ?? {};
     for (const key in obj) {
@@ -455,6 +457,9 @@ export function fromSGNode(node: Node, deep: boolean = true, host?: Node, visite
         };
     }
     visited.add(node);
+    // A serialized node's address may be used by the other thread to rendezvous back into this
+    // one long after the local trees stopped referencing it — keep it resolvable by address.
+    sgRoot.registerCrossThreadNode(node);
 
     const result: FlexObject = {};
     const fields = node.getNodeFields();

--- a/src/extensions/scenegraph/nodes/Task.ts
+++ b/src/extensions/scenegraph/nodes/Task.ts
@@ -672,7 +672,9 @@ export class Task extends Node {
                 BrsDevice.stdout.write(
                     `debug,[task:${sgRoot.threadId}] Node sync type: ${update.type}, from ${update.id} ${
                         update.action
-                    } '${update.key}' - target node not found! It was ${replied ? "replied" : "not replied"}`
+                    } '${update.key}' address ${update.address ?? "n/a"} - target node not found! It was ${
+                        replied ? "replied" : "not replied"
+                    }`
                 );
                 return undefined;
             }
@@ -811,6 +813,12 @@ export class Task extends Node {
      */
     private resolveNode(address: string, searchFields: boolean = false): Node | undefined {
         if (address) {
+            // Nodes that crossed the thread boundary stay resolvable by address even when no
+            // longer reachable from the trees below (mirroring Roku's process-wide references).
+            const crossThreadNode = sgRoot.getCrossThreadNode(address);
+            if (crossThreadNode) {
+                return crossThreadNode;
+            }
             const rootNodes = [this, sgRoot.scene, sgRoot.mGlobal];
             for (const rootNode of rootNodes) {
                 const foundNode = this.findNodeByAddress(rootNode, address, searchFields);


### PR DESCRIPTION
## Root cause

A rendezvous update targets a node by its **address**, but on the receiving thread `Task.resolveNode` could only find nodes by tree-walking from the task, scene, and `m.global` roots. A node that crossed the thread boundary but was no longer reachable from those trees — e.g. a per-request callback node created on the render thread, handed to a Task via a task field, and later replaced by the next request — became unresolvable. `handleUnresolvedNode` then **acked the update but silently discarded the field write**, so the observer waiting on that node's field never fired and the app hung (log line: `target node not found! It was replied`).

On a real device node references are process-wide: any node the other thread holds a handle to stays reachable regardless of tree attachment, and apps legitimately rely on late write-backs to such nodes (a common pattern for per-request callback nodes).

## Solution

- `SGRoot` keeps a registry `Map<address, WeakRef<Node>>` of every node whose address has crossed the thread boundary, populated at the Serializer chokepoints all transfers pass through: `fromSGNode` (serialize) and `toSGNode`/`updateSGNode` (deserialize) — covering both render→task and task→render directions.
- `WeakRef` + a `FinalizationRegistry` keep the registry from retaining nodes or leaking entries; only nodes that actually cross threads pay the (tiny) registration cost.
- `Task.resolveNode` consults the registry first (O(1)) and falls back to the existing tree walk.
- The unresolved-node diagnostic now includes the target address.

## Verification

- Full suite green (141 suites / 1967 tests), including all rendezvous regression fixtures in `test/cli/cli.test.js`.
- Verified end-to-end in the browser build with a multi-Scene app that funnels every HTTP request through a Task via disposable callback nodes: previously its startup stalled on the dropped write-back; with the registry every write resolves and startup completes. (Task rendezvous cannot be exercised via `brs-cli`, which is single-threaded.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)