### PR TITLE
fix(rsg): mirror remote field add/remove on the local node copy

### DIFF
--- a/src/extensions/scenegraph/components/RoSGNode.ts
+++ b/src/extensions/scenegraph/components/RoSGNode.ts
@@ -442,6 +442,10 @@ export abstract class RoSGNode extends BrsComponent implements BrsValue, ISGNode
             impl: (interpreter: Interpreter, fieldName: BrsString, type: BrsString, alwaysNotify: BrsBoolean) => {
                 const remote = this.rendezvousCall(interpreter, "addField", [fieldName, type, alwaysNotify]);
                 if (remote !== undefined) {
+                    // Mirror the field on this thread's copy: subsequent local reads/writes consult
+                    // hasNodeField before rendezvousing, so without the mirror a field added through
+                    // a rendezvous stays invisible here (set fails, get returns invalid).
+                    this.addNodeField(fieldName.getValue(), type.getValue(), alwaysNotify.toBoolean(), true);
                     return remote;
                 }
                 this.location = interpreter.formatLocation();
@@ -461,6 +465,10 @@ export abstract class RoSGNode extends BrsComponent implements BrsValue, ISGNode
             impl: (interpreter: Interpreter, fields: RoAssociativeArray) => {
                 const remote = this.rendezvousCall(interpreter, "addFields", [fields]);
                 if (remote !== undefined) {
+                    // Mirror the fields on this thread's copy (see addField).
+                    if (fields instanceof RoAssociativeArray) {
+                        this.setNodeFields(fields, true);
+                    }
                     return remote;
                 }
                 if (!(fields instanceof RoAssociativeArray)) {
@@ -887,6 +895,8 @@ export abstract class RoSGNode extends BrsComponent implements BrsValue, ISGNode
             impl: (interpreter: Interpreter, fieldName: BrsString) => {
                 const remote = this.rendezvousCall(interpreter, "removeField", [fieldName]);
                 if (remote !== undefined) {
+                    // Mirror the removal on this thread's copy (see addField).
+                    this.removeFieldEntry(fieldName.getValue());
                     return remote;
                 }
                 this.removeFieldEntry(fieldName.getValue());
@@ -905,6 +915,14 @@ export abstract class RoSGNode extends BrsComponent implements BrsValue, ISGNode
             impl: (interpreter: Interpreter, fieldNames: RoArray) => {
                 const remote = this.rendezvousCall(interpreter, "removeFields", [fieldNames]);
                 if (remote !== undefined) {
+                    // Mirror the removals on this thread's copy (see addField).
+                    if (fieldNames instanceof RoArray) {
+                        for (const fieldName of fieldNames.getElements()) {
+                            if (isBrsString(fieldName)) {
+                                this.removeFieldEntry(fieldName.getValue());
+                            }
+                        }
+                    }
                     return remote;
                 }
                 if (!(fieldNames instanceof RoArray)) {

--- a/test/extensions/scenegraph/RemoteFieldMirror.test.js
+++ b/test/extensions/scenegraph/RemoteFieldMirror.test.js
@@ -1,0 +1,54 @@
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { Node } = scenegraph;
+const { Interpreter } = core;
+const { BrsString, BrsBoolean, RoAssociativeArray, RoArray, Int32 } = core;
+
+describe("remote field management mirrors on the local node copy", () => {
+    let interpreter;
+    beforeEach(() => {
+        interpreter = new Interpreter();
+    });
+
+    /** Makes the node behave as a remote (render-owned) node: every field-management call
+     * rendezvouses. The stub returns the remote result; the local mirror is what's under test. */
+    function remoteNode() {
+        const node = new Node([], "Node");
+        node.rendezvousCall = () => BrsBoolean.True;
+        return node;
+    }
+
+    test("addField adds the field locally when served via rendezvous", () => {
+        const node = remoteNode();
+
+        const addField = node.getMethod("addField");
+        addField.call(interpreter, new BrsString("translationAA"), new BrsString("assocarray"), BrsBoolean.False);
+
+        // Without the mirror, hasNodeField is false here — a subsequent local set fails with
+        // "Tried to set nonexistent field" and a read returns invalid, even though the
+        // authoritative copy on the owning thread has the field.
+        expect(node.hasNodeField("translationaa")).toBe(true);
+    });
+
+    test("addFields adds the fields locally when served via rendezvous", () => {
+        const node = remoteNode();
+
+        const addFields = node.getMethod("addFields");
+        addFields.call(interpreter, new RoAssociativeArray([{ name: new BrsString("counter"), value: new Int32(1) }]));
+
+        expect(node.hasNodeField("counter")).toBe(true);
+    });
+
+    test("removeField/removeFields remove the fields locally when served via rendezvous", () => {
+        const node = remoteNode();
+        node.addNodeField("first", "string", false, true);
+        node.addNodeField("second", "string", false, true);
+
+        node.getMethod("removeField").call(interpreter, new BrsString("first"));
+        node.getMethod("removeFields").call(interpreter, new RoArray([new BrsString("second")]));
+
+        expect(node.hasNodeField("first")).toBe(false);
+        expect(node.hasNodeField("second")).toBe(false);
+    });
+});


### PR DESCRIPTION
## Root cause

When a Task thread calls `addField`/`addFields`/`removeField`/`removeFields` on a node owned by another thread (typically `m.global`), the call correctly rendezvouses to the owning thread — but then returned immediately, leaving the calling thread's **local copy** of the node without the change. That local copy gates all subsequent field access: `get`/`set` consult `hasNodeField` before deciding to rendezvous. So a field added through a rendezvous stayed invisible on the calling thread — setting it failed with `Tried to set nonexistent field`, and reading it returned `invalid`. This breaks a very common app pattern:

```brs
if m.global.translationCache = invalid
    m.global.addField("translationCache", "assocarray", false)
    m.global.translationCache = {}   ' ERROR: nonexistent field
end if
cache = m.global.translationCache    ' invalid → crash on next access
```

## Solution

The four field-management methods now apply the same mutation to the local copy after a successful rendezvous:

- `addField` / `addFields` → `addNodeField`/`setNodeFields` locally (idempotent — a field that later arrives via node sync is unaffected).
- `removeField` / `removeFields` → `removeFieldEntry` locally.

The authoritative copy on the owning thread is still updated exclusively by the rendezvous; the mirror only keeps the caller's view consistent, matching a real device where the node is a single process-wide object.

## Verification

- New `test/extensions/scenegraph/RemoteFieldMirror.test.js`: with the rendezvous stubbed as "served remotely", each method must leave the local copy consistent (field present after add, absent after remove).
- Full suite green (143 suites / 1970 tests).
- Verified in the browser build: a Task-thread module that adds a field to `m.global` and immediately writes/reads it now works end-to-end instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)