### PR TITLE
fix(rsg): RowList keeps currFocusRow/currFocusColumn in sync with the focused item

### DIFF
--- a/src/extensions/scenegraph/nodes/RowList.ts
+++ b/src/extensions/scenegraph/nodes/RowList.ts
@@ -212,7 +212,20 @@ export class RowList extends ArrayGrid {
         }
 
         super.setValue("itemFocused", new Int32(rowIndex));
+        this.setRowItemFocused(rowIndex, colIndex);
+    }
+
+    /**
+     * Records the focused [row, column] and mirrors it into the inherited ArrayGrid
+     * currFocusRow/currFocusColumn fields. Roku keeps those two fields in sync with the focus
+     * position as the grid scrolls (see arraygrid.md); apps observe/alias them to track which
+     * row and column is focused. Without this mirror they stay pinned at their 0.0 default, so an
+     * app driving a focused-item overlay from currFocusRow/currFocusColumn never leaves item [0,0].
+     */
+    protected setRowItemFocused(rowIndex: number, colIndex: number) {
         super.setValue("rowItemFocused", new RoArray([new Int32(rowIndex), new Int32(colIndex)]));
+        super.setValue("currFocusRow", new Float(rowIndex));
+        super.setValue("currFocusColumn", new Float(colIndex));
     }
 
     protected handleUpDown(key: string) {
@@ -353,7 +366,7 @@ export class RowList extends ArrayGrid {
 
         if (nextCol !== this.rowFocus[currentRow]) {
             this.rowFocus[currentRow] = nextCol;
-            super.setValue("rowItemFocused", new RoArray([new Int32(currentRow), new Int32(nextCol)]));
+            this.setRowItemFocused(currentRow, nextCol);
             return true;
         }
         return false;
@@ -369,7 +382,7 @@ export class RowList extends ArrayGrid {
         }
 
         this.rowFocus[currentRow] = nextCol;
-        super.setValue("rowItemFocused", new RoArray([new Int32(currentRow), new Int32(nextCol)]));
+        this.setRowItemFocused(currentRow, nextCol);
         return true;
     }
 
@@ -380,7 +393,7 @@ export class RowList extends ArrayGrid {
         if (nextCol !== this.rowFocus[currentRow]) {
             this.rowFocus[currentRow] = nextCol;
             this.rowScrollOffset[currentRow] = nextCol;
-            super.setValue("rowItemFocused", new RoArray([new Int32(currentRow), new Int32(nextCol)]));
+            this.setRowItemFocused(currentRow, nextCol);
             return true;
         }
         return false;
@@ -415,8 +428,7 @@ export class RowList extends ArrayGrid {
         }
 
         if (handled) {
-            const value = new RoArray([new Int32(currentRow), new Int32(this.rowFocus[currentRow])]);
-            super.setValue("rowItemFocused", value);
+            this.setRowItemFocused(currentRow, this.rowFocus[currentRow]);
         }
         return handled;
     }

--- a/test/extensions/scenegraph/RowList.test.js
+++ b/test/extensions/scenegraph/RowList.test.js
@@ -49,6 +49,35 @@ describe("RowList key handling", () => {
         expect(list.getValueJS("itemFocused")).toBe(0);
     });
 
+    test("currFocusRow/currFocusColumn track the focused item on horizontal and vertical navigation", () => {
+        // Regression: currFocusRow/currFocusColumn (inherited ArrayGrid fields) were declared but never
+        // written, so they stayed pinned at their 0.0 default. Apps that observe/alias them to drive a
+        // focused-item overlay (e.g. a home-screen metadata/poster panel) never left item [0, 0]. They
+        // must mirror rowItemFocused as focus moves.
+        const list = SGNodeFactory.createNode("RowList");
+        list.setValue("content", buildContent([["A", "B", "C"], ["D", "E"], ["F"]]));
+
+        // Fresh list: focus at [0, 0].
+        expect(list.getValueJS("currFocusRow")).toBe(0);
+        expect(list.getValueJS("currFocusColumn")).toBe(0);
+
+        // Horizontal move within row 0 updates the column (row stays 0).
+        list.handleKey("right", true);
+        expect(list.getValueJS("currFocusRow")).toBe(0);
+        expect(list.getValueJS("currFocusColumn")).toBe(1);
+        expect(list.getValueJS("rowItemFocused")).toEqual([0, 1]);
+
+        // Vertical move to row 1 updates the row.
+        list.handleKey("down", true);
+        expect(list.getValueJS("currFocusRow")).toBe(1);
+        expect(list.getValueJS("rowItemFocused")[0]).toBe(1);
+
+        // A programmatic jumpToRowItem also syncs both fields.
+        list.setValue("jumpToRowItem", new RoArray([new Int32(2), new Int32(0)]));
+        expect(list.getValueJS("currFocusRow")).toBe(2);
+        expect(list.getValueJS("currFocusColumn")).toBe(0);
+    });
+
     test("a multi-row fixedFocusWrap list still wraps (down/up stay handled)", () => {
         const list = SGNodeFactory.createNode("RowList");
         list.setValue("vertFocusAnimationStyle", new BrsString("fixedFocusWrap"));


### PR DESCRIPTION
## Problem
The inherited `ArrayGrid` `currFocusRow`/`currFocusColumn` fields were declared but **never written** by `RowList`, so they stayed pinned at their `0.0` default while `rowItemFocused` updated correctly. Per the `arraygrid.md` spec both fields track the focus position as the grid scrolls, and apps observe/alias them to drive focused-item UI (e.g. a metadata/poster overlay) — which therefore never left item `[0, 0]` on navigation.

## Fix
Route every focus-move site — the central `setFocusedItem` (covering vertical and `jumpToRowItem` navigation) plus the four horizontal handlers — through a `setRowItemFocused(row, col)` helper that writes `rowItemFocused` and mirrors the position into `currFocusRow`/`currFocusColumn`.

## Tests
Adds a `RowList.test.js` case asserting `currFocusRow`/`currFocusColumn` track the focused item across horizontal, vertical, and programmatic (`jumpToRowItem`) navigation. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
