### PR TITLE
fix(rsg): SceneGraph Video - prebuffer, configurable autoplay, buffering-step delivery, and active-player routing

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -24,6 +24,7 @@ const deviceInfo = {
   localIps: ["eth1,127.0.0.1"], // In a Browser isn't possible to get a real IP, populate it on NodeJS or Electron
   audioVolume: 50, // Defines the default volume level for system sounds - valid: (0-100)
   audioLanguage: "en", // Preferred audio track language
+  autoPlayEnabled: true, // Autoplay device setting, returned by `roDeviceInfo.IsAutoplayEnabled()` (default: enabled)
   maxFps: 60, // Maximum frames per second for rendering
   tmpVolSize: 32 * 1024 * 1024, // Allocated size for `tmp:/` volume (32 MB)
   cacheFSVolSize: 32 * 1024 * 1024, // Allocated size for `cachefs:/` volume (32 MB)

--- a/src/api/video.ts
+++ b/src/api/video.ts
@@ -324,8 +324,22 @@ export function addVideoPlaylist(newList: any[]) {
  */
 export function resetVideo() {
     stopVideo();
-    if (player.src.startsWith("blob:")) {
-        revokeVideoURL(player.src);
+    if (player) {
+        // stopVideo() is a no-op once a video has finished or was already stopped
+        // (playerState === "stop"), which leaves the previous video's source, buffered
+        // frames and text tracks attached to the shared player element. Release them
+        // unconditionally here so nothing bleeds into the next app that gets loaded.
+        if (hls) {
+            destroyHls();
+        }
+        if (player.src.startsWith("blob:")) {
+            revokeVideoURL(player.src);
+        }
+        if (player.getAttribute("src") !== null) {
+            player.removeAttribute("src");
+            player.load();
+        }
+        clearVideoTracking();
     }
     playList = new Array();
     packageVideos = new Map();
@@ -335,6 +349,8 @@ export function resetVideo() {
     startPosition = 0;
     playerState = "stop";
     videosState = false;
+    bufferOnly = false;
+    canPlay = false;
 }
 
 /**

--- a/src/api/video.ts
+++ b/src/api/video.ts
@@ -166,7 +166,7 @@ export function handleVideoEvent(eventData: string) {
     const data = eventData.split(",");
     if (data[1] === "play") {
         playVideo();
-    } else if (data[1] === "load") {
+    } else if (data[1] === "load" || data[1] === "prebuffer") {
         loadVideo(true);
     } else if (data[1] === "rect" && data.length === 6) {
         notifyAll("rect", {

--- a/src/core/brsTypes/components/RoDeviceInfo.ts
+++ b/src/core/brsTypes/components/RoDeviceInfo.ts
@@ -894,7 +894,7 @@ export class RoDeviceInfo extends BrsComponent implements BrsValue {
             returns: ValueKind.Boolean,
         },
         impl: (_: Interpreter) => {
-            return BrsBoolean.False;
+            return BrsBoolean.from(BrsDevice.deviceInfo.autoPlayEnabled);
         },
     });
 

--- a/src/core/common.ts
+++ b/src/core/common.ts
@@ -42,6 +42,7 @@ export interface DeviceInfo {
     startTime: number;
     audioVolume: number;
     audioLanguage: SupportedLanguage;
+    autoPlayEnabled: boolean;
     maxFps: number;
     tmpVolSize: number;
     cacheFSVolSize: number;
@@ -148,6 +149,7 @@ export const DefaultDeviceInfo: DeviceInfo = {
     startTime: Date.now(),
     audioVolume: 50, // Defines the default volume level for system sounds - valid: (0-100)
     audioLanguage: "en",
+    autoPlayEnabled: true, // Autoplay device setting - enabled by default, as on a real Roku device
     maxFps: 60,
     tmpVolSize: 32 * 1024 * 1024, // 32 MB
     cacheFSVolSize: 32 * 1024 * 1024, // 32 MB

--- a/src/extensions/scenegraph/SGRoot.ts
+++ b/src/extensions/scenegraph/SGRoot.ts
@@ -585,7 +585,18 @@ export class SGRoot {
         }
         let isDirty = false;
         const progress = Atomics.load(BrsDevice.sharedArray, DataType.VLP);
-        if (this.videoProgress !== progress && progress >= 0 && progress <= 1000) {
+        if (progress >= 0 && progress <= 1000 && this.videoProgress !== progress) {
+            // Emit the intermediate buffering steps between the last reported value and the
+            // current one, so a consumer that gates on a specific percentage never misses a
+            // threshold when the render loop is starved (e.g. during Task startup) and the load
+            // progress jumps. Apps commonly start playback at ~33% ("prebufferDone") and reveal
+            // UI at ~99%; delivering only a jump straight to 100% would skip the 33% callback and
+            // the video would never start. Mirrors a real device's gradual buffering progression.
+            let reported = Math.max(this.videoProgress, 0);
+            while (reported + 200 < progress) {
+                reported += 200;
+                this._video.setState(MediaEvent.Loading, Math.trunc(reported / 10));
+            }
             this._video.setState(MediaEvent.Loading, Math.trunc(progress / 10));
         }
         this.videoProgress = progress;

--- a/src/extensions/scenegraph/nodes/Video.ts
+++ b/src/extensions/scenegraph/nodes/Video.ts
@@ -234,8 +234,15 @@ export class Video extends Group {
         postMessage({ captionStyle: new Array<CaptionStyleOption>() });
         postMessage({ captionRenderArea: { mode: "fullscreen" } });
 
-        // Set itself as the root video object
-        sgRoot.setVideo(this);
+        // Become the root video object only if none is active yet. A newly created Video must NOT
+        // steal event routing from a Video that is already playing: `processVideo` delivers the
+        // single shared player's events to `sgRoot.video`, so if a second Video (e.g. one the app
+        // builds while a startup logo is still playing) hijacked it here, the playing Video's
+        // `state` would never reach "finished"/"stopped" and its observers would be stranded.
+        // A Video that later starts playback claims the root in the `control` setter instead.
+        if (!sgRoot.video) {
+            sgRoot.setVideo(this);
+        }
     }
 
     get(index: BrsType) {
@@ -259,7 +266,14 @@ export class Video extends Group {
             const control = value.getValue().toLowerCase();
             if (validControl.includes(control)) {
                 this.checkContentChanged();
-                if (!sgRoot.inTaskThread()) postMessage(`video,${control}`);
+                if (!sgRoot.inTaskThread()) {
+                    // A playback-starting command makes this the active video that `processVideo`
+                    // routes the shared player's events to, taking over from any previous one.
+                    if (["play", "prebuffer", "resume", "replay"].includes(control) && sgRoot.video !== this) {
+                        sgRoot.setVideo(this);
+                    }
+                    postMessage(`video,${control}`);
+                }
             } else if (control !== "none") {
                 BrsDevice.stderr.write(`warning,${getNow()} [sg.video.cntrl.bad] control field set to invalid value`);
                 return;

--- a/test/brsTypes/components/RoDeviceInfo.test.js
+++ b/test/brsTypes/components/RoDeviceInfo.test.js
@@ -10,6 +10,7 @@ global.Intl.DateTimeFormat = jest.fn().mockImplementation(() => {
 });
 const brs = require("../../../packages/node/bin/brs.node");
 const { Interpreter, netlib } = brs;
+const { BrsDevice } = brs;
 const { RoDeviceInfo, RoAssociativeArray, RoArray, BrsBoolean, BrsString, Int32, Int64 } = brs.types;
 
 describe("RoDeviceInfo", () => {
@@ -606,12 +607,24 @@ describe("RoDeviceInfo", () => {
             });
         });
         describe("isAutoPlayEnabled", () => {
-            it("should return false as auto play is not supported", () => {
+            it("should return true as auto play is enabled by default", () => {
                 let deviceInfo = new RoDeviceInfo(interpreter);
                 let method = deviceInfo.getMethod("isAutoPlayEnabled");
 
                 expect(method).toBeTruthy();
-                expect(method.call(interpreter)).toEqual(BrsBoolean.False);
+                expect(method.call(interpreter)).toEqual(BrsBoolean.True);
+            });
+            it("should reflect the configurable autoPlayEnabled device setting", () => {
+                const original = BrsDevice.deviceInfo.autoPlayEnabled;
+                try {
+                    BrsDevice.deviceInfo.autoPlayEnabled = false;
+                    let deviceInfo = new RoDeviceInfo(interpreter);
+                    let method = deviceInfo.getMethod("isAutoPlayEnabled");
+
+                    expect(method.call(interpreter)).toEqual(BrsBoolean.False);
+                } finally {
+                    BrsDevice.deviceInfo.autoPlayEnabled = original;
+                }
             });
         });
         describe("IsAutoAdjustRefreshRateEnabled", () => {

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -601,7 +601,7 @@ describe("end to end brightscript functions", () => {
             "false",
             "false",
             "false",
-            "false",
+            "true",
         ]);
     });
 

--- a/test/extensions/scenegraph/Video.test.js
+++ b/test/extensions/scenegraph/Video.test.js
@@ -157,4 +157,40 @@ describe("Video cross-thread deserialization guard", () => {
         expect(sgRoot.video).not.toBe(proxy);
         expect(global.postMessage).not.toHaveBeenCalledWith("video,loop,false");
     });
+
+    test("a newly created Video does NOT steal the root from an already-active Video", () => {
+        // Regression: the single shared player's events are routed by processVideo to sgRoot.video.
+        // A Video created while another is still playing (e.g. an app building its player UI during
+        // a startup video) must not hijack that routing in its constructor, or the playing Video's
+        // 'state' would never reach 'finished'/'stopped' and its observers would be stranded.
+        const active = SGNodeFactory.createNode("Video");
+        expect(sgRoot.video).toBe(active);
+
+        const other = SGNodeFactory.createNode("Video");
+        expect(other.nodeSubtype).toBe("Video");
+        expect(sgRoot.video).toBe(active); // routing stays with the active Video
+        expect(sgRoot.video).not.toBe(other);
+    });
+
+    test("a Video claims the root when it starts playback (play/prebuffer/resume/replay)", () => {
+        for (const control of ["play", "prebuffer", "resume", "replay"]) {
+            sgRoot.setVideo();
+            const active = SGNodeFactory.createNode("Video");
+            const other = SGNodeFactory.createNode("Video");
+            expect(sgRoot.video).toBe(active);
+
+            other.setValue("control", new BrsString(control));
+            expect(sgRoot.video).toBe(other); // playback command takes over routing
+        }
+    });
+
+    test("a non-playback control (pause/stop) does not steal the root", () => {
+        sgRoot.setVideo();
+        const active = SGNodeFactory.createNode("Video");
+        const other = SGNodeFactory.createNode("Video");
+        expect(sgRoot.video).toBe(active);
+
+        other.setValue("control", new BrsString("stop"));
+        expect(sgRoot.video).toBe(active); // stop/pause don't hijack routing
+    });
 });


### PR DESCRIPTION
## Summary

Five independent fixes that, together, make a SceneGraph `Video` play correctly during app startup when the app prebuffers, gates playback on `bufferingStatus`, and builds other UI (including other `Video` nodes) while the video is still playing — and ensure a finished video is fully cleaned up so it doesn't bleed into the next app.

### 1. `roDeviceInfo.IsAutoplayEnabled()` is now a configurable device setting
It was hardcoded to `false`. Apps that (per Roku's autoplay certification policy) suppress startup video when autoplay is disabled were skipping that video entirely. It now reads a new `autoPlayEnabled` field on `DeviceInfo`, defaulting to `true` as on a real Roku, overridable via `deviceData`.

### 2. API handles the `prebuffer` control command
The SceneGraph `Video` node posts `video,prebuffer` for `control = "prebuffer"`, but the API's `handleVideoEvent` had no case for it, so the command was dropped and buffering never began. It now maps to a buffer-only `loadVideo(true)`, matching `roVideoPlayer.preBuffer()` (`video,load`).

### 3. `processVideo` delivers intermediate buffering steps
`SGRoot.processVideo` reported only the latest load-progress value. When the render loop is briefly starved (e.g. during Task startup) and progress jumps (20% → 100%), a consumer that starts playback at ~33% (`prebufferDone`) and reveals UI at ~99% missed the 33% callback and never started. It now steps through the intermediate percentages so no threshold is skipped, mirroring a device's gradual buffering.

### 4. A newly created Video no longer steals event routing from a playing Video
The single shared player's events are routed by `processVideo` to `sgRoot.video`, but the `Video` constructor unconditionally called `sgRoot.setVideo(this)`. A `Video` created while another was still playing hijacked `sgRoot.video`, so the playing video's `finished`/`stopped` event was delivered to the wrong node — its `state` never advanced past `playing`, stranding any `observeField("state", ...)` callback waiting on completion. A Video now claims the active-player role only when there is none yet (constructor) or when it starts playback (`control` = play/prebuffer/resume/replay).

### 5. `resetVideo()` fully releases the shared player element
Loading a new app calls `resetVideo()`, which delegated media teardown to `stopVideo()` — but `stopVideo()` early-returns when `playerState === "stop"`, exactly the state a video is left in after it finishes naturally. The finished video's source, buffered frames and text tracks stayed attached to the shared `<video>` element and bled into the next app (the previous app's video replaying, or its leftover captions showing). `resetVideo()` now unconditionally destroys any HLS instance, revokes a blob URL, removes `src` + reloads to drop buffered data, and clears tracking (disabling text tracks).

## Tests
- `test/brsTypes/components/RoDeviceInfo.test.js` — `isAutoPlayEnabled` default is now enabled, and reflects the configurable setting.
- `test/e2e/BrsComponents.test.js` — `roDeviceInfo.brs` expected output updated.
- `test/extensions/scenegraph/Video.test.js` — active-player routing: a new Video doesn't steal the root from an active one, a playback command claims it, pause/stop do not.
- Full suite green (147 suites). The API-side media element (`src/api/video.ts`) is browser-only and verified interactively in the desktop app, consistent with the rest of that module (the `node` test environment has no DOM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
