### PR TITLE
fix(rsg): honor clippingRect to limit node/children rendering

### DIFF
--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -343,9 +343,13 @@ export class ArrayGrid extends Group {
             this.refreshContent();
             content.changed = false;
         }
+        const clipped = this.pushClippingRect(drawTrans, draw2D);
         this.renderContent(interpreter, rect, rotation, opacity, draw2D);
         this.updateBoundingRects(rect, origin, rotation);
         this.renderChildren(interpreter, drawTrans, rotation, opacity, draw2D);
+        if (clipped) {
+            draw2D?.popClip();
+        }
         this.nodeRenderingDone(origin, angle, opacity, draw2D);
     }
 

--- a/src/extensions/scenegraph/nodes/Group.ts
+++ b/src/extensions/scenegraph/nodes/Group.ts
@@ -666,9 +666,40 @@ export class Group extends Node {
         // descendants compute their rects but keep reporting renderTracking "none" — they are laid
         // out, not displayed.
         opacity = this.isVisible() ? opacity * this.getOpacity() : 0;
+        const clipped = this.pushClippingRect(drawTrans, draw2D);
         this.renderChildren(interpreter, drawTrans, rotation, opacity, draw2D);
+        if (clipped) {
+            draw2D?.popClip();
+        }
         this.updateContainerBounds(nodeTrans, drawTrans);
         this.nodeRenderingDone(origin, angle, opacity, draw2D);
+    }
+
+    /**
+     * Applies this node's `clippingRect`, limiting where the node and its children may draw.
+     * The rect is in the node's local coordinate system (per the SceneGraph reference), so it is
+     * translated to scene/screen space by the node's draw translation before being pushed. An
+     * empty rect (width or height ≤ 0, the default `[0,0,0,0]`) disables clipping. Clipping is only
+     * applied on a real draw pass (`draw2D` present); a measurement/layout pass (no draw target)
+     * must remain unclipped so hidden-UI bounding rects still compute. The canvas clip intersects
+     * any already-active clip, so nested/ancestor `clippingRect`s compose and stay bounded by the
+     * screen. Returns whether a clip was pushed (caller must `popClip()` when true).
+     */
+    protected pushClippingRect(drawTrans: number[], draw2D?: IfDraw2D): boolean {
+        if (!draw2D) {
+            return false;
+        }
+        const clip = this.getValueJS("clippingRect") as { x: number; y: number; width: number; height: number };
+        if (!clip || clip.width <= 0 || clip.height <= 0) {
+            return false;
+        }
+        draw2D.pushClip({
+            x: clip.x + drawTrans[0],
+            y: clip.y + drawTrans[1],
+            width: clip.width,
+            height: clip.height,
+        });
+        return true;
     }
 
     private updateContainerBounds(nodeTrans: number[], drawTrans: number[]) {

--- a/test/extensions/scenegraph/ClippingRect.test.js
+++ b/test/extensions/scenegraph/ClippingRect.test.js
@@ -1,0 +1,134 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsDevice, BrsString, Float, RoArray, Interpreter } = core;
+
+/**
+ * Regression: honoring the `clippingRect` field. On Roku, `clippingRect` (declared on Group and
+ * inherited by every node, and auto-set by lists/grids) limits where a node and its children may
+ * render — the mechanism a collapsing container (e.g. a side menu clipped to a narrow width) uses
+ * to hide content that sits past its bounds. The field used to be a declared but ignored no-op, so
+ * clipped-away UI drew anyway. It is now applied via IfDraw2D.pushClip/popClip.
+ *
+ * The rect is in the node's LOCAL coordinate system and must be translated to scene/screen space,
+ * only applied on a real draw pass (draw2D present) so measurement passes stay unclipped.
+ */
+describe("clippingRect limits child rendering", () => {
+    let interpreter;
+
+    beforeAll(() => {
+        // MarkupGrid font-typed defaults need the common: fonts; mount once.
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    function vector(values) {
+        return new RoArray(values.map((v) => new Float(v)));
+    }
+
+    /** Records pushClip/popClip and rect draws so we can assert the clip bracket and its geometry. */
+    function recordingDraw2D() {
+        const clips = [];
+        let depth = 0;
+        let maxDepth = 0;
+        return {
+            clips,
+            getMaxDepth: () => maxDepth,
+            getDepth: () => depth,
+            pushClip: (rect) => {
+                clips.push({ ...rect });
+                depth += 1;
+                maxDepth = Math.max(maxDepth, depth);
+            },
+            popClip: () => {
+                depth -= 1;
+            },
+            doDrawRotatedRect: () => {},
+        };
+    }
+
+    /** Scene > Group(clippingRect) > Rectangle, with the group translated so we can check local→scene. */
+    function buildClippedGroup(clippingRect, groupTranslation = [0, 0]) {
+        const scene = SGNodeFactory.createNode("Scene");
+        const group = SGNodeFactory.createNode("Group");
+        if (groupTranslation) {
+            group.setValue("translation", vector(groupTranslation));
+        }
+        if (clippingRect) {
+            group.setValue("clippingRect", vector(clippingRect));
+        }
+        const rect = SGNodeFactory.createNode("Rectangle");
+        rect.setValue("width", new Float(300));
+        rect.setValue("height", new Float(100));
+        group.appendChildToParent(rect);
+        scene.appendChildToParent(group);
+        return { scene, group, rect };
+    }
+
+    test("a non-empty clippingRect is pushed in scene coordinates around the children", () => {
+        const { group } = buildClippedGroup([0, 0, 108, 1080], [40, 20]);
+        const draw2D = recordingDraw2D();
+
+        group.renderNode(interpreter, [0, 0], 0, 1, draw2D);
+
+        // The local clip [0,0,108,1080] is offset by the group's translation [40,20].
+        expect(draw2D.clips).toEqual([{ x: 40, y: 20, width: 108, height: 1080 }]);
+        // The clip was pushed and popped (balanced): depth returned to 0.
+        expect(draw2D.getDepth()).toBe(0);
+        expect(draw2D.getMaxDepth()).toBe(1);
+    });
+
+    test("an empty clippingRect (default) pushes no clip", () => {
+        const { group } = buildClippedGroup(null, [40, 20]);
+        const draw2D = recordingDraw2D();
+
+        group.renderNode(interpreter, [0, 0], 0, 1, draw2D);
+
+        expect(draw2D.clips).toHaveLength(0);
+        expect(draw2D.getMaxDepth()).toBe(0);
+    });
+
+    test("a zero-width clippingRect pushes no clip", () => {
+        const { group } = buildClippedGroup([0, 0, 0, 1080]);
+        const draw2D = recordingDraw2D();
+
+        group.renderNode(interpreter, [0, 0], 0, 1, draw2D);
+
+        expect(draw2D.clips).toHaveLength(0);
+    });
+
+    test("a measurement pass (no draw2D) is unaffected and still computes bounding rects", () => {
+        const { group, rect } = buildClippedGroup([0, 0, 108, 1080], [40, 20]);
+
+        // No draw target: nothing to clip, but the child must still be measured/laid out.
+        const bounds = rect.getBoundingRect("toScene", interpreter);
+        expect(bounds.width).toBe(300);
+        expect(bounds.height).toBe(100);
+        expect(group.getBoundingRect("toScene").width).toBe(300);
+    });
+
+    test("a MarkupGrid honors clippingRect around its content", () => {
+        const scene = SGNodeFactory.createNode("Scene");
+        const grid = SGNodeFactory.createNode("MarkupGrid");
+        grid.setValue("translation", vector([50, 0]));
+        grid.setValue("clippingRect", vector([0, 0, 108, 1080]));
+        scene.appendChildToParent(grid);
+        const draw2D = recordingDraw2D();
+
+        grid.renderNode(interpreter, [0, 0], 0, 1, draw2D);
+
+        expect(draw2D.clips).toEqual([{ x: 50, y: 0, width: 108, height: 1080 }]);
+        expect(draw2D.getDepth()).toBe(0);
+    });
+});


### PR DESCRIPTION
## Problem

`clippingRect` is declared on `Group` (inherited by every node, and auto-set by lists/grids per the SceneGraph spec) but was **never read** — a no-op field. Apps that rely on it to hide overflow had the clipped-away UI drawn anyway.

Concrete case: a collapsing container animates its grid's `clippingRect` to a narrow width. Content that sits past that width should be clipped away when collapsed, but stayed fully visible in the simulator.

## Fix

- Add `Group.pushClippingRect(drawTrans, draw2D)`: reads `clippingRect` (node-local coords), translates it to scene space via the node's draw translation, and pushes it through the existing `IfDraw2D.pushClip`/`popClip` (already used by `RowList`, `ScrollingLabel`, `ScrollableText`).
  - No-op on an empty rect (`width`/`height` ≤ 0, the default `[0,0,0,0]`).
  - No-op on measurement passes (no `draw2D`), so hidden-UI `boundingRect()` measurement is unaffected.
  - The canvas clip intersects any active ancestor clip and is bounded by the screen, matching the reference ("clippingRect can be specified by the node or any ancestor", "always clipped to screen boundaries").
- Bracket `renderChildren` in `Group.renderNode` and `renderContent`/`renderChildren` in `ArrayGrid.renderNode`. Bounds and render-tracking stay outside the clip since `boundingRect` is independent of clipping on Roku.

Reference: `scenegraph/layout-group-nodes/group.md` — `clippingRect` "Specifies a rectangle in the node local coordinate system that is used to limit the region where this node and its children can render."

## Scope

- `itemClippingRect` (per-item grid clip) left as-is — not needed here.
- Clip-rect rotation not handled (axis-aligned rect), matching the existing `RowList` clip and `drawNinePatch`.

## Tests

- New `test/extensions/scenegraph/ClippingRect.test.js` (5 cases): clip pushed in scene coords, no clip on empty/zero rect, measurement pass unaffected, grid honoring it.
- Full SceneGraph + CLI suites green (404 tests), including fragile-path regressions (`HiddenMeasure`, `GridMeasureSpacing`, `RowList`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)