### PR TITLE
fix(rsg): update() converts a nested {subtype:...} AA to a node on any field, not just children[]

### DIFF
--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -1428,6 +1428,25 @@ export class Node extends RoSGNode implements BrsValue {
             } else if (fieldName === "subtype") {
                 // Skip the "subtype" field, already handled
                 continue;
+            } else if (
+                value instanceof RoAssociativeArray &&
+                this.isNodeCreationDirective(node, fieldName, value, createFields)
+            ) {
+                // A nested AA carrying a "subtype" key is a node-creation directive on real Roku
+                // for ANY field - not just "children" array elements - as long as the target
+                // field either doesn't exist yet (createFields) or is already typed as Node; a
+                // field declared with another type keeps the AA as a literal value (see below).
+                const childSubtype = jsValueOf(value.get(new BrsString("subtype"))) ?? subtype;
+                const childNode = createNode(childSubtype, interpreter);
+                if (childNode instanceof RoSGNode) {
+                    this.populateNodeFromAA(interpreter, childNode, value, createFields, childSubtype);
+                    node.setValue(key, childNode, false, FieldKind.Node);
+                } else {
+                    // Unknown/invalid subtype: the field is still typed as Node (matching Roku),
+                    // but its value is Invalid since no node could be created.
+                    node.setValue(key, BrsInvalid.Instance, false, FieldKind.Node);
+                }
+                this.makeDirty();
             }
             // Set all other fields, respecting the createFields parameter
             else if (node.hasNodeField(fieldName) || (createFields && !isInvalid(value))) {
@@ -1435,6 +1454,31 @@ export class Node extends RoSGNode implements BrsValue {
                 this.makeDirty();
             }
         }
+    }
+
+    /**
+     * Checks whether a nested AA value (from an update()/populateNodeFromAA call) carrying a
+     * `subtype` key should be treated as a node-creation directive for `fieldName` on `node`,
+     * matching Roku's behavior: this applies to any field, but only when the target field either
+     * doesn't exist yet (and will be freshly created) or already has FieldKind.Node - a field
+     * declared with another type (e.g. assocarray) is left storing the AA as a literal value.
+     * @param node Node the field belongs to.
+     * @param fieldName Lowercased field name being set.
+     * @param value Candidate AA value for the field.
+     * @param createFields Whether new fields may be created by this update() call.
+     * @returns True when `value` should be converted into a real node instead of stored as-is.
+     */
+    private isNodeCreationDirective(
+        node: Node,
+        fieldName: string,
+        value: RoAssociativeArray,
+        createFields: boolean
+    ): boolean {
+        if (value.get(new BrsString("subtype")) instanceof BrsInvalid) {
+            return false;
+        }
+        const field = node.resolveField(fieldName);
+        return field ? field.getType() === FieldKind.Node : createFields;
     }
 
     /**

--- a/test/e2e/SceneGraph.test.js
+++ b/test/e2e/SceneGraph.test.js
@@ -206,6 +206,36 @@ describe("SceneGraph node tests", () => {
             "All subtype tests completed successfully!",
         ]);
     });
+    test("update-nested-node-field.brs", async () => {
+        await execute([resourceFile("scenegraph", "update-nested-node-field.brs")], outputStreams);
+
+        expect(allArgs(outputStreams.stdout.write).map((arg) => arg.trimEnd())).toEqual([
+            "Testing update() with a nested {subtype:...} AA on an arbitrary field",
+            "",
+            "Test 1: fresh field with a valid subtype",
+            "  type(n1.thing): roSGNode",
+            "  n1.thing.subtype(): Node",
+            "",
+            "Test 2: fresh field with an invalid subtype",
+            "  n2.hasField(thing): true",
+            "  type(n2.thing): roInvalid",
+            "",
+            "Test 3: fresh field with a plain (non-subtype) AA",
+            "  type(n3.meta): roAssociativeArray",
+            "  n3.meta.foo: bar",
+            "",
+            "Test 4: pre-declared placeholder field accepts a real node later",
+            "  Pre-declared type(responseNode.result): roSGNode",
+            "  After real update, type(responseNode.result): roSGNode",
+            "  responseNode.result.code: 200",
+            "",
+            "Test 5: children[] alongside a sibling subtype-node field",
+            "  parent.getChildCount(): 2",
+            "  type(parent.linked): roSGNode",
+            "",
+            "Test completed successfully!",
+        ]);
+    });
     test("local-port-rendering.brs", async () => {
         await execute([resourceFile("scenegraph", "local-port-rendering.brs")], outputStreams);
 

--- a/test/e2e/resources/scenegraph/update-nested-node-field.brs
+++ b/test/e2e/resources/scenegraph/update-nested-node-field.brs
@@ -1,0 +1,72 @@
+sub Main()
+    print "Testing update() with a nested {subtype:...} AA on an arbitrary field"
+    print ""
+
+    ' Test 1: a brand new field whose value is {subtype:"Node"} should become a
+    ' real roSGNode, just like a "children" array element with the same shape.
+    print "Test 1: fresh field with a valid subtype"
+    n1 = CreateObject("roSGNode", "Node")
+    n1.update({ thing: { subtype: "Node" } }, true)
+    print "  type(n1.thing): " + type(n1.thing)
+    if type(n1.thing) = "roSGNode"
+        print "  n1.thing.subtype(): " + n1.thing.subtype()
+    end if
+    print ""
+
+    ' Test 2: an unknown/invalid subtype should fail node creation, leaving the
+    ' field's value Invalid (the field is still created, typed as Node).
+    print "Test 2: fresh field with an invalid subtype"
+    n2 = CreateObject("roSGNode", "Node")
+    n2.update({ thing: { subtype: "TotallyBogusNodeType12345" } }, true)
+    print "  n2.hasField(thing): " + n2.hasField("thing").toStr()
+    print "  type(n2.thing): " + type(n2.thing)
+    print ""
+
+    ' Test 3: a nested AA WITHOUT a "subtype" key must still be stored as a
+    ' plain AssocArray value - only the "subtype" shape triggers conversion.
+    print "Test 3: fresh field with a plain (non-subtype) AA"
+    n3 = CreateObject("roSGNode", "Node")
+    n3.update({ meta: { foo: "bar" } }, true)
+    print "  type(n3.meta): " + type(n3.meta)
+    if type(n3.meta) = "roAssociativeArray"
+        print "  n3.meta.foo: " + n3.meta.foo
+    end if
+    print ""
+
+    ' Test 4: the real-world regression - a field pre-declared via a
+    ' {subtype:"Node"} placeholder (as in a "create a response holder" helper)
+    ' must accept a REAL node value in a later update() call without a type
+    ' mismatch.
+    print "Test 4: pre-declared placeholder field accepts a real node later"
+    responseNode = CreateObject("roSGNode", "Node")
+    responseNode.update({ request: { subtype: "Node" }, result: { subtype: "Node" } }, true)
+    print "  Pre-declared type(responseNode.result): " + type(responseNode.result)
+
+    realResult = CreateObject("roSGNode", "ContentNode")
+    realResult.update({ code: 200 }, true)
+    responseNode.update({ result: realResult }, true)
+
+    print "  After real update, type(responseNode.result): " + type(responseNode.result)
+    if type(responseNode.result) = "roSGNode"
+        print "  responseNode.result.code: " + responseNode.result.code.toStr()
+    end if
+    print ""
+
+    ' Test 5: a "children" array alongside a sibling subtype-node field in the
+    ' same update() call - the special-cased "children" handling must not
+    ' interfere with the generic subtype-node handling (or vice versa).
+    print "Test 5: children[] alongside a sibling subtype-node field"
+    parent = CreateObject("roSGNode", "Node")
+    parent.update({
+        linked: { subtype: "Node" }
+        children: [
+            { subtype: "Node", id: "child1" }
+            { subtype: "Node", id: "child2" }
+        ]
+    }, true)
+    print "  parent.getChildCount(): " + parent.getChildCount().toStr()
+    print "  type(parent.linked): " + type(parent.linked)
+
+    print ""
+    print "Test completed successfully!"
+end sub


### PR DESCRIPTION
## Summary

- `populateNodeFromAA()` only auto-converted a nested `{subtype: "..."}` AA into a real `roSGNode` when it was an element of a `children` array. Every other field just stored the AA verbatim, typed as `AssocArray`.
- This breaks a common SceneGraph idiom: pre-declaring a node-shaped field via `node.update({ field: { subtype: "Node" } }, true)`, then later calling `update()` again with a real node value for that field. Since the field's type was already locked in as `AssocArray`, the real node value gets rejected by `Field.canAcceptValue()`, logs `BRIGHTSCRIPT: ERROR: roSGNode.AddReplace: "...": Type mismatch!`, and the update is silently dropped - no exception, no observer notification.
- Verified this exact failure mode against a real production app pattern (a Task-based REST API helper that pre-declares a `result` field this way before the async response arrives).

## Real hardware verification

Confirmed the correct semantics against a real Roku device before implementing the fix:
- A brand-new field whose value is `{subtype: "Node"}` becomes a real `roSGNode`.
- An **unknown/invalid** `subtype` still creates the field typed as `Node`, but with value `Invalid` (plus a `No such node <type>` warning) - it does not fall back to storing the literal AA.
- A field **already declared** `type="node"` gets the same conversion.
- A field already declared `type="assocarray"` does **not** convert - the AA is stored as-is. So the conversion is gated on the target field either not existing yet or already being `FieldKind.Node`, not unconditional.
- The full pre-declare-then-real-update pattern succeeds with no type mismatch on real hardware, confirming this is an engine gap rather than app-level misuse.

## Changes

- `src/extensions/scenegraph/nodes/Node.ts`: `populateNodeFromAA()` now recognizes a nested `{subtype:...}` AA as a node-creation directive for any field (reusing the existing `createNode()` / recursive `populateNodeFromAA()` machinery already used for `children` elements), gated by the new `isNodeCreationDirective()` helper matching the real-hardware behavior above.
- `test/e2e/resources/scenegraph/update-nested-node-field.brs` (new) + a matching case in `test/e2e/SceneGraph.test.js`: valid subtype, invalid subtype, a plain non-subtype AA (regression guard - only the `subtype` shape triggers conversion), the pre-declare-then-real-update regression itself, and `children[]` alongside a sibling subtype-node field in the same `update()` call.

## Test plan

- [x] New e2e test passes (`update-nested-node-field.brs`)
- [x] Full existing SceneGraph e2e suite passes with no changes needed (`update-children-*.brs`, etc.)
- [x] Full repo test suite: 148 suites / 2011 tests pass, 0 regressions
- [x] `eslint` and `prettier --check` clean on touched files
- [x] Behavior cross-checked against a real Roku device for all scenarios above (both before and after the fix)