### PR TITLE
fix(core): resolve node methods in call position when a field shadows the name

### DIFF
--- a/src/core/interpreter/index.ts
+++ b/src/core/interpreter/index.ts
@@ -116,6 +116,8 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
     private _tryMode = false;
     private _debugMode: DebugMode = DebugMode.NONE;
     private _dotLevel = 0;
+    /** The callee expression of the `Expr.Call` currently being evaluated (call position). */
+    private _activeCallee?: Expr.Expression;
     private _printed = false; // Prevent the warning when no entry point exists
     private _lastStmt: Stmt.Statement | null = null;
 
@@ -1251,7 +1253,14 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
 
     visitCall(expression: Expr.Call) {
         // evaluate the function to call (it could be the result of another function call)
-        const evaluated = this.evaluate(expression.callee);
+        const prevCallee = this._activeCallee;
+        this._activeCallee = expression.callee;
+        let evaluated: BrsType;
+        try {
+            evaluated = this.evaluate(expression.callee);
+        } finally {
+            this._activeCallee = prevCallee;
+        }
         const callee = evaluated instanceof RoFunction ? evaluated.unbox() : evaluated;
         // evaluate all of the arguments as well (they could also be function calls)
         let args = expression.args.map(this.evaluate, this);
@@ -1336,6 +1345,15 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                 const target = source.get(new BrsString(expression.name.text));
                 if (isBrsCallable(target) && source instanceof RoAssociativeArray) {
                     target.setContext(source);
+                }
+                // A SceneGraph node may declare an XML <interface> field named after one of its
+                // component methods (e.g. a boolean field `isInFocusChain`). On Roku the field only
+                // shadows the method for reads — call syntax still resolves the interface method.
+                if (!isBrsCallable(target) && this._activeCallee === expression && isSceneGraphNode(source)) {
+                    const method = source.getMethod(expression.name.text);
+                    if (method) {
+                        return method;
+                    }
                 }
                 return target;
             } catch (err: any) {

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -377,6 +377,29 @@ describe("cli", () => {
         expect(stderr).toContain('Attempt to add duplicate field "sharedField" to RokuML component "XmlChildComp"');
     }, 10000);
 
+    it("Resolves a component method in call position when an XML field shadows its name", async () => {
+        let command = ["node", brsCliPath, "-r method-shadow-field-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        // A component may declare an <interface> field named after a built-in method
+        // (e.g. isInFocusChain). On Roku the field only shadows the method for reads:
+        // call syntax still resolves the interface method, while plain reads and
+        // observeField target the XML field (Tubi's TubiProgressBar relies on this).
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "=== Method Shadow Field Repro ===",
+            "init call isInFocusChain() = false",
+            "observer fired with true",
+            "field read = true",
+            "method call = false",
+            "=== Method Shadow Field Repro Complete ===",
+            "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+    }, 10000);
+
     it("Resolves an anonymous function observer registered by its toStr() name", async () => {
         let command = ["node", brsCliPath, "-r anon-observer-app", "source/main.brs", "-c 0"].join(" ");
 

--- a/test/cli/resources/method-shadow-field-app/components/ShadowGroup.xml
+++ b/test/cli/resources/method-shadow-field-app/components/ShadowGroup.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Declares an <interface> field named after a built-in component method
+    (isInFocusChain, from ifSGNodeFocus). On a real Roku the field only shadows
+    the method for reads: call syntax (node.isInFocusChain()) still resolves the
+    interface method, while a plain read (node.isInFocusChain) and observeField
+    target the XML field. Tubi's TubiProgressBar relies on exactly this.
+-->
+<component name="ShadowGroup" extends="Group">
+    <interface>
+        <field id="isInFocusChain" type="boolean" value="false" alwaysNotify="true" />
+    </interface>
+    <script type="text/brightscript">
+    <![CDATA[
+        sub init()
+            m.top.observeField("isInFocusChain", "onShadowChange")
+            print "init call isInFocusChain() = "; m.top.isInFocusChain()
+        end sub
+
+        sub onShadowChange(msg)
+            print "observer fired with "; msg.getData()
+        end sub
+    ]]>
+    </script>
+</component>

--- a/test/cli/resources/method-shadow-field-app/manifest
+++ b/test/cli/resources/method-shadow-field-app/manifest
@@ -1,0 +1,4 @@
+title=Method Shadow Field Test
+major_version=1
+minor_version=0
+build_version=0

--- a/test/cli/resources/method-shadow-field-app/source/main.brs
+++ b/test/cli/resources/method-shadow-field-app/source/main.brs
@@ -1,0 +1,13 @@
+sub Main()
+    print "=== Method Shadow Field Repro ==="
+
+    ' ShadowGroup declares an XML field named "isInFocusChain", which is also an
+    ' ifSGNodeFocus method. Call syntax must resolve the method (a field value is
+    ' not callable), while reads and observers must see the XML field.
+    node = CreateObject("roSGNode", "ShadowGroup")
+    node.isInFocusChain = true
+    print "field read = "; node.isInFocusChain
+    print "method call = "; node.isInFocusChain()
+
+    print "=== Method Shadow Field Repro Complete ==="
+end sub


### PR DESCRIPTION
## Root cause

A SceneGraph component may declare an XML `<interface>` field named after one of the node's built-in interface methods:

```xml
<component name="MyTile" extends="Group">
  <interface>
    <field id="isInFocusChain" type="boolean" value="false" alwaysNotify="true" />
  </interface>
</component>
```

```brs
sub init()
    m.top.observeField("isInFocusChain", "onChainChange") ' observes the XML field
    if m.top.isInFocusChain() then ...                     ' calls the ifSGNodeFocus method
end sub
```

On a real device both lines work: the field only shadows the method **for reads** — call syntax still resolves the interface method. In the interpreter, dotted access went through `Node.get()`, where fields win over methods, so the call received the boolean field value and crashed with `Function Call Operator ( ) attempted on non-function`.

## Solution

- `visitCall` records the callee expression (`_activeCallee`, save/restore around evaluation) so member resolution knows it is happening in call position.
- `visitDottedGet` falls back to `getMethod()` — only for SceneGraph nodes, only when the expression is the active callee, and only when the member value is not callable — before returning the field value.

Scope is deliberately narrow: associative-array semantics (stored members shadow built-in methods) are unchanged, as are plain field reads, `observeField`, and every non-call dot access.

## Verification

- New CLI fixture `test/cli/resources/method-shadow-field-app` + test in `test/cli/cli.test.js`: the shadowed method resolves in call position (both inside `init()` and from Main), a plain read returns the XML field value, and the field observer fires on assignment.
- Full suite green (141 suites / 1968 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)