### PR TITLE
fix(brs): keep AA enumeration stable when replacing an existing key's value

### DIFF
--- a/src/core/brsTypes/components/RoAssociativeArray.ts
+++ b/src/core/brsTypes/components/RoAssociativeArray.ts
@@ -168,12 +168,20 @@ export class RoAssociativeArray extends BrsComponent implements BrsValue, BrsIte
         let oldKey = this.findElementKey(index.value);
         this.addChildRef(value);
         if (oldKey) this.removeChildRef(this.elements.get(oldKey));
+        let indexValue = isCaseSensitive ? index.value : index.value.toLowerCase();
         if (!this.modeCaseSensitive && oldKey) {
+            if (oldKey === indexValue) {
+                // Replace in place: keep the key's position in the backing Map. Roku does not
+                // reorder an AA when an existing key's value is replaced — a delete + re-insert
+                // here moved the key to the end, which made a `for each` that assigns to existing
+                // keys of the same AA skip entries (and visit others twice).
+                this.elements.set(oldKey, value);
+                return BrsInvalid.Instance;
+            }
+            // Different casing: re-case the stored key to the latest write (matching Roku).
             this.elements.delete(oldKey);
             this.keyMap.set(oldKey.toLowerCase(), new Set()); // clear key set cuz in insensitive mode we should have 1 key in set
         }
-
-        let indexValue = isCaseSensitive ? index.value : index.value.toLowerCase();
         this.elements.set(indexValue, value);
 
         let lkey = index.value.toLowerCase();

--- a/test/brsTypes/components/RoAssociativeArray.test.js
+++ b/test/brsTypes/components/RoAssociativeArray.test.js
@@ -70,6 +70,39 @@ describe("RoAssociativeArray", () => {
 
             expect(aa.get(new BrsString("foo"))).toEqual(new BrsString("not ninetynine", false, true));
         });
+
+        it("keeps a replaced key's enumeration position (for each + assign must not skip keys)", () => {
+            // Roku does not reorder an AA when an existing key's value is replaced. A delete +
+            // re-insert moved the key to the end of the backing Map, so a `for each` that assigns
+            // to existing keys of the same AA skipped entries (Tubi's request-options merge loop).
+            let aa = new RoAssociativeArray([
+                { name: new BrsString("method"), value: new BrsString("GET") },
+                { name: new BrsString("params"), value: new RoAssociativeArray([]) },
+                { name: new BrsString("body"), value: new BrsString("") },
+                { name: new BrsString("headers"), value: new RoAssociativeArray([]) },
+                { name: new BrsString("retries"), value: new Int32(3) },
+            ]);
+
+            const visited = [];
+            aa.resetNext();
+            for (let i = 0; i < 20 && aa.hasNext().toBoolean(); i++) {
+                const key = aa.getNext();
+                visited.push(key.toString());
+                aa.set(key, new BrsString("replaced"));
+            }
+
+            expect(visited).toEqual(["method", "params", "body", "headers", "retries"]);
+        });
+
+        it("re-cases the stored key on a replace with different casing (last write wins)", () => {
+            let aa = new RoAssociativeArray([{ name: new BrsString("x"), value: new Int32(123) }]);
+
+            aa.set(new BrsString("X"), new Int32(456), true);
+
+            expect(aa.elements.size).toBe(1);
+            expect([...aa.elements.keys()]).toEqual(["X"]);
+            expect(aa.get(new BrsString("x")).getValue()).toBe(456);
+        });
     });
 
     describe("methods", () => {


### PR DESCRIPTION
## Root cause

`RoAssociativeArray.set()` on an **existing** key (case-insensitive mode) performed a delete + re-insert, which moves the key to the **end** of the backing `Map`. The ifEnum enumerator (`getNext`) indexes into the live key order, so a `for each` loop that assigns to existing keys of the *same* AA it is iterating skipped entries and visited others multiple times:

```brs
merged = { method: "GET", params: {}, body: "", headers: {}, retries: 3 }
for each o in merged
    if options[o] <> invalid then merged[o] = options[o]
end for
' visited: method, body, retries, body, body — params and headers never merged
```

This option-merge idiom is common in HTTP/request wrappers, and the corruption is silent — the loop completes, some keys just never get merged. On a real device replacing an existing key's value does **not** reorder the AA.

## Solution

`set()` now updates the value **in place** when the incoming stored key is identical to the existing one, preserving the key's position (and therefore any live enumeration). A replace with **different casing** keeps the previous delete + re-insert, matching Roku where the stored key takes the case of the latest write — pinned by the `ParseJson` case-insensitive duplicate-key case in `test/e2e/resources/stdlib/json.brs` (`{"x": 123, "X": 456}` → single key `X`).

Enumeration itself intentionally stays live and insertion-ordered — keys **added** during iteration are still visited, exactly as pinned by the device-validated `test/e2e/resources/components/ifEnum.brs` fixture.

## Verification

- New unit tests in `test/brsTypes/components/RoAssociativeArray.test.js`: the merge-loop pattern visits every key exactly once, and a different-cased replace still re-cases the stored key.
- Full suite green (141 suites / 1969 tests), including the `ifEnum` and `json` e2e fixtures that pin Roku's enumeration and key-casing semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)