### PR TITLE
fix(panelset): reliable next-panel creation and focusable-based navigation

### DIFF
--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -194,9 +194,20 @@ export class ArrayGrid extends Group {
 
     setNodeFocus(focusOn: boolean): boolean {
         const focus = super.setNodeFocus(focusOn);
-        const focusIndex = this.getValueJS("itemFocused") as number;
-        if (focus && focusIndex >= 0) {
-            this.setFocusedItem(focusIndex);
+        if (focus) {
+            let focusIndex = this.getValueJS("itemFocused") as number;
+            if (focusIndex < 0) {
+                // No item has been focused yet: default to the first item (Roku's itemFocused
+                // default is 0). Rebuild the internal content view first so items added in place
+                // (e.g. via ContentNode.update() after the content node was assigned empty) count.
+                this.refreshContent();
+                if (this.content.length > 0) {
+                    focusIndex = 0;
+                }
+            }
+            if (focusIndex >= 0) {
+                this.setFocusedItem(focusIndex);
+            }
         }
         return focus;
     }

--- a/src/extensions/scenegraph/nodes/GridPanel.ts
+++ b/src/extensions/scenegraph/nodes/GridPanel.ts
@@ -80,8 +80,10 @@ export class GridPanel extends Panel {
                 rightLabel.setValueSilent(index, new Float(width - this.labelOffsetX * 5));
             }
         } else if (fieldName === "nextpanel") {
-            const hasNextPanel = this.getValueJS("hasNextPanel") === true;
-            if (hasNextPanel && value instanceof Panel && this.nextPanelCallback) {
+            // nextPanel is write-only: setting it forwards the new panel to the PanelSet.
+            // Gated on the create-next-panel wiring, not on hasNextPanel (which only governs
+            // the right-arrow indicator / forward navigation to a further panel).
+            if (value instanceof Panel && this.nextPanelCallback) {
                 this.nextPanelCallback(value);
             }
         }

--- a/src/extensions/scenegraph/nodes/GridPanel.ts
+++ b/src/extensions/scenegraph/nodes/GridPanel.ts
@@ -22,6 +22,10 @@ export class GridPanel extends Panel {
     private readonly labelOffsetX: number;
     private readonly labelOffsetY: number;
     public nextPanelCallback?: (panel: Panel) => void;
+    public clearNextPanelCallback?: () => void;
+    private nextPanelForwarded: boolean = false;
+    private processingItemFocus: boolean = false;
+    private lastNextPanelIndex: number = -1;
 
     constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.GridPanel) {
         super([], name);
@@ -84,6 +88,7 @@ export class GridPanel extends Panel {
             // Gated on the create-next-panel wiring, not on hasNextPanel (which only governs
             // the right-arrow indicator / forward navigation to a further panel).
             if (value instanceof Panel && this.nextPanelCallback) {
+                this.nextPanelForwarded = true;
                 this.nextPanelCallback(value);
             }
         }
@@ -99,8 +104,33 @@ export class GridPanel extends Panel {
     }
 
     private onItemFocusChanged(index: number) {
-        if (this.getValueJS("createNextPanelOnItemFocus") === true && this.nextPanelCallback) {
+        if (this.getValueJS("createNextPanelOnItemFocus") !== true || !this.nextPanelCallback) {
+            return;
+        }
+        // Appending/replacing the detail panel re-focuses the grid, which re-enters this callback
+        // for the same item. Ignore that nested call so the clear path does not remove the panel
+        // that was just created.
+        if (this.processingItemFocus) {
+            return;
+        }
+        // Whether this is a genuine move to a *different* item. createNextPanelIndex also fires when
+        // the PanelSet re-focuses this list from the left (e.g. going back), re-notifying the same
+        // item; the clear path must not run then — the app simply re-supplies the same detail panel.
+        const indexChanged = index !== this.lastNextPanelIndex;
+        this.lastNextPanelIndex = index;
+        this.processingItemFocus = true;
+        this.nextPanelForwarded = false;
+        try {
+            // Observers dispatch synchronously: if the app assigns nextPanel during this setValue,
+            // the nextpanel handler flips nextPanelForwarded to true before we return here.
             this.setValue("createNextPanelIndex", new Int32(index));
+        } finally {
+            this.processingItemFocus = false;
+        }
+        if (indexChanged && !this.nextPanelForwarded && this.clearNextPanelCallback) {
+            // App produced no next panel for this newly-focused item (e.g. Exit returns invalid):
+            // clear the trailing detail panel, matching Roku's fade-out-to-empty behavior.
+            this.clearNextPanelCallback();
         }
     }
 }

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -874,6 +874,24 @@ export class Node extends RoSGNode implements BrsValue {
     }
 
     /**
+     * Indicates whether this node's subtree contains a visible, focusable descendant (the node
+     * itself is not counted). Used to decide whether focus can meaningfully move into a container
+     * — e.g. a PanelSet only navigates into a panel that has interactive content to receive focus.
+     * @returns True when a visible descendant is focusable.
+     */
+    hasFocusableDescendant(): boolean {
+        for (const child of this.getNodeChildren()) {
+            if (!(child instanceof Node) || child.getValueJS("visible") === false) {
+                continue;
+            }
+            if (child.isFocusable() || child.hasFocusableDescendant()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Base render entry point that simply delegates to child nodes.
      * @param interpreter Active interpreter.
      * @param origin Parent-space translation.

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -874,24 +874,6 @@ export class Node extends RoSGNode implements BrsValue {
     }
 
     /**
-     * Indicates whether this node's subtree contains a visible, focusable descendant (the node
-     * itself is not counted). Used to decide whether focus can meaningfully move into a container
-     * — e.g. a PanelSet only navigates into a panel that has interactive content to receive focus.
-     * @returns True when a visible descendant is focusable.
-     */
-    hasFocusableDescendant(): boolean {
-        for (const child of this.getNodeChildren()) {
-            if (!(child instanceof Node) || child.getValueJS("visible") === false) {
-                continue;
-            }
-            if (child.isFocusable() || child.hasFocusableDescendant()) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
      * Base render entry point that simply delegates to child nodes.
      * @param interpreter Active interpreter.
      * @param origin Parent-space translation.

--- a/src/extensions/scenegraph/nodes/PanelSet.ts
+++ b/src/extensions/scenegraph/nodes/PanelSet.ts
@@ -151,20 +151,30 @@ export class PanelSet extends Group {
             return false;
         }
         const currentPanel = this.panels.at(this.focusIndex);
-        if (currentPanel?.getValueJS("hasNextPanel") === true) {
-            this.focusIndex++;
-            super.setValue("isGoingBack", BrsBoolean.False);
-            currentPanel.setNodeFocus(false);
-            this.setNodeFocus(true);
-            return true;
+        const nextPanel = this.panels[this.focusIndex + 1];
+        // Move focus into the adjacent (already-present) panel only if it has interactive content
+        // to receive focus — a ListPanel's grid, buttons, etc. A purely informational panel (only
+        // labels) is not navigable, matching Roku. hasNextPanel governs the right-arrow indicator
+        // and drilling into a *further* panel, not whether the visible detail panel can be entered.
+        if (!nextPanel.hasFocusableDescendant()) {
+            return false;
         }
-        return false;
+        this.focusIndex++;
+        super.setValue("isGoingBack", BrsBoolean.False);
+        currentPanel?.setNodeFocus(false);
+        this.setNodeFocus(true);
+        return true;
     }
 
     appendChildToParent(child: BrsType): boolean {
         const added = super.appendChildToParent(child);
         if (added && child instanceof Panel) {
             this.panels.push(child);
+            if (child instanceof GridPanel) {
+                // Wire the create-next-panel callback at append time so it does not depend on the
+                // PanelSet itself receiving focus — apps commonly focus a contained Panel directly.
+                this.wireNextPanel(child);
+            }
             if (child.getValueJS("isFullScreen") === true) {
                 this.focusIndex = this.panels.length - 1;
             } else {
@@ -218,25 +228,30 @@ export class PanelSet extends Group {
         this.changed = false;
     }
 
+    private wireNextPanel(panel: GridPanel) {
+        panel.nextPanelCallback = (nextPanel: Panel) => {
+            if (this.panels.length === 1) {
+                this.appendChildToParent(nextPanel);
+                return;
+            }
+            const removed = this.panels.splice(-1, 1, nextPanel);
+            const removedIndex = this.children.indexOf(removed[0]);
+            this.replaceChildAtIndex(nextPanel, removedIndex);
+        };
+    }
+
     private refreshFocus() {
         const currentFocus = sgRoot.focused;
         if (this.panels.length && (currentFocus === this || this.isChildrenFocused())) {
             const focusedPanel = this.panels[this.focusIndex];
             if (focusedPanel && currentFocus !== focusedPanel) {
                 this.handleSelect = focusedPanel.getValueJS("selectButtonMovesPanelForward") === true;
-                const hasNextPanel = focusedPanel.getValueJS("hasNextPanel") === true;
-                if (hasNextPanel && focusedPanel instanceof GridPanel) {
-                    focusedPanel.nextPanelCallback = (nextPanel: Panel) => {
-                        if (this.panels.length === 1) {
-                            this.appendChildToParent(nextPanel);
-                            return;
-                        }
-                        const removed = this.panels.splice(-1, 1, nextPanel);
-                        const removedIndex = this.children.indexOf(removed[0]);
-                        this.replaceChildAtIndex(nextPanel, removedIndex);
-                    };
-                } else if (focusedPanel instanceof GridPanel) {
-                    focusedPanel.nextPanelCallback = undefined;
+                // Ensure the focused GridPanel's create-next-panel callback is wired (also done at
+                // append time). The mechanism is driven by createNextPanelOnItemFocus (checked in
+                // GridPanel), not by hasNextPanel — that field only controls the right-arrow
+                // indicator / forward navigation to a further panel.
+                if (focusedPanel instanceof GridPanel) {
+                    this.wireNextPanel(focusedPanel);
                 }
                 const isFull = focusedPanel.getValueJS("isFullScreen") === true;
                 const isLast = this.focusIndex === this.panels.length - 1;

--- a/src/extensions/scenegraph/nodes/PanelSet.ts
+++ b/src/extensions/scenegraph/nodes/PanelSet.ts
@@ -147,19 +147,23 @@ export class PanelSet extends Group {
     }
 
     protected goForward() {
-        if (this.focusIndex >= this.panels.length - 1) {
+        // Find the next focusable panel to the right, skipping any non-focusable ones. A panel's own
+        // `focusable` field is Roku's authoritative signal for whether the PanelSet can move focus
+        // into it: an informational detail panel (e.g. an About panel) sets focusable=false and must
+        // not receive focus, while a Panel left at its default (focusable=true) is navigable. Skipping
+        // non-focusable panels lets focus reach a focusable panel that sits past a non-focusable one.
+        let targetIndex = -1;
+        for (let i = this.focusIndex + 1; i < this.panels.length; i++) {
+            if (this.panels[i].isFocusable()) {
+                targetIndex = i;
+                break;
+            }
+        }
+        if (targetIndex === -1) {
             return false;
         }
         const currentPanel = this.panels.at(this.focusIndex);
-        const nextPanel = this.panels[this.focusIndex + 1];
-        // Move focus into the adjacent (already-present) panel only if it has interactive content
-        // to receive focus — a ListPanel's grid, buttons, etc. A purely informational panel (only
-        // labels) is not navigable, matching Roku. hasNextPanel governs the right-arrow indicator
-        // and drilling into a *further* panel, not whether the visible detail panel can be entered.
-        if (!nextPanel.hasFocusableDescendant()) {
-            return false;
-        }
-        this.focusIndex++;
+        this.focusIndex = targetIndex;
         super.setValue("isGoingBack", BrsBoolean.False);
         currentPanel?.setNodeFocus(false);
         this.setNodeFocus(true);
@@ -238,6 +242,22 @@ export class PanelSet extends Group {
             const removedIndex = this.children.indexOf(removed[0]);
             this.replaceChildAtIndex(nextPanel, removedIndex);
         };
+        panel.clearNextPanelCallback = () => this.clearTrailingPanel(panel);
+    }
+
+    private clearTrailingPanel(source: GridPanel) {
+        // Only clear when the trailing panel is the detail panel fed by this menu — i.e. the
+        // source menu panel is second-to-last. First-ever focus (menu is the only panel) no-ops.
+        if (this.panels.length < 2 || this.panels.at(-2) !== source) {
+            return;
+        }
+        const removed = this.panels.pop();
+        if (removed) {
+            this.removeChildByReference(removed);
+        }
+        this.focusIndex = Math.max(0, this.panels.length - 1);
+        super.setValue("numPanels", new Float(this.panels.length));
+        this.isDirty = true;
     }
 
     private refreshFocus() {

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -619,6 +619,37 @@ describe("cli", () => {
         ]);
     }, 10000);
 
+    it("PanelSet clears the trailing detail panel when the app supplies no next panel", async () => {
+        let command = ["node", brsCliPath, "-r panelset-clearpanel-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        // Repro of a sliding-panels settings menu. The left ListPanel uses the
+        // createNextPanelOnItemFocus mechanism: focusing a menu item sets createNextPanelIndex and the
+        // app responds by assigning a detail Panel to nextPanel. Item 0 supplies a focusable detail
+        // panel (numPanels 1 -> 2); item 1 supplies an informational About panel that replaces it
+        // (numPanels stays 2); item 2 ("Exit") supplies NO panel — the engine must then clear the
+        // trailing detail panel so only the menu remains (numPanels drops back to 1). Before the fix
+        // the stale previous detail panel was kept, matching neither Roku nor the app's intent.
+        // Returning to item 0 re-creates its detail panel (1 -> 2). Re-focusing the SAME item (as the
+        // PanelSet does when focus returns from the left) re-fires createNextPanelIndex for that index;
+        // the app re-supplies the same panel and it must NOT be cleared (numPanels stays 2) — the clear
+        // only runs on a genuine move to a new item whose app supplies nothing.
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "=== PanelSet ClearPanel Repro ===",
+            "item 0 numPanels =  2",
+            "item 1 numPanels =  2",
+            "item 2 numPanels =  1",
+            "back to 0 numPanels =  2",
+            "re-focus 0 numPanels =  2",
+            "=== PanelSet ClearPanel Repro Complete ===",
+            "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+    }, 10000);
+
     it("Run App from Root Folder Only", async () => {
         // Issue #771: pointing the CLI at a folder with `--root` and no positional files
         // discovers source/*.brs and loads components/ from the root-mounted pkg:/ volume,

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -594,6 +594,31 @@ describe("cli", () => {
         ]);
     }, 10000);
 
+    it("PanelSet creates the right panel on item focus without hasNextPanel", async () => {
+        let command = ["node", brsCliPath, "-r panelset-nextpanel-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        // Repro of a sliding-panels settings screen showing only its left menu. The right detail
+        // panel is created via the createNextPanelOnItemFocus mechanism: focusing a grid item sets
+        // createNextPanelIndex, and the app responds by setting nextPanel. That whole chain must be
+        // driven by createNextPanelOnItemFocus, NOT gated on hasNextPanel (which only governs the
+        // right-arrow indicator / forward navigation to a further panel). Before the fix the menu
+        // panel's hasNextPanel was false, so the nextPanel callback was never wired: no second panel
+        // was appended and numPanels stayed 1.
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "=== PanelSet NextPanel Repro ===",
+            "before focus numPanels =  1",
+            "created right panel for index  0",
+            "after focus numPanels =  2",
+            "=== PanelSet NextPanel Repro Complete ===",
+            "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+    }, 10000);
+
     it("Run App from Root Folder Only", async () => {
         // Issue #771: pointing the CLI at a folder with `--root` and no positional files
         // discovers source/*.brs and loads components/ from the root-mounted pkg:/ volume,

--- a/test/cli/resources/panelset-clearpanel-app/components/AboutPanel.xml
+++ b/test/cli/resources/panelset-clearpanel-app/components/AboutPanel.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- An informational panel with only Labels (no focusable content). The app sets focusable=false,
+     so RIGHT/OK must not move focus into it. -->
+<component name="AboutPanel" extends="Panel">
+    <children>
+        <Label id="aboutTitle" text="About" />
+        <Label id="aboutText" text="Informational text only" />
+    </children>
+</component>

--- a/test/cli/resources/panelset-clearpanel-app/components/DetailPanel.xml
+++ b/test/cli/resources/panelset-clearpanel-app/components/DetailPanel.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- A focusable detail panel (contains a Button) — RIGHT/OK can move focus into it. -->
+<component name="DetailPanel" extends="Panel">
+    <children>
+        <Button id="detailButton" text="Detail" />
+    </children>
+</component>

--- a/test/cli/resources/panelset-clearpanel-app/components/MainScene.xml
+++ b/test/cli/resources/panelset-clearpanel-app/components/MainScene.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- A PanelSet holding a left ListPanel menu. Detail panels are created dynamically via the
+     createNextPanelOnItemFocus mechanism. Some menu items supply a next panel, one supplies none
+     (mirroring an "Exit" option) — that case must clear the trailing detail panel. -->
+<component name="MainScene" extends="Scene">
+    <children>
+        <PanelSet id="panelSet" />
+    </children>
+</component>

--- a/test/cli/resources/panelset-clearpanel-app/components/MenuItem.xml
+++ b/test/cli/resources/panelset-clearpanel-app/components/MenuItem.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Minimal grid item component so the MarkupGrid can create items for its content. -->
+<component name="MenuItem" extends="Group">
+    <interface>
+        <field id="itemContent" type="node" />
+        <field id="width" type="float" />
+        <field id="height" type="float" />
+    </interface>
+</component>

--- a/test/cli/resources/panelset-clearpanel-app/components/MenuPanel.brs
+++ b/test/cli/resources/panelset-clearpanel-app/components/MenuPanel.brs
@@ -1,0 +1,42 @@
+sub init()
+    ' Enable the create-next-panel mechanism.
+    m.top.createNextPanelOnItemFocus = true
+
+    m.grid = m.top.findNode("grid")
+    m.content = m.top.findNode("menuContent")
+
+    ' Associate the XML-declared grid with the ListPanel's grid/list field.
+    m.top.list = m.grid
+
+    ' Populate the content node in place. Items: 0 = has focusable detail panel,
+    ' 1 = About (labels-only, focusable=false), 2 = Exit (no next panel supplied).
+    titles = ["Detail", "About", "Exit"]
+    for i = 0 to 2
+        item = m.content.createChild("ContentNode")
+        item.title = titles[i]
+        item.id = titles[i] + "Button"
+    end for
+
+    m.top.observeFieldScoped("createNextPanelIndex", "onCreateNextPanelIndex")
+end sub
+
+' Fires each time a grid item is focused. The app builds the matching right panel and assigns it to
+' nextPanel — except for the "Exit" item, where it deliberately supplies nothing (mirroring an app
+' whose createNextPanel returns invalid), which must clear the trailing detail panel.
+sub onCreateNextPanelIndex()
+    index = m.top.createNextPanelIndex
+    if index < 0 then return
+    buttonContent = m.content.getChild(index)
+
+    nextPanel = invalid
+    if buttonContent.id = "DetailButton"
+        nextPanel = CreateObject("roSGNode", "DetailPanel")
+    else if buttonContent.id = "AboutButton"
+        nextPanel = CreateObject("roSGNode", "AboutPanel")
+        nextPanel.focusable = false
+    end if
+
+    if nextPanel <> invalid
+        m.top.nextPanel = nextPanel
+    end if
+end sub

--- a/test/cli/resources/panelset-clearpanel-app/components/MenuPanel.xml
+++ b/test/cli/resources/panelset-clearpanel-app/components/MenuPanel.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Left menu panel: a ListPanel whose MarkupGrid and its content ContentNode are declared in XML,
+     mirroring a real settings menu. Three items are added in place after build. The app responds to
+     createNextPanelIndex by supplying a detail panel for items 0 and 1, but NOT for item 2 (an
+     "Exit"-style option) — which must clear the trailing detail panel. -->
+<component name="MenuPanel" extends="ListPanel">
+    <script type="text/brightscript" uri="pkg:/components/MenuPanel.brs" />
+    <children>
+        <Group id="menuGroup">
+            <MarkupGrid id="grid" itemComponentName="MenuItem" numRows="6" numColumns="1" itemSize="[437,72]">
+                <ContentNode id="menuContent" role="content" />
+            </MarkupGrid>
+        </Group>
+    </children>
+</component>

--- a/test/cli/resources/panelset-clearpanel-app/manifest
+++ b/test/cli/resources/panelset-clearpanel-app/manifest
@@ -1,0 +1,4 @@
+title=PanelSet ClearPanel Test
+major_version=1
+minor_version=0
+build_version=0

--- a/test/cli/resources/panelset-clearpanel-app/source/main.brs
+++ b/test/cli/resources/panelset-clearpanel-app/source/main.brs
@@ -1,0 +1,45 @@
+sub Main()
+    print "=== PanelSet ClearPanel Repro ==="
+
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+
+    scene = screen.CreateScene("MainScene")
+    screen.show()
+
+    panelSet = scene.findNode("panelSet")
+
+    menuPanel = CreateObject("roSGNode", "MenuPanel")
+    panelSet.appendChild(menuPanel)
+
+    ' Focus the menu Panel directly. Focus cascades to the grid, whose default item (index 0) becomes
+    ' focused, creating the focusable detail panel.
+    scene.setFocus(true)
+    menuPanel.setFocus(true)
+    print "item 0 numPanels = "; panelSet.numPanels
+
+    ' Focus item 1 (About): the app supplies a focusable=false panel. It replaces the detail panel,
+    ' so numPanels stays 2 (the informational panel is displayed).
+    grid = menuPanel.findNode("grid")
+    grid.jumpToItem = 1
+    print "item 1 numPanels = "; panelSet.numPanels
+
+    ' Focus item 2 (Exit): the app supplies no next panel. The trailing detail panel must be cleared,
+    ' leaving only the menu panel.
+    grid.jumpToItem = 2
+    print "item 2 numPanels = "; panelSet.numPanels
+
+    ' Back to item 0: a focusable detail panel must be created again (numPanels 1 -> 2).
+    grid.jumpToItem = 0
+    print "back to 0 numPanels = "; panelSet.numPanels
+
+    ' Re-focus the same item 0 (as happens when the PanelSet re-focuses the menu from the left, e.g.
+    ' going back). createNextPanelIndex fires again for the same index; the app re-supplies the same
+    ' detail panel, so the panel must NOT be cleared — numPanels stays 2.
+    menuPanel.setFocus(false)
+    menuPanel.setFocus(true)
+    print "re-focus 0 numPanels = "; panelSet.numPanels
+
+    print "=== PanelSet ClearPanel Repro Complete ==="
+end sub

--- a/test/cli/resources/panelset-nextpanel-app/components/MainScene.xml
+++ b/test/cli/resources/panelset-nextpanel-app/components/MainScene.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- A PanelSet holding a left ListPanel menu. The right detail panel is created dynamically
+     via the createNextPanelOnItemFocus mechanism (never via hasNextPanel). -->
+<component name="MainScene" extends="Scene">
+    <children>
+        <PanelSet id="panelSet" />
+    </children>
+</component>

--- a/test/cli/resources/panelset-nextpanel-app/components/MenuItem.xml
+++ b/test/cli/resources/panelset-nextpanel-app/components/MenuItem.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Minimal grid item component so the MarkupGrid can create items for its content. -->
+<component name="MenuItem" extends="Group">
+    <interface>
+        <field id="itemContent" type="node" />
+        <field id="width" type="float" />
+        <field id="height" type="float" />
+    </interface>
+</component>

--- a/test/cli/resources/panelset-nextpanel-app/components/MenuPanel.brs
+++ b/test/cli/resources/panelset-nextpanel-app/components/MenuPanel.brs
@@ -1,0 +1,33 @@
+sub init()
+    ' Enable the create-next-panel mechanism. hasNextPanel is deliberately left at its default
+    ' (false): the right panel must still be created when a grid item receives focus.
+    m.top.createNextPanelOnItemFocus = true
+
+    m.grid = m.top.findNode("grid")
+    m.content = m.top.findNode("menuContent")
+
+    ' Associate the XML-declared grid with the ListPanel's grid/list field.
+    m.top.list = m.grid
+
+    ' Populate the (already-assigned) content node in place, like ContentNode.update() — the grid's
+    ' content field was set to this node while it was empty, so no item is focused yet.
+    for i = 1 to 3
+        item = m.content.createChild("ContentNode")
+        item.title = "Menu " + i.toStr()
+    end for
+
+    m.top.observeFieldScoped("createNextPanelIndex", "onCreateNextPanelIndex")
+end sub
+
+' Fires when a grid item is focused (createNextPanelOnItemFocus mechanism). The app responds by
+' building the right panel and assigning it to nextPanel, which the PanelSet must then append.
+sub onCreateNextPanelIndex()
+    index = m.top.createNextPanelIndex
+    if index < 0 then return
+    if m.nextPanelCreated = true then return
+    m.nextPanelCreated = true
+    print "created right panel for index "; index
+    panel = CreateObject("roSGNode", "Panel")
+    panel.hasNextPanel = false
+    m.top.nextPanel = panel
+end sub

--- a/test/cli/resources/panelset-nextpanel-app/components/MenuPanel.xml
+++ b/test/cli/resources/panelset-nextpanel-app/components/MenuPanel.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Left menu panel: a ListPanel whose MarkupGrid and its content ContentNode are declared in XML
+     (role="content"), mirroring a real settings menu. Items are added to that content node in place
+     after build (like ContentNode.update). It enables createNextPanelOnItemFocus but intentionally
+     leaves hasNextPanel at its default (false): focusing an item must still create the right panel. -->
+<component name="MenuPanel" extends="ListPanel">
+    <script type="text/brightscript" uri="pkg:/components/MenuPanel.brs" />
+    <children>
+        <Group id="menuGroup">
+            <MarkupGrid id="grid" itemComponentName="MenuItem" numRows="6" numColumns="1" itemSize="[437,72]">
+                <ContentNode id="menuContent" role="content" />
+            </MarkupGrid>
+        </Group>
+    </children>
+</component>

--- a/test/cli/resources/panelset-nextpanel-app/manifest
+++ b/test/cli/resources/panelset-nextpanel-app/manifest
@@ -1,0 +1,4 @@
+title=PanelSet NextPanel Test
+major_version=1
+minor_version=0
+build_version=0

--- a/test/cli/resources/panelset-nextpanel-app/source/main.brs
+++ b/test/cli/resources/panelset-nextpanel-app/source/main.brs
@@ -1,0 +1,27 @@
+sub Main()
+    print "=== PanelSet NextPanel Repro ==="
+
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+
+    scene = screen.CreateScene("MainScene")
+    screen.show()
+
+    panelSet = scene.findNode("panelSet")
+
+    menuPanel = CreateObject("roSGNode", "MenuPanel")
+    panelSet.appendChild(menuPanel)
+    print "before focus numPanels = "; panelSet.numPanels
+
+    ' Mirror the real app: the screen focuses the menu Panel directly (never the PanelSet).
+    ' Focus cascades to the menu grid, whose default item (index 0) becomes focused, which must
+    ' trigger createNextPanelIndex → nextPanel → the right panel being appended — even though
+    ' hasNextPanel was never set on the menu panel.
+    scene.setFocus(true)
+    menuPanel.setFocus(true)
+
+    print "after focus numPanels = "; panelSet.numPanels
+
+    print "=== PanelSet NextPanel Repro Complete ==="
+end sub


### PR DESCRIPTION
## Overview

Fixes several issues with the SceneGraph **PanelSet** / **ListPanel** / **GridPanel** sliding-panels behavior, so a settings-style screen (left menu ListPanel + dynamically created right detail panel) navigates and clears correctly, matching the Roku SlidingPanels reference.

This branch has two commits:

### 1. Next-panel creation works without `hasNextPanel`
The create-next-panel mechanism is driven by `createNextPanelOnItemFocus`, not by `hasNextPanel`. The callback that appends/replaces the right panel is now wired at append time (not only when the PanelSet itself receives focus), since apps commonly focus a contained Panel directly. Setting `nextPanel` forwards the panel regardless of `hasNextPanel` (which only governs the right-arrow indicator / drilling to a further panel). An `ArrayGrid` that gains focus with no item focused yet defaults to item 0, so items added in place after an empty content node was assigned still trigger the chain.

### 2. Focusable-based navigation + clearing empty detail panels
- **Enter panels by their own `focusable` field.** `goForward` scans rightward for the next panel whose `focusable` field is true, **skipping** non-focusable ones. This is Roku's authoritative signal for whether the PanelSet can move focus into a panel:
  - An informational detail panel (`focusable = false`, labels only) is not entered — focus stays on the menu.
  - Focus can still reach a focusable panel that sits **past** a non-focusable one.
- **Clear the trailing detail panel when a newly focused item supplies no next panel** (the app's create-next-panel handler returns `invalid`). This matches Roku's fade-out-to-empty behavior instead of keeping the previous item's panel visible. The clear runs only on a genuine move to a new item — `createNextPanelIndex` also re-fires when the PanelSet re-focuses the list from the left (going back), and re-supplying the same panel must not clear it. A re-entrancy guard prevents the panel append/replace (which re-focuses the grid) from triggering the clear on the panel just created.
- Removes the now-unused `hasFocusableDescendant` helper from `Node`.

## Testing

Two CLI regression fixtures + tests:
- `panelset-nextpanel-app` — the right panel is created on item focus with `hasNextPanel` left at its default (false); `numPanels` goes 1 → 2.
- `panelset-clearpanel-app` — creating a focusable detail panel, replacing it with a non-focusable (informational) one, clearing it when no panel is supplied, recreating it on return, and **not** clearing on same-item re-focus (`numPanels`: 2, 2, 1, 2, 2).

Verification:
- `npm run lint` and `npm run prettier:write` pass.
- Full CLI and SceneGraph extension suites pass (`npx jest test/cli/cli.test.js test/extensions/scenegraph`).
- Key-press navigation (entering focusable panels, skipping a non-focusable middle panel, staying on the menu at an informational panel) verified manually in-app, since the CLI harness cannot simulate remote key events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)