### PR TITLE
feat(rsg): add scrollingStatus field to ArrayGrid nodes

### DIFF
--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -83,6 +83,10 @@ export class ArrayGrid extends Group {
         { name: "itemUnfocused", type: "integer", value: "-1", alwaysNotify: true },
         { name: "jumpToItem", type: "integer", value: "-1", alwaysNotify: true },
         { name: "animateToItem", type: "integer", value: "-1", alwaysNotify: true },
+        // Read-only on device: true while the list/grid is scrolling the focus. Documented under
+        // ZoomRowList but present on all ArrayGrid-derived nodes on a real Roku (apps alias it on
+        // plain RowList). Scrolling here is instant, so it stays false.
+        { name: "scrollingStatus", type: "boolean", value: "false" },
         { name: "currFocusRow", type: "float", value: "0.0" },
         { name: "currFocusColumn", type: "float", value: "0.0" },
         { name: "currFocusSection", type: "float", value: "0.0" },

--- a/test/extensions/scenegraph/ArrayGridFields.test.js
+++ b/test/extensions/scenegraph/ArrayGridFields.test.js
@@ -1,0 +1,26 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { RowList, ZoomRowList, MarkupGrid } = scenegraph;
+const { BrsDevice } = core;
+
+describe("ArrayGrid scrollingStatus field", () => {
+    beforeAll(() => {
+        // List/grid nodes have font-typed defaults; mount the common: volume once.
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    test("is present (default false) on ArrayGrid-derived list and grid nodes", () => {
+        // Documented under ZoomRowList but present on all ArrayGrid-derived nodes on a real
+        // device — apps alias it on plain RowList, and an unresolvable alias target aborts the
+        // component's remaining <interface> fields, cascading into missing-field errors.
+        for (const NodeType of [RowList, ZoomRowList, MarkupGrid]) {
+            const node = new NodeType();
+            expect(node.hasNodeField("scrollingstatus")).toBe(true);
+            expect(node.getValueJS("scrollingStatus")).toBe(false);
+        }
+    });
+});


### PR DESCRIPTION
## Root cause

Every ArrayGrid-derived list/grid node on a real device exposes a read-only `scrollingStatus` boolean (true while the node is scrolling the focus). The reference docs only list it under **ZoomRowList**, but it exists on plain **RowList** on-device and apps alias it:

```xml
<field id="listScrollingStatus" alias="RowList.scrollingStatus" />
```

In the engine the field didn't exist, so the alias target failed to resolve — and an `<interface>` field alias whose first target is missing aborts the component's remaining field declarations. That cascades: every field declared after the alias reads back as nonexistent (`Tried to set nonexistent field ...`), and any outer component aliasing one of those dropped fields fails too.

## Solution

Declare `scrollingStatus` (boolean, default `false`) in `ArrayGrid.defaultFields`, so RowList, MarkupGrid, PosterGrid, and the other derived nodes inherit it, matching device behavior. Scrolling in the engine is currently instant, so the field keeps its default; wiring it to scroll animations can come later.

## Verification

- New `test/extensions/scenegraph/ArrayGridFields.test.js`: the field is present with default `false` on RowList, ZoomRowList, and MarkupGrid.
- Full suite green (143 suites / 1968 tests).
- Verified in the browser build: a component chain that aliases `RowList.scrollingStatus` now declares all of its remaining `<interface>` fields instead of dropping them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)