### PR TITLE
fix(rsg): Poster commits the uri field before its synchronous load and notification

### DIFF
--- a/src/extensions/scenegraph/nodes/Poster.ts
+++ b/src/extensions/scenegraph/nodes/Poster.ts
@@ -63,12 +63,23 @@ export class Poster extends Group {
                 this.setValueSilent("bitmapWidth", new Float(0));
                 this.setValueSilent("bitmapHeight", new Float(0));
                 this.uri = uri;
+                // Commit the uri field BEFORE the (synchronous) load and the loadStatus
+                // notification below, so that when the resulting loadStatus="ready"/"failed"
+                // change is observed, .uri already holds the new value — matching Roku, where the
+                // uri field is set before the asynchronous image load completes. Apps commonly
+                // preload an image on an off-screen Poster and, in its loadStatus observer, copy
+                // .uri onto a visible Poster and then clear the preloader's uri; if the uri were
+                // committed only afterwards (the trailing super.setValue), that clear would be
+                // clobbered by the deferred write and the real image would revert to a placeholder.
+                // Returning here avoids that trailing re-commit.
+                super.setValue(index, value, alwaysNotify, kind);
                 const loadStatus = this.loadUri(uri);
                 if (loadStatus !== "ready") {
                     const failedUri = this.getValueJS("failedBitmapUri") as string;
                     this.loadUri(failedUri);
                 }
                 super.setValue("loadStatus", new BrsString(loadStatus));
+                return;
             } else if (typeof uri !== "string" || uri.trim() === "") {
                 this.uri = "";
                 this.bitmap = undefined;

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -398,6 +398,27 @@ describe("cli", () => {
         ]);
     }, 10000);
 
+    it("Poster preload-and-swap: the loadStatus observer's uri clear is not clobbered", async () => {
+        let command = ["node", brsCliPath, "-r poster-preload-swap-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        // The preloader's loadStatus="ready" observer copies its uri onto the visible poster and then
+        // clears its own uri (""). The Poster must commit the uri field BEFORE the synchronous load +
+        // loadStatus notification so that clear sticks; otherwise a trailing re-commit reverts the
+        // preloader's uri to the loaded image.
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "=== Poster Preload Swap Repro ===",
+            "visiblePoster.uri = common:/images/icon_options.png",
+            "preloadPoster.uri =",
+            "=== Poster Preload Swap Repro Complete ===",
+            "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+    }, 10000);
+
     it("Allows redeclaring an inherited system field but still blocks XML duplicate fields", async () => {
         let command = ["node", brsCliPath, "-r duplicate-system-field-app", "source/main.brs", "-c 0"].join(" ");
 

--- a/test/cli/resources/poster-preload-swap-app/components/PreloadScene.xml
+++ b/test/cli/resources/poster-preload-swap-app/components/PreloadScene.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Reproduces the very common "preload and swap" Poster pattern: an off-screen Poster preloads
+    the real image, and in its loadStatus="ready" observer the app copies the loaded .uri onto a
+    visible Poster and then CLEARS the preloader's uri ("").
+
+    On a real Roku the uri field is set before the (asynchronous) image load completes, so when the
+    loadStatus observer runs, the preloader's uri already holds the new value and the app's clear to
+    "" sticks. If the engine committed the uri field only AFTER the synchronous load + loadStatus
+    notification, that trailing write would clobber the observer's clear and the preloader's uri
+    would revert to the loaded image (defeating the swap and, in real apps, tripping a safety timer
+    that reverts the visible poster to a placeholder).
+-->
+<component name="PreloadScene" extends="Scene">
+    <interface>
+        <field id="visibleUri" type="string" />
+        <field id="preloadUri" type="string" />
+    </interface>
+    <children>
+        <Poster id="visiblePoster" />
+    </children>
+    <script type="text/brightscript">
+        <![CDATA[
+        sub init()
+            m.visiblePoster = m.top.findNode("visiblePoster")
+            m.preloadPoster = CreateObject("roSGNode", "Poster")
+            m.preloadPoster.observeField("loadStatus", "onPreloadStatus")
+            m.preloadPoster.uri = "common:/images/icon_options.png"
+            ' Publish the final field values so the harness can read them back.
+            m.top.visibleUri = m.visiblePoster.uri
+            m.top.preloadUri = m.preloadPoster.uri
+        end sub
+
+        sub onPreloadStatus()
+            if m.preloadPoster.loadStatus = "ready"
+                m.visiblePoster.uri = m.preloadPoster.uri
+                m.preloadPoster.uri = ""
+            end if
+        end sub
+        ]]>
+    </script>
+</component>

--- a/test/cli/resources/poster-preload-swap-app/manifest
+++ b/test/cli/resources/poster-preload-swap-app/manifest
@@ -1,0 +1,4 @@
+title=poster-preload-swap-app
+major_version=1
+minor_version=0
+build_version=0

--- a/test/cli/resources/poster-preload-swap-app/source/main.brs
+++ b/test/cli/resources/poster-preload-swap-app/source/main.brs
@@ -1,0 +1,15 @@
+sub Main()
+    print "=== Poster Preload Swap Repro ==="
+
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+
+    scene = screen.CreateScene("PreloadScene")
+    screen.show()
+
+    print "visiblePoster.uri = "; scene.visibleUri
+    print "preloadPoster.uri = "; scene.preloadUri
+
+    print "=== Poster Preload Swap Repro Complete ==="
+end sub


### PR DESCRIPTION
## Problem
`Poster.setValue("uri")` committed the `uri` field only **after** running the (synchronous) image load and firing the `loadStatus` notification. Apps commonly preload an image on an off-screen Poster and, in its `loadStatus="ready"` observer, copy `.uri` onto a visible Poster and then clear the preloader's uri (`""`). Because that observer runs synchronously **during** the `loadStatus` notification — before the trailing `uri` commit — the deferred commit clobbered the observer's clear, reverting the preloader's uri back to the loaded image. This defeats the swap and, in real apps, trips a safety timer that reverts the visible poster to a placeholder.

## Fix
Commit the `uri` field **before** the load and the `loadStatus` notification (matching Roku, where `uri` is set before the asynchronous load completes) and `return` early to avoid the trailing re-commit.

## Tests
Adds a `poster-preload-swap-app` CLI fixture reproducing the preload-and-swap pattern and asserting the preloader's uri clear sticks (visible poster keeps the loaded image; preloader uri stays empty). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
