### PR TITLE
feat(rsg): add ifSGNodeBoundingRect sub-part methods

### DIFF
--- a/src/extensions/scenegraph/components/RoSGNode.ts
+++ b/src/extensions/scenegraph/components/RoSGNode.ts
@@ -126,6 +126,9 @@ export abstract class RoSGNode extends BrsComponent implements BrsValue, ISGNode
                 this.boundingRect,
                 this.localBoundingRect,
                 this.sceneBoundingRect,
+                this.subBoundingRect,
+                this.localSubBoundingRect,
+                this.sceneSubBoundingRect,
                 this.ancestorBoundingRect,
             ],
             ifSGNodeHttpAgentAccess: [this.getHttpAgent, this.setHttpAgent],
@@ -229,6 +232,7 @@ export abstract class RoSGNode extends BrsComponent implements BrsValue, ISGNode
     protected abstract findRootNode(start?: RoSGNode): RoSGNode;
 
     protected abstract getBoundingRect(type: string, interpreter?: Interpreter): Rect;
+    protected abstract getSubBoundingRect(type: string, itemNumber: string, interpreter?: Interpreter): Rect;
     protected abstract compareNodes(other: RoSGNode): boolean;
     protected abstract getThreadInfo(): RoAssociativeArray;
 
@@ -1534,6 +1538,57 @@ export abstract class RoSGNode extends BrsComponent implements BrsValue, ISGNode
                     return remote;
                 }
                 return toAssociativeArray(this.getBoundingRect("toScene", interpreter));
+            },
+        });
+    }
+
+    /* Returns the bounding rectangle of an identified sub part, in the parent's coordinate system. */
+    protected get subBoundingRect(): Callable {
+        return new Callable("subBoundingRect", {
+            signature: {
+                args: [new StdlibArgument("itemNumber", ValueKind.String)],
+                returns: ValueKind.Dynamic,
+            },
+            impl: (interpreter: Interpreter, itemNumber: BrsString) => {
+                const remote = this.rendezvousCall(interpreter, "subBoundingRect", [itemNumber]);
+                if (remote !== undefined) {
+                    return remote;
+                }
+                return toAssociativeArray(this.getSubBoundingRect("toParent", itemNumber.getValue(), interpreter));
+            },
+        });
+    }
+
+    /* Returns the bounding rectangle of an identified sub part, in the node's local coordinate system. */
+    protected get localSubBoundingRect(): Callable {
+        return new Callable("localSubBoundingRect", {
+            signature: {
+                args: [new StdlibArgument("itemNumber", ValueKind.String)],
+                returns: ValueKind.Dynamic,
+            },
+            impl: (interpreter: Interpreter, itemNumber: BrsString) => {
+                const remote = this.rendezvousCall(interpreter, "localSubBoundingRect", [itemNumber]);
+                if (remote !== undefined) {
+                    return remote;
+                }
+                return toAssociativeArray(this.getSubBoundingRect("local", itemNumber.getValue(), interpreter));
+            },
+        });
+    }
+
+    /* Returns the bounding rectangle of an identified sub part, in the Scene's coordinate system. */
+    protected get sceneSubBoundingRect(): Callable {
+        return new Callable("sceneSubBoundingRect", {
+            signature: {
+                args: [new StdlibArgument("itemNumber", ValueKind.String)],
+                returns: ValueKind.Dynamic,
+            },
+            impl: (interpreter: Interpreter, itemNumber: BrsString) => {
+                const remote = this.rendezvousCall(interpreter, "sceneSubBoundingRect", [itemNumber]);
+                if (remote !== undefined) {
+                    return remote;
+                }
+                return toAssociativeArray(this.getSubBoundingRect("toScene", itemNumber.getValue(), interpreter));
             },
         });
     }

--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -15,6 +15,7 @@ import {
 import { FieldKind, FieldModel } from "../SGTypes";
 import { Poster, SGNodeType } from ".";
 import { Group } from "./Group";
+import { Node } from "./Node";
 import { createNode } from "../factory/NodeFactory";
 import { brsValueOf, jsValueOf } from "../factory/Serializer";
 import { sgRoot } from "../SGRoot";
@@ -220,6 +221,28 @@ export class ArrayGrid extends Group {
             return this.metadata.findIndex((item) => item.index === index);
         }
         return index;
+    }
+
+    /**
+     * Resolves an ifSGNodeBoundingRect sub part identifier to the matching item component:
+     * `itemX` (data-model index X), `itemX_Y` (row X — list nodes hold one component per row),
+     * `focusItem` and `focusIndicator` (the focused item; the indicator hugs the item rect).
+     * Item components are created lazily during rendering, so an off-screen item resolves to
+     * undefined and the caller falls back to the node's own bounding rect (matching Roku's
+     * "if the subpart does not exist" behavior).
+     */
+    protected resolveSubpart(itemNumber: string): Node | undefined {
+        const name = itemNumber.trim().toLowerCase();
+        let compIndex = -1;
+        if (name === "focusitem" || name === "focusindicator") {
+            compIndex = this.focusIndex;
+        } else if (name.startsWith("item")) {
+            const contentIndex = Number.parseInt(name.slice(4), 10);
+            if (Number.isInteger(contentIndex)) {
+                compIndex = this.findContentIndex(contentIndex);
+            }
+        }
+        return compIndex >= 0 ? this.itemComps[compIndex] : undefined;
     }
 
     protected updateItemFocus(index: number, focus: boolean, nodeFocus: boolean) {

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -866,6 +866,49 @@ export class Node extends RoSGNode implements BrsValue {
     }
 
     /**
+     * Returns the bounding rectangle of an identified sub part (ifSGNodeBoundingRect's
+     * subBoundingRect/localSubBoundingRect/sceneSubBoundingRect). Sub parts (`itemX`, `itemX_Y`,
+     * `focusItem`, `focusIndicator`) only exist on ArrayGrid-derived nodes, which override
+     * `resolveSubpart`. Per the Roku spec, when the sub part does not exist the node's own
+     * bounding rectangle (in the requested coordinate space) is returned.
+     * @param type Rectangle type: `local`, `toScene`, or any other value for parent space.
+     * @param itemNumber Sub part identifier (e.g. "item3", "item4_11", "focusItem").
+     * @param interpreter Interpreter used to refresh layout before measuring.
+     * @returns Bounding rectangle of the sub part in the requested coordinate space.
+     */
+    getSubBoundingRect(type: string, itemNumber: string, interpreter?: Interpreter): Rect {
+        // Refresh layout the same way getBoundingRect does (guarded against re-entrant renders).
+        const ownRect = this.getBoundingRect(type, interpreter);
+        const subpart = this.resolveSubpart(itemNumber);
+        if (!subpart) {
+            return ownRect;
+        }
+        const subScene = subpart.rectToScene;
+        if (type === "toScene") {
+            return { ...subScene };
+        }
+        // The subpart rect is tracked in scene coordinates; re-express it relative to this
+        // node's position in the requested space.
+        const base = type === "local" ? this.rectLocal : this.rectToParent;
+        return {
+            x: base.x + (subScene.x - this.rectToScene.x),
+            y: base.y + (subScene.y - this.rectToScene.y),
+            width: subScene.width,
+            height: subScene.height,
+        };
+    }
+
+    /**
+     * Resolves a bounding-rect sub part identifier to a node. Only ArrayGrid-derived nodes
+     * have sub parts; the base implementation reports "no such sub part".
+     * @param _itemNumber Sub part identifier.
+     * @returns The sub part node, or undefined when the node has no such sub part.
+     */
+    protected resolveSubpart(_itemNumber: string): Node | undefined {
+        return undefined;
+    }
+
+    /**
      * Registers a field observer callback or message port.
      * @param interpreter Active interpreter owning the observer.
      * @param scope Observer lifetime scope.

--- a/test/extensions/scenegraph/SubBoundingRect.test.js
+++ b/test/extensions/scenegraph/SubBoundingRect.test.js
@@ -1,0 +1,68 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { Node, Group, MarkupGrid, ContentNode } = scenegraph;
+const { BrsDevice } = core;
+
+describe("ifSGNodeBoundingRect sub-part methods", () => {
+    beforeAll(() => {
+        // MarkupGrid's font-typed defaults need the common: fonts; mount the common volume once.
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    test("subBoundingRect/localSubBoundingRect/sceneSubBoundingRect are registered on nodes", () => {
+        const node = new Node([], "Node");
+        for (const method of ["subBoundingRect", "localSubBoundingRect", "sceneSubBoundingRect"]) {
+            expect(node.getMethod(method)).toBeTruthy();
+        }
+    });
+
+    test("falls back to the node's own bounding rect when the sub part does not exist", () => {
+        const node = new Group([], "Group");
+        node.rectToParent = { x: 10, y: 20, width: 100, height: 50 };
+        node.rectLocal = { x: 0, y: 0, width: 100, height: 50 };
+        node.rectToScene = { x: 110, y: 220, width: 100, height: 50 };
+
+        // Plain nodes have no sub parts; per the Roku spec the node's own rect is returned.
+        expect(node.getSubBoundingRect("toParent", "item3")).toEqual(node.rectToParent);
+        expect(node.getSubBoundingRect("local", "focusItem")).toEqual(node.rectLocal);
+        expect(node.getSubBoundingRect("toScene", "item1_2")).toEqual(node.rectToScene);
+    });
+
+    test("resolves itemX and focusItem on an ArrayGrid-derived node", () => {
+        const grid = new MarkupGrid();
+        grid.rectToParent = { x: 10, y: 20, width: 438, height: 800 };
+        grid.rectLocal = { x: 0, y: 0, width: 438, height: 800 };
+        grid.rectToScene = { x: 100, y: 200, width: 438, height: 800 };
+
+        // Simulate two rendered item components (itemComps are created during rendering).
+        const item0 = new Group([], "Group");
+        item0.rectToScene = { x: 100, y: 200, width: 438, height: 72 };
+        const item1 = new Group([], "Group");
+        item1.rectToScene = { x: 100, y: 284, width: 438, height: 72 };
+        grid.itemComps[0] = item0;
+        grid.itemComps[1] = item1;
+        grid.content.push(new ContentNode(), new ContentNode());
+        grid.focusIndex = 1;
+
+        // itemX in the parent's coordinate system: grid position + offset within the grid.
+        expect(grid.getSubBoundingRect("toParent", "item1")).toEqual({ x: 10, y: 104, width: 438, height: 72 });
+        // itemX in the grid's local coordinate system.
+        expect(grid.getSubBoundingRect("local", "item1")).toEqual({ x: 0, y: 84, width: 438, height: 72 });
+        // itemX in scene coordinates is the tracked rect itself.
+        expect(grid.getSubBoundingRect("toScene", "item0")).toEqual(item0.rectToScene);
+        // focusItem/focusIndicator resolve to the focused item component.
+        expect(grid.getSubBoundingRect("toParent", "focusItem")).toEqual({ x: 10, y: 104, width: 438, height: 72 });
+        expect(grid.getSubBoundingRect("toParent", "focusIndicator")).toEqual({
+            x: 10,
+            y: 104,
+            width: 438,
+            height: 72,
+        });
+        // An item that was never rendered (no component yet) falls back to the grid's rect.
+        expect(grid.getSubBoundingRect("toParent", "item7")).toEqual(grid.rectToParent);
+    });
+});


### PR DESCRIPTION
## Root cause

`ifSGNodeBoundingRect`'s sub-part methods — `subBoundingRect`, `localSubBoundingRect`, `sceneSubBoundingRect` — were not implemented (only `boundingRect`/`localBoundingRect`/`sceneBoundingRect`/`ancestorBoundingRect` existed). Apps use them to align sibling decorations with a grid item, e.g. positioning a selection background behind a MarkupGrid row:

```brs
rect = m.list.subBoundingRect("item" + index.toStr())
m.background.translation = [m.background.translation[0], rect.y]
```

The missing method resolved to `invalid`, crashing with `Function Call Operator ( ) attempted on non-function`.

## Solution

Per the reference spec (`external/dev-doc` → `ifsgnodeboundingrect.md`):

- **`RoSGNode`** gains the three methods, registered under `ifSGNodeBoundingRect` and rendezvous-aware like their siblings (a Task-thread call on a render-owned node is served by the render thread).
- **`Node.getSubBoundingRect(type, itemNumber)`** refreshes layout the same way `getBoundingRect` does (including the re-entrant render guard) and implements the documented fallback: *if the subpart does not exist, the node's own bounding rectangle is returned* — so plain nodes and never-rendered items answer safely instead of erroring.
- **`ArrayGrid.resolveSubpart`** resolves the documented identifiers: `itemX` (data-model index, mapped through section metadata), `itemX_Y` (row X — list nodes hold one component per row), and `focusItem`/`focusIndicator` (the focused item component). Sub-part rects are derived from the scene-space rects the render pass already tracks, then re-expressed in the requested coordinate system.

## Verification

- New `test/extensions/scenegraph/SubBoundingRect.test.js`: method registration, the spec fallback on plain nodes, and `itemX`/`focusItem`/`focusIndicator` resolution on a MarkupGrid in all three coordinate systems (plus fallback for a never-rendered item).
- Full suite green (142 suites / 1970 tests).
- Verified in the browser build: a MarkupGrid side menu that positions its selection background via `subBoundingRect("itemN")` now lays out correctly instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)