### PR TITLE
fix(rsg): failed interface field alias no longer aborts the component's fields

### DIFF
--- a/src/extensions/scenegraph/factory/NodeFactory.ts
+++ b/src/extensions/scenegraph/factory/NodeFactory.ts
@@ -779,9 +779,9 @@ function addFields(interpreter: Interpreter, node: Node, typeDef: ComponentDefin
             continue;
         }
         if (fieldValue.alias?.includes(".")) {
-            if (!addAliases(fieldName, fieldValue.alias, node, typeDef)) {
-                return;
-            }
+            // An unresolvable alias target only warns (like a device): the remaining targets are
+            // still tried, and the fields declared after this one are still added.
+            addAliases(fieldName, fieldValue.alias, node, typeDef);
         } else {
             // resolveField materializes a ContentNode hidden metadata default so a component that
             // redeclares one (e.g. "title") is still detected and routed through replaceField.
@@ -820,13 +820,18 @@ function addFields(interpreter: Interpreter, node: Node, typeDef: ComponentDefin
 
 /**
  * Add aliases for a field to a node based on the component definition.
+ *
+ * An unresolvable target (missing node or missing field) writes the device-style warning and is
+ * skipped — the remaining targets are still tried, so an alias whose FIRST target is bad still
+ * binds to any later valid ones (and vice versa). Matching a real device, a failed alias never
+ * aborts the component: fields declared after it must still be added, so callers must not treat
+ * this as fatal. When no target resolves at all, the field is simply not created.
  * @param fieldName The name of the field to alias.
  * @param fieldAlias The alias string specifying target nodes and fields.
  * @param node The node to which aliases are added.
  * @param typeDef The component definition containing field specifications.
- * @returns True if aliases were successfully added, false otherwise.
  */
-function addAliases(fieldName: string, fieldAlias: string, node: Node, typeDef: ComponentDefinition): boolean {
+function addAliases(fieldName: string, fieldAlias: string, node: Node, typeDef: ComponentDefinition) {
     // Parse comma-separated alias list (e.g., "child1.field1,child2.field2")
     const aliasParts = fieldAlias.split(",").map((s: string) => s.trim());
     const targets: FieldAliasTarget[] = [];
@@ -838,11 +843,11 @@ function addAliases(fieldName: string, fieldAlias: string, node: Node, typeDef: 
         if (childNode instanceof Node && childField) {
             const field = childNode.resolveField(childField.toLowerCase());
             if (field) {
-                if (targets.length === 0) {
+                if (!sharedField) {
                     // Get first child field and type
                     sharedField = field;
                     fieldType = field.getType();
-                } else if (sharedField && field.getType() === fieldType) {
+                } else if (field.getType() === fieldType) {
                     // Set siblings with the shared field
                     childNode.getNodeFields().set(childField.toLowerCase(), sharedField);
                 } else {
@@ -855,27 +860,17 @@ function addAliases(fieldName: string, fieldAlias: string, node: Node, typeDef: 
                 msg += `-- Interface field alias failed: Node "${childName}" has no field named "${childField}"\n`;
                 msg += `-- Error found ${typeDef.xmlPath}`;
                 BrsDevice.stderr.write(msg);
-                if (sharedField) {
-                    break;
-                }
-                return false;
             }
         } else {
             let msg = `warning,Error creating XML component ${node.nodeSubtype}\n`;
             msg += `-- Interface field alias failed: No node named ${childName}\n`;
             msg += `-- Error found ${typeDef.xmlPath}`;
             BrsDevice.stderr.write(msg);
-            if (sharedField) {
-                break;
-            }
-            return false;
         }
     }
     if (targets.length > 0 && sharedField) {
         node.addNodeFieldAlias(fieldName, targets, sharedField);
-        return true;
     }
-    return false;
 }
 
 /**

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -248,6 +248,32 @@ describe("cli", () => {
         ]);
     }, 10000);
 
+    it("Keeps a component usable when interface field aliases have unresolvable targets", async () => {
+        // Regression: a failed alias target (missing node or missing field) used to abort addFields,
+        // dropping every <interface> field declared after it. A device only warns: the remaining
+        // alias targets still bind and the trailing fields are still added.
+        let command = ["node", brsCliPath, "-r bad-alias-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout, stderr } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "=== Testing Failed Alias Targets ===",
+            "scene.trailing = present",
+            "label1.text = bound",
+            "label2.text = synced",
+            "label3.text = synced",
+            "hasField allBad = false",
+            "=== Test Complete ===",
+            "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+        // The device-style warnings are still written for each unresolvable target.
+        expect(stderr).toContain("-- Interface field alias failed: No node named ghost");
+        expect(stderr).toContain('-- Interface field alias failed: Node "label1" has no field named "nosuchfield"');
+    }, 10000);
+
     it("SceneGraph Observers Test", async () => {
         let command = ["node", brsCliPath, "-r observer-app", "source/main.brs", "-c 0"].join(" ");
 

--- a/test/cli/resources/bad-alias-app/components/BadAliasTest.xml
+++ b/test/cli/resources/bad-alias-app/components/BadAliasTest.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="BadAliasTest" extends="Scene">
+  <interface>
+    <!-- First target references a node that does not exist; the later valid target must still bind -->
+    <field id="firstBad" alias="ghost.text, label1.text" />
+    <!-- Middle target references a field that does not exist; valid siblings must still bind -->
+    <field id="midBad" alias="label2.text, label1.nosuchfield, label3.text" />
+    <!-- No target resolves: the field is not created, but it must not abort the component -->
+    <field id="allBad" alias="ghost.text" />
+    <!-- Declared after the failed aliases: must still be added (no cascade) -->
+    <field id="trailing" type="string" value="present" />
+  </interface>
+  <children>
+    <Label id="label1" />
+    <Label id="label2" />
+    <Label id="label3" />
+  </children>
+</component>

--- a/test/cli/resources/bad-alias-app/source/main.brs
+++ b/test/cli/resources/bad-alias-app/source/main.brs
@@ -1,0 +1,27 @@
+sub Main()
+    print "=== Testing Failed Alias Targets ==="
+
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+
+    scene = screen.CreateScene("BadAliasTest")
+    screen.show()
+
+    ' A field declared after the failed aliases must exist (no trailing-field cascade)
+    print "scene.trailing = "; scene.trailing
+
+    ' First target was a missing node: the alias still bound to the later valid target
+    scene.firstBad = "bound"
+    print "label1.text = "; scene.findNode("label1").text
+
+    ' Middle target was a missing field: the valid siblings around it still bound
+    scene.midBad = "synced"
+    print "label2.text = "; scene.findNode("label2").text
+    print "label3.text = "; scene.findNode("label3").text
+
+    ' An alias with no resolvable target creates no field
+    print "hasField allBad = "; scene.hasField("allBad")
+
+    print "=== Test Complete ==="
+end sub


### PR DESCRIPTION
## Root cause

An unresolvable `<field alias>` target — a typo'd node id, or a field the target node does not declare — aborted `addFields` in `NodeFactory`: when the **first** target failed, `addAliases` returned `false` and **every `<interface>` field declared after the alias was silently dropped**. The component then misbehaves far from the cause: observers on the missing fields never fire, reads return `invalid`, sets log "Tried to set nonexistent field", and a derived component aliasing one of the dropped fields cascades the loss further.

A real device only warns (`-- Interface field alias failed: …`) and keeps going — components with a stale alias target still work.

## Fix

`addAliases` now matches device behavior:

- Each unresolvable target writes the device-style warning and is **skipped**; the remaining targets are still tried, so an alias whose first target is bad still binds to any later valid one (previously only the reverse worked — a bad *later* target already kept the earlier partial alias).
- A failed alias **never aborts `addFields`** — fields declared after it are always added.
- When no target resolves at all, the aliased field is simply not created; the component stays otherwise intact.

The duplicate-field redeclaration abort is unchanged — only alias resolution failures are affected.

## Verification

- New `bad-alias-app` fixture + test in `test/cli/cli.test.js` covering: first-bad-target still binds to the later valid target, a bad middle target still binds its valid siblings, a trailing field declared after the failed aliases survives, an all-bad alias creates no field, and the device-style warnings are still emitted.
- Full test suite green: 141 suites / 1970 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)