### PR TITLE
fix(rsg): skip grid slots whose item component failed to create

### DIFF
--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -336,6 +336,10 @@ export class ArrayGrid extends Group {
                 this.itemComps[index] = itemComp;
             }
         }
+        if (!this.itemComps[index]) {
+            // Item component creation failed: skip the slot instead of crashing the render pass.
+            return;
+        }
         if (content.changed) {
             this.itemComps[index].setValue("itemContent", content, true);
             content.changed = false;

--- a/src/extensions/scenegraph/nodes/RowList.ts
+++ b/src/extensions/scenegraph/nodes/RowList.ts
@@ -2,6 +2,7 @@ import {
     AAMember,
     Interpreter,
     BrsBoolean,
+    BrsDevice,
     BrsString,
     BrsType,
     Float,
@@ -766,6 +767,22 @@ export class RowList extends ArrayGrid {
         }
     }
 
+    private itemCompFailureLogged = false;
+
+    /** Writes a single error (not one per slot/frame) when item components cannot be created. */
+    private logItemCompFailure() {
+        if (this.itemCompFailureLogged) {
+            return;
+        }
+        this.itemCompFailureLogged = true;
+        const itemCompName = this.getValueJS("itemComponentName") ?? "";
+        BrsDevice.stderr.write(
+            `error,[sg.rowlist.create.fail] Failed to create item component: ${
+                itemCompName || "missing 'itemComponentName'"
+            }`
+        );
+    }
+
     protected renderRowItemComponent(
         interpreter: Interpreter,
         rowIndex: number,
@@ -809,17 +826,21 @@ export class RowList extends ArrayGrid {
         }
         // Update the component's focus state
         const itemComp = this.rowItemComps[rowIndex][colIndex];
-        if (itemComp) {
-            itemComp.setValue("rowHasFocus", BrsBoolean.from(this.focusIndex === rowIndex), false);
-            itemComp.setValue(this.focusField, BrsBoolean.from(nodeFocus), false);
-            itemComp.setValue("itemHasFocus", BrsBoolean.from(focused), false);
-            if (content.changed) {
-                itemComp.setValue("itemContent", content, true);
-                content.changed = false;
-            }
-            itemComp.setValue("focusPercent", new Float(focused ? 1 : 0), false);
-            itemComp.setValue("rowFocusPercent", new Float(this.focusIndex === rowIndex ? 1 : 0), false);
+        if (!itemComp) {
+            // Item component creation failed (e.g. an unresolvable itemComponentName): skip the
+            // slot instead of crashing the whole render pass on the undefined reference.
+            this.logItemCompFailure();
+            return;
         }
+        itemComp.setValue("rowHasFocus", BrsBoolean.from(this.focusIndex === rowIndex), false);
+        itemComp.setValue(this.focusField, BrsBoolean.from(nodeFocus), false);
+        itemComp.setValue("itemHasFocus", BrsBoolean.from(focused), false);
+        if (content.changed) {
+            itemComp.setValue("itemContent", content, true);
+            content.changed = false;
+        }
+        itemComp.setValue("focusPercent", new Float(focused ? 1 : 0), false);
+        itemComp.setValue("rowFocusPercent", new Float(this.focusIndex === rowIndex ? 1 : 0), false);
 
         const drawFocus = this.getValueJS("drawFocusFeedback");
         const drawFocusOnTop = this.getValueJS("drawFocusFeedbackOnTop");
@@ -827,7 +848,7 @@ export class RowList extends ArrayGrid {
             this.renderFocus(itemRect, opacity, nodeFocus, draw2D);
         }
         const itemOrigin = [itemRect.x, itemRect.y];
-        this.rowItemComps[rowIndex][colIndex].renderNode(interpreter, itemOrigin, rotation, opacity, draw2D);
+        itemComp.renderNode(interpreter, itemOrigin, rotation, opacity, draw2D);
         if (focused && drawFocus && drawFocusOnTop) {
             this.renderFocus(itemRect, opacity, nodeFocus, draw2D);
         }

--- a/test/extensions/scenegraph/RowListItemCompFailure.test.js
+++ b/test/extensions/scenegraph/RowListItemCompFailure.test.js
@@ -1,0 +1,59 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsDevice, BrsString, Interpreter } = core;
+
+function buildContent(rows) {
+    const root = SGNodeFactory.createNode("ContentNode");
+    for (const items of rows) {
+        const rowNode = SGNodeFactory.createNode("ContentNode");
+        for (const title of items) {
+            const itemNode = SGNodeFactory.createNode("ContentNode");
+            itemNode.setValue("title", new BrsString(title));
+            rowNode.appendChildToParent(itemNode);
+        }
+        root.appendChildToParent(rowNode);
+    }
+    return root;
+}
+
+describe("RowList with an item component that cannot be created", () => {
+    beforeAll(() => {
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+        jest.restoreAllMocks();
+    });
+
+    test("skips the slots and logs one error instead of crashing the render pass", () => {
+        // Regression: when createItemComponent returned nothing (unresolvable itemComponentName),
+        // renderRowItemComponent still dereferenced rowItemComps[row][col].renderNode — a TypeError
+        // that killed the whole render pass mid-frame (everything after the RowList stopped drawing).
+        const interpreter = new Interpreter();
+        const list = SGNodeFactory.createNode("RowList");
+        list.setValue("itemComponentName", new BrsString("NoSuchComponent"));
+        list.setValue("itemSize", scenegraph.getBrsValueFromFieldType("vector2d", "[1280, 200]"));
+        list.setValue(
+            "content",
+            buildContent([
+                ["A", "B", "C"],
+                ["D", "E"],
+            ])
+        );
+
+        const errors = [];
+        jest.spyOn(BrsDevice.stderr, "write").mockImplementation((msg) => errors.push(msg));
+
+        expect(() => list.renderNode(interpreter, [0, 0], 0, 1)).not.toThrow();
+
+        const failures = errors.filter((msg) => msg.includes("[sg.rowlist.create.fail]"));
+        expect(failures).toHaveLength(1);
+        expect(failures[0]).toContain("NoSuchComponent");
+    });
+});


### PR DESCRIPTION
## Root cause

When `createItemComponent` returns nothing (an unresolvable `itemComponentName`, or a component whose creation failed), the grid render paths still dereferenced the missing component:

- `RowList.renderRowItemComponent` guarded its `setValue` block with `if (itemComp)` — but then called `this.rowItemComps[rowIndex][colIndex].renderNode(...)` unguarded.
- `ArrayGrid.renderItemComponent` dereferenced `this.itemComps[index]` for both the content update and the `renderNode` call.

The resulting `TypeError` kills the whole render pass mid-frame, so everything after the grid in the scene silently stops drawing — a hard-to-diagnose partially blank UI instead of a visible error.

## Fix

Both paths now skip the slot when the component is missing, and `RowList` writes a single `[sg.rowlist.create.fail]` error (once — not per slot/frame) naming the item component, mirroring the existing `[sg.markupgrid.create.fail]` diagnostic.

## Verification

- New regression suite `test/extensions/scenegraph/RowListItemCompFailure.test.js`: a RowList with an unresolvable `itemComponentName` renders without throwing and logs exactly one `[sg.rowlist.create.fail]` error.
- Full test suite green: 142 suites / 1970 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)