### PR TITLE
fix(rsg): SceneGraph Video only clears its rect while actively displaying frames

### DIFF
--- a/src/extensions/scenegraph/nodes/Video.ts
+++ b/src/extensions/scenegraph/nodes/Video.ts
@@ -745,7 +745,9 @@ export class Video extends Group {
         }
         if (draw2D) {
             this.isDirty = false;
-            draw2D.doDrawClearedRect(rect);
+            if (this.isDisplayingVideo()) {
+                draw2D.doDrawClearedRect(rect);
+            }
         }
         if (this.statusChanged) {
             if (this.seekTimeout > 0 && this.seekTimeout < Date.now() && ["rw", "ff"].includes(this.seekMode)) {
@@ -757,6 +759,20 @@ export class Video extends Group {
         this.updateBoundingRects(rect, origin, rotation);
         this.renderChildren(interpreter, drawTrans, rotation, opacity, draw2D);
         this.nodeRenderingDone(origin, angle, opacity, draw2D);
+    }
+
+    /**
+     * The transparent hole punched by `doDrawClearedRect` is only filled with real <video>
+     * frames while the shared player is actually playing/paused (see `drawVideoFrame` in
+     * `src/api/display.ts`, gated on `["play", "pause"].includes(videoState)`). Punching it at
+     * any other time just erases the poster the app drew behind the Video, showing the Scene
+     * background through it as a grey box. Only the current `sgRoot.video` owns the shared
+     * player's frames, so a previously-active Video whose state is frozen at playing/paused must
+     * not clear either.
+     */
+    private isDisplayingVideo(): boolean {
+        const state = this.getValueJS("state");
+        return sgRoot.video === this && (state === "playing" || state === "paused");
     }
 
     private resetSeeking() {

--- a/test/extensions/scenegraph/Video.test.js
+++ b/test/extensions/scenegraph/Video.test.js
@@ -4,7 +4,7 @@ const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
 const core = require("../../../packages/node/bin/brs.node.js");
 
 const { SGNodeFactory, sgRoot } = scenegraph;
-const { BrsDevice, BrsString, Int32, RoAssociativeArray } = core;
+const { BrsDevice, BrsString, Int32, RoAssociativeArray, Interpreter, MediaEvent } = core;
 
 describe("Video bufferingBar and retrievingBar fields", () => {
     let originalPostMessage;
@@ -192,5 +192,90 @@ describe("Video cross-thread deserialization guard", () => {
 
         other.setValue("control", new BrsString("stop"));
         expect(sgRoot.video).toBe(active); // stop/pause don't hijack routing
+    });
+});
+
+describe("Video renderNode clears its rect only while actively displaying frames", () => {
+    // Regression: renderNode punched a transparent hole (doDrawClearedRect) over the Video's
+    // rectangle whenever the node was merely visible, erasing the poster the app drew behind it.
+    // The main thread only paints real <video> frames into that hole while playing/paused
+    // (display.ts drawVideoFrame), so a visible-but-not-playing Video showed the Scene background
+    // through the hole as a grey box. The clear is now gated on the Video being the active player
+    // AND actually playing/paused.
+    let interpreter;
+    let originalPostMessage;
+
+    beforeAll(() => {
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+        originalPostMessage = global.postMessage;
+        global.postMessage = jest.fn();
+        sgRoot.setVideo();
+    });
+
+    afterEach(() => {
+        global.postMessage = originalPostMessage;
+        sgRoot.setVideo();
+    });
+
+    function mountVideo() {
+        const scene = SGNodeFactory.createNode("Scene");
+        const video = SGNodeFactory.createNode("Video");
+        scene.appendChildToParent(video);
+        return { scene, video };
+    }
+
+    test("a freshly created (state 'none') active Video does not clear its rect", () => {
+        const { video } = mountVideo();
+        expect(sgRoot.video).toBe(video);
+        expect(video.getValueJS("state")).toBe("none");
+
+        const draw2D = { doDrawClearedRect: jest.fn() };
+        video.renderNode(interpreter, [0, 0], 0, 1, draw2D);
+
+        expect(draw2D.doDrawClearedRect).not.toHaveBeenCalled();
+    });
+
+    test("the active Video clears its rect once it is playing", () => {
+        const { video } = mountVideo();
+        video.setState(MediaEvent.StartStream, 0);
+        expect(video.getValueJS("state")).toBe("playing");
+
+        const draw2D = { doDrawClearedRect: jest.fn() };
+        video.renderNode(interpreter, [0, 0], 0, 1, draw2D);
+
+        expect(draw2D.doDrawClearedRect).toHaveBeenCalledTimes(1);
+    });
+
+    test("the Video stops clearing its rect after playback finishes", () => {
+        const { video } = mountVideo();
+        video.setState(MediaEvent.StartStream, 0);
+        video.setState(MediaEvent.Finished, 0);
+        expect(video.getValueJS("state")).toBe("finished");
+
+        const draw2D = { doDrawClearedRect: jest.fn() };
+        video.renderNode(interpreter, [0, 0], 0, 1, draw2D);
+
+        expect(draw2D.doDrawClearedRect).not.toHaveBeenCalled();
+    });
+
+    test("a non-active Video does not clear even if its state is 'playing'", () => {
+        const { scene, video: active } = mountVideo();
+        const other = SGNodeFactory.createNode("Video");
+        scene.appendChildToParent(other);
+        expect(sgRoot.video).toBe(active);
+
+        other.setState(MediaEvent.StartStream, 0);
+        expect(other.getValueJS("state")).toBe("playing");
+        expect(sgRoot.video).not.toBe(other);
+
+        const draw2D = { doDrawClearedRect: jest.fn() };
+        other.renderNode(interpreter, [0, 0], 0, 1, draw2D);
+
+        expect(draw2D.doDrawClearedRect).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## Problem
`Video.renderNode` punched a transparent hole (`doDrawClearedRect`) over the node's rectangle whenever the node was merely **visible**, erasing whatever the app drew behind it (e.g. a poster). The main thread only paints real `<video>` frames into that hole while the shared player is **playing/paused** (`display.ts` `drawVideoFrame`). So a visible-but-not-playing Video (autoplay off, finished, or not the active player) showed the dark Scene background through the hole as a grey box over the content behind it.

## Fix
Gate the clear on the Video being the **active player** (`sgRoot.video === this`) **and** actually displaying frames (`state` `playing`/`paused`), matching the main-thread paint gate. Both terms are required: `state === "playing"` is only set on the active player, but a previously-active Video whose state is frozen at `playing`/`paused` after another Video took over would otherwise still clear. When not displaying, the Scene's per-frame full redraw repaints the content behind the (no-longer-cleared) area.

The `video,rect` post and the `isDirty` reset are unchanged (posting the rect while not playing is harmless).

## Tests
Adds a `Video.test.js` suite asserting the clear happens only for the active player while `playing`/`paused` (state `none` → no clear; `playing` → clears once; `finished` → no clear; non-active forced `playing` → no clear). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
