### PR TITLE
feat(rsg): implement ifSGNodeBoundingRect ancestorSubBoundingRect()

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -19,7 +19,6 @@ The **BrightScript Engine** implements the BrightScript language specification u
     * Inside a library, `pkg:/` still resolves to the host app's package (not the library's own); reference a library's bundled scripts with relative `uri` paths in its component XML.
     * Library `source/` global functions and intra-library component inheritance (a library component extending another library component) are not supported yet.
     * Encrypted/signed `.bpk` libraries are not supported yet (plain `.zip` only).
-  * The following `ifSGNodeBoundingRect` methods are not implemented yet: `localSubBoundingRect`, `subBoundingRect`, `sceneSubBoundingRect` and `ancestorSubBoundingRect`
 * Audio playback is implemented via `roAudioResources`, `roAudioPlayer` components and `SoundEffect`, `Audio` nodes, but with some limitations:
   * Only one instance of `roAudioPlayer` component or `Audio` node should be used, if more are created those will share the content playlist.
   * If the `roAudioPlayer` component or `Audio` node instance is destroyed the audio keeps playing, make sure to stop the playback before discarding the object.

--- a/src/extensions/scenegraph/components/RoSGNode.ts
+++ b/src/extensions/scenegraph/components/RoSGNode.ts
@@ -130,6 +130,7 @@ export abstract class RoSGNode extends BrsComponent implements BrsValue, ISGNode
                 this.localSubBoundingRect,
                 this.sceneSubBoundingRect,
                 this.ancestorBoundingRect,
+                this.ancestorSubBoundingRect,
             ],
             ifSGNodeHttpAgentAccess: [this.getHttpAgent, this.setHttpAgent],
         });
@@ -1637,6 +1638,39 @@ export abstract class RoSGNode extends BrsComponent implements BrsValue, ISGNode
                     ancestorRect.y += nodeRect.y;
                 }
                 return ancestorFound ? toAssociativeArray(ancestorRect) : toAssociativeArray(boundingRect);
+            },
+        });
+    }
+
+    /* Returns the bounding rectangle of an identified sub part, in relation to an ancestor component. */
+    protected get ancestorSubBoundingRect(): Callable {
+        return new Callable("ancestorSubBoundingRect", {
+            signature: {
+                args: [
+                    new StdlibArgument("itemNumber", ValueKind.String),
+                    new StdlibArgument("ancestor", ValueKind.Object),
+                ],
+                returns: ValueKind.Dynamic,
+            },
+            impl: (interpreter: Interpreter, itemNumber: BrsString, ancestor: RoSGNode) => {
+                const remote = this.rendezvousCall(interpreter, "ancestorSubBoundingRect", [itemNumber, ancestor]);
+                if (remote !== undefined) {
+                    return remote;
+                }
+                const subRect = this.getSubBoundingRect("toParent", itemNumber.getValue(), interpreter);
+                const ancestorRect = { ...subRect };
+                let ancestorFound = false;
+                const path = this.createPath(this, false).slice(1);
+                for (const node of path) {
+                    if (ancestor === node) {
+                        ancestorFound = true;
+                        break;
+                    }
+                    const nodeRect = node.getBoundingRect("toParent", interpreter);
+                    ancestorRect.x += nodeRect.x;
+                    ancestorRect.y += nodeRect.y;
+                }
+                return ancestorFound ? toAssociativeArray(ancestorRect) : toAssociativeArray(subRect);
             },
         });
     }

--- a/test/extensions/scenegraph/SubBoundingRect.test.js
+++ b/test/extensions/scenegraph/SubBoundingRect.test.js
@@ -3,8 +3,8 @@ const path = require("path");
 const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
 const core = require("../../../packages/node/bin/brs.node.js");
 
-const { Node, Group, MarkupGrid, ContentNode } = scenegraph;
-const { BrsDevice } = core;
+const { Node, Group, MarkupGrid, ContentNode, sgRoot } = scenegraph;
+const { BrsDevice, Interpreter, BrsString } = core;
 
 describe("ifSGNodeBoundingRect sub-part methods", () => {
     beforeAll(() => {
@@ -13,9 +13,14 @@ describe("ifSGNodeBoundingRect sub-part methods", () => {
         BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
     });
 
-    test("subBoundingRect/localSubBoundingRect/sceneSubBoundingRect are registered on nodes", () => {
+    test("subBoundingRect/localSubBoundingRect/sceneSubBoundingRect/ancestorSubBoundingRect are registered on nodes", () => {
         const node = new Node([], "Node");
-        for (const method of ["subBoundingRect", "localSubBoundingRect", "sceneSubBoundingRect"]) {
+        for (const method of [
+            "subBoundingRect",
+            "localSubBoundingRect",
+            "sceneSubBoundingRect",
+            "ancestorSubBoundingRect",
+        ]) {
             expect(node.getMethod(method)).toBeTruthy();
         }
     });
@@ -64,5 +69,79 @@ describe("ifSGNodeBoundingRect sub-part methods", () => {
         });
         // An item that was never rendered (no component yet) falls back to the grid's rect.
         expect(grid.getSubBoundingRect("toParent", "item7")).toEqual(grid.rectToParent);
+    });
+});
+
+describe("ancestorSubBoundingRect", () => {
+    let interpreter;
+
+    beforeAll(() => {
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+    });
+
+    function readRect(aa) {
+        return {
+            x: aa.get(new BrsString("x")).getValue(),
+            y: aa.get(new BrsString("y")).getValue(),
+            width: aa.get(new BrsString("width")).getValue(),
+            height: aa.get(new BrsString("height")).getValue(),
+        };
+    }
+
+    // Scene -> group -> grid, with the grid holding one rendered item component.
+    function buildGrid() {
+        const scene = new Group([], "Group");
+        const group = new Group([], "Group");
+        const grid = new MarkupGrid();
+        scene.appendChildToParent(group);
+        group.appendChildToParent(grid);
+
+        group.rectToParent = { x: 50, y: 60, width: 500, height: 900 };
+        grid.rectToParent = { x: 10, y: 20, width: 438, height: 800 };
+        grid.rectLocal = { x: 0, y: 0, width: 438, height: 800 };
+        grid.rectToScene = { x: 100, y: 200, width: 438, height: 800 };
+
+        const item1 = new Group([], "Group");
+        item1.rectToScene = { x: 100, y: 284, width: 438, height: 72 };
+        grid.itemComps[1] = item1;
+        grid.content.push(new ContentNode(), new ContentNode());
+
+        return { scene, group, grid };
+    }
+
+    test("expresses a sub part rect in an ancestor's coordinate system", () => {
+        const { scene, grid } = buildGrid();
+
+        // Skip the layout-refresh render so the manually injected rects are measured as-is.
+        sgRoot.rendering = true;
+        try {
+            const result = grid.getMethod("ancestorSubBoundingRect").call(interpreter, new BrsString("item1"), scene);
+            // subBoundingRect("item1") is {10,104} in the grid's parent (group) space; adding the
+            // group's own parent-space offset {50,60} re-expresses it in the scene's coordinate system.
+            expect(readRect(result)).toEqual({ x: 60, y: 164, width: 438, height: 72 });
+        } finally {
+            sgRoot.rendering = false;
+        }
+    });
+
+    test("falls back to the node's own sub part rect when the ancestor is not in the chain", () => {
+        const { grid } = buildGrid();
+        const stranger = new Group([], "Group");
+
+        sgRoot.rendering = true;
+        try {
+            const result = grid
+                .getMethod("ancestorSubBoundingRect")
+                .call(interpreter, new BrsString("item1"), stranger);
+            // Not an ancestor: returns subBoundingRect("item1") unchanged (grid's parent space).
+            expect(readRect(result)).toEqual({ x: 10, y: 104, width: 438, height: 72 });
+        } finally {
+            sgRoot.rendering = false;
+        }
     });
 });


### PR DESCRIPTION
## Summary

Implements the last missing method of the `ifSGNodeBoundingRect` interface, **`ancestorSubBoundingRect(itemNumber as String, ancestor as roSGNode)`**, and removes the now-stale limitation note.

`ancestorSubBoundingRect` returns a node's identified sub-part bounding rect expressed in a given ancestor's coordinate system. It is a straight combination of two existing, working patterns:
- seeds from `getSubBoundingRect("toParent", …)` (already used by `subBoundingRect`), then
- runs the same ancestor-chain walk as the existing `ancestorBoundingRect` (`createPath(this, false).slice(1)`), accumulating each intermediate ancestor's parent-space offset until it reaches the target ancestor.

Per the Roku spec, it falls back to the node's own sub-part rect when the ancestor is not in the chain (and `getSubBoundingRect` already falls back to the node's own rect when the sub-part does not exist).

Reference: `external/dev-doc/docs/REFERENCES/brightscript/interfaces/ifsgnodeboundingrect.md`.

## Docs

Removed the `docs/limitations.md` bullet claiming `localSubBoundingRect`, `subBoundingRect`, `sceneSubBoundingRect`, `ancestorSubBoundingRect` are unimplemented — the first three were already done and the fourth lands here. All other named limitations were cross-checked against the code and still hold, so they were left untouched.

## Tests

Extended `test/extensions/scenegraph/SubBoundingRect.test.js`:
- method registration,
- the ancestor-coordinate-system transform (asserts the sub-part rect re-expressed in scene space),
- the not-an-ancestor fallback to the node's own sub-part rect.

## Verification

- `npm run lint` + `npm run prettier:write`: clean.
- `npm run build:cli` then `npm run build:sg`: both succeed.
- Full suite: 147 suites / 1998 tests pass, no regressions.
- CLI end-to-end smoke: a real SceneGraph app calling `ancestorSubBoundingRect("item0", m.top)` returns a rect matching `ancestorBoundingRect(scene)` (correct invariant for a node with no ArrayGrid sub-parts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)