### PR TITLE
fix(interpreter): update index type check in array setting to allow any numeric type

### DIFF
--- a/src/core/interpreter/index.ts
+++ b/src/core/interpreter/index.ts
@@ -1732,7 +1732,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
         let current: BrsType = source;
         for (let i = 0; i < statement.indexes.length; i++) {
             let index = this.evaluate(statement.indexes[i]);
-            if (!isBrsNumber(index)) {
+            if (!isAnyNumber(index)) {
                 this.addError(new RuntimeError(RuntimeErrorDetail.NonNumericArrayIndex, statement.indexes[i].location));
             }
 


### PR DESCRIPTION
The code below would raise an exception on the indexed assignment 
```brs
sub main()
    x = box(1)
    a = [2,3,4]
    a[x] = 30
    print a
end sub
```