### PR TITLE
fix(core): roTextureManager only warns once for a repeatedly-failing local texture

### DIFF
--- a/src/core/brsTypes/components/RoTextureManager.ts
+++ b/src/core/brsTypes/components/RoTextureManager.ts
@@ -31,6 +31,7 @@ let textureManager: RoTextureManager;
 export class RoTextureManager extends BrsComponent implements BrsValue, BrsHttpAgent {
     readonly kind = ValueKind.Object;
     private readonly textures: Map<string, RoBitmap>;
+    private readonly failedLocalUris: Set<string>;
     private readonly brsFS = BrsDevice.fileSystem;
     readonly requests: Map<number, RoTextureRequest>;
     private port?: RoMessagePort;
@@ -45,6 +46,7 @@ export class RoTextureManager extends BrsComponent implements BrsValue, BrsHttpA
         this.certificatesFile = DefaultCertificatesFile;
         this.requests = new Map<number, RoTextureRequest>();
         this.textures = new Map<string, RoBitmap>();
+        this.failedLocalUris = new Set<string>();
         this.customHeaders = new Map<string, string>();
         const ifHttpAgent = new IfHttpAgent(this);
         const setPortIface = new IfSetMessagePort(this, this.getNewEvents.bind(this));
@@ -119,6 +121,12 @@ export class RoTextureManager extends BrsComponent implements BrsValue, BrsHttpA
                 this.textures.delete(uri);
             }
         }
+        for (const uri of this.failedLocalUris) {
+            const uriVolume = `${uri.split(":/")[0]}:`;
+            if (uriVolume === volume) {
+                this.failedLocalUris.delete(uri);
+            }
+        }
     }
 
     loadTexture(uri: string, headers?: Map<string, string>): RoBitmap | undefined {
@@ -158,6 +166,9 @@ export class RoTextureManager extends BrsComponent implements BrsValue, BrsHttpA
     }
 
     private loadLocalFile(uri: string) {
+        if (this.failedLocalUris.has(uri)) {
+            return undefined;
+        }
         try {
             const fsys = BrsDevice.fileSystem;
             let assetPath = uri;
@@ -174,6 +185,7 @@ export class RoTextureManager extends BrsComponent implements BrsValue, BrsHttpA
             }
             return fsys.readFileSync(assetPath);
         } catch (err: any) {
+            this.failedLocalUris.add(uri);
             if (BrsDevice.isDevMode) {
                 BrsDevice.stderr.write(`warning,[roTextureManager] Error requesting texture ${uri}: ${err.message}`);
             }
@@ -226,6 +238,7 @@ export class RoTextureManager extends BrsComponent implements BrsValue, BrsHttpA
         },
         impl: (_: Interpreter, url: BrsString) => {
             this.textures.delete(url.value);
+            this.failedLocalUris.delete(url.value);
             return Uninitialized.Instance;
         },
     });
@@ -235,6 +248,7 @@ export class RoTextureManager extends BrsComponent implements BrsValue, BrsHttpA
         signature: { args: [], returns: ValueKind.Void },
         impl: (_: Interpreter) => {
             this.textures.clear();
+            this.failedLocalUris.clear();
             return Uninitialized.Instance;
         },
     });

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -112,6 +112,25 @@ describe("cli", () => {
         ]);
     }, 10000);
 
+    it("only warns once for a repeatedly-requested missing local texture", async () => {
+        let command = ["node", brsCliPath, "roTextureManagerMissingFile.brs", "-c 0"].join(" ");
+
+        let { stdout, stderr } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+            env: { ...process.env, NODE_ENV: "development" },
+        });
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "first request state: 4",
+            "second request state: 4",
+            "------ Finished 'roTextureManagerMissingFile.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+        // The second identical request must not re-hit the filesystem or re-log the warning.
+        let warnings = stderr.match(/Error requesting texture pkg:\/images\/does-not-exist\.png/g) ?? [];
+        expect(warnings.length).toEqual(1);
+    }, 10000);
+
     it("prints syntax errors once", async () => {
         let folder = "errors";
         let filename = "uninitialized-object.brs";

--- a/test/cli/resources/roTextureManagerMissingFile.brs
+++ b/test/cli/resources/roTextureManagerMissingFile.brs
@@ -1,0 +1,13 @@
+sub Main()
+    msgport = CreateObject("roMessagePort")
+    mgr = CreateObject("roTextureManager")
+    mgr.SetMessagePort(msgport)
+    request = CreateObject("roTextureRequest", "pkg:/images/does-not-exist.png")
+    request.setAsync(false)
+
+    mgr.RequestTexture(request)
+    print "first request state:";request.GetState()
+
+    mgr.RequestTexture(request)
+    print "second request state:";request.GetState()
+end sub


### PR DESCRIPTION
## Summary
- A local `pkg:`/`tmp:`/etc. texture that fails to load (e.g. missing file) was never cached as failed, so any code path that re-requests the same URI on every frame (e.g. `Scene.renderNode` reading `backgroundUri`) re-hit the filesystem and re-logged the same `[roTextureManager] Error requesting texture ...` warning indefinitely.
- `RoTextureManager` now tracks failed local URIs in a `failedLocalUris` set, so a given failing local texture is only attempted (and warned about) once. The cache is cleared on `unloadBitmap`, `cleanup`, and volume unmount, so a legitimately remounted volume (e.g. `ext1:`) can still retry. Network (`http`) requests are unaffected — those can still legitimately vary between attempts.

## Test plan
- [x] New CLI test `only warns once for a repeatedly-requested missing local texture` in `test/cli/cli.test.js`, backed by `test/cli/resources/roTextureManagerMissingFile.brs` — verified it fails without the fix (2 warnings) and passes with it (1 warning).
- [x] `npm test` (full suite, 147 suites / 2004 tests) passes.
- [x] `npm run lint` and `npm run prettier:write` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)