### PR TITLE
fix(rsg): re-measure a degenerate bounding rect (either dimension zero) mid-render

### DIFF
--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -933,20 +933,21 @@ export class Node extends RoSGNode implements BrsValue {
             interpreter &&
             sgRoot.rendering &&
             !sgRoot.measuring &&
-            this.rectLocal.width <= 0 &&
-            this.rectLocal.height <= 0
+            (this.rectLocal.width <= 0 || this.rectLocal.height <= 0)
         ) {
-            // A query raised *during* an active render, on a node this pass has not laid out yet
-            // (its local rect is still zero) — most commonly a freshly-created ArrayGrid item
-            // component measuring its own content synchronously (e.g. a button sizing its background
-            // from `elementsGroup.boundingRect().width`) before the pass reaches it. A full-tree
-            // refresh from the scene root is unavailable here (it would re-enter the owning grid's
-            // item creation and recurse), so instead render only THIS node's own subtree to populate
-            // its rects. The grid is an ancestor, so a local pass cannot re-enter item creation.
-            // `.width`/`.height` are translation-invariant, so measuring at origin [0,0] yields the
-            // correct size; the true toScene/toParent origin is recomputed when the pass reaches this
-            // node. Restricting to zero-sized rects leaves already-measured nodes (and callers that
-            // inject rects while `rendering`) untouched. `measuring` bounds nested queries.
+            // A query raised *during* an active render, on a node this pass has not fully laid out
+            // yet (its local rect is degenerate in either dimension) — most commonly a freshly-created
+            // ArrayGrid item component measuring its own content synchronously (e.g. a button sizing
+            // its background from `elementsGroup.boundingRect().width`) before the pass reaches it.
+            // Either dimension being zero signals "not measured": a text label first measured while
+            // its text was still empty caches width 0 but a non-zero (text-independent) line height,
+            // so requiring BOTH to be zero would skip the refresh and return a stale zero width. A
+            // full-tree refresh from the scene root is unavailable here (it would re-enter the owning
+            // grid's item creation and recurse), so instead render only THIS node's own subtree to
+            // populate its rects. The grid is an ancestor, so a local pass cannot re-enter item
+            // creation. `.width`/`.height` are translation-invariant, so measuring at origin [0,0]
+            // yields the correct size; the true toScene/toParent origin is recomputed when the pass
+            // reaches this node. `measuring` bounds nested queries.
             sgRoot.measuring = true;
             try {
                 this.renderNode(interpreter, [0, 0], 0, 1);

--- a/src/extensions/scenegraph/nodes/SimpleLabel.ts
+++ b/src/extensions/scenegraph/nodes/SimpleLabel.ts
@@ -72,7 +72,19 @@ export class SimpleLabel extends Group {
         if (this.measured === undefined) {
             const rect: Rect = { x: 0, y: 0, width: 0, height: 0 };
             this.measured = this.renderLabel(rect, 0, 1);
-            this.rectLocal = { x: 0, y: 0, width: this.measured.width, height: this.measured.height };
+            const width = this.measured.width;
+            const height = this.measured.height;
+            // Populate all three coordinate-space rects, not just rectLocal. A component that sizes
+            // itself from a SimpleLabel's `boundingRect()` (parent space) — e.g. a text pill fitting a
+            // 9-patch background to its label — queries this before the render pass reaches the label;
+            // getBoundingRect's measuring fallback is then skipped (rectLocal is already non-zero), so
+            // it must return the measured size in every space, not a stale zero rectToParent/rectToScene.
+            // Width/height are translation-invariant; the true origins are recomputed when the pass
+            // reaches this node in renderNode.
+            const trans = this.getTranslation();
+            this.rectLocal = { x: 0, y: 0, width, height };
+            this.rectToParent = { x: trans[0], y: trans[1], width, height };
+            this.rectToScene = { x: trans[0], y: trans[1], width, height };
         }
         return this.measured;
     }

--- a/test/extensions/scenegraph/SimpleLabel.test.js
+++ b/test/extensions/scenegraph/SimpleLabel.test.js
@@ -6,6 +6,9 @@ const core = require("../../../packages/node/bin/brs.node.js");
 const { SGNodeFactory, sgRoot } = scenegraph;
 const { BrsDevice, BrsString, Int32 } = core;
 
+/** Minimal fake interpreter accepted by getBoundingRect (mirrors Poster.test.js). */
+const fakeObserverInterpreter = { environment: {}, inSubEnv: () => {} };
+
 /** Minimal interpreter accepted by renderNode → renderChildren (never dereferenced when draw2D is absent). */
 const fakeInterpreter = {};
 
@@ -76,6 +79,37 @@ describe("SimpleLabel node", () => {
         const measured = label.getMeasured();
         expect(measured.width).toBeGreaterThan(0);
         expect(measured.height).toBeGreaterThan(0);
+    });
+
+    /**
+     * Regression: boundingRect() queried during a render on a label whose cached rect is degenerate
+     * in ONLY one dimension must still re-measure. A text label first measured while its text was
+     * empty caches width 0 but a non-zero, text-independent line height. When a consumer then reads
+     * boundingRect() mid-render (e.g. an item component sizing a background from the label), the
+     * getBoundingRect measuring fallback used to require BOTH width and height to be zero, so a
+     * {width:0, height:N} rect skipped the refresh and returned width 0 — collapsing the background
+     * to padding. The fallback now triggers when EITHER dimension is zero.
+     */
+    test("boundingRect() re-measures a zero-width/non-zero-height label queried mid-render", () => {
+        const label = SGNodeFactory.createNode("SimpleLabel");
+        label.setValue("fontUri", new BrsString("font:MediumSystemFont"));
+        label.setValue("fontSize", new Int32(16));
+        label.setValue("text", new BrsString("Measured"));
+        const trueWidth = label.getMeasured().width;
+        expect(trueWidth).toBeGreaterThan(0);
+
+        // Poison the cached rect to width 0 with a non-zero height, as an empty-text measure leaves it.
+        label.rectLocal = { x: 0, y: 0, width: 0, height: 22 };
+        label.rectToParent = { x: 0, y: 0, width: 0, height: 22 };
+        label.rectToScene = { x: 0, y: 0, width: 0, height: 22 };
+
+        sgRoot.rendering = true;
+        try {
+            const rect = label.getBoundingRect("toParent", fakeObserverInterpreter);
+            expect(rect.width).toBe(trueWidth);
+        } finally {
+            sgRoot.rendering = false;
+        }
     });
 
     test("renders without a draw surface for every origin combination", () => {


### PR DESCRIPTION
## Problem

A single-line text label whose 9-patch/background is sized from the label's `boundingRect().width` could collapse to padding width — a narrow sliver at full text height — even though the label measured its text correctly.

Root cause: `Node.getBoundingRect`'s mid-render measuring fallback only re-rendered a node whose local rect was zero in **both** width and height:

```ts
this.rectLocal.width <= 0 && this.rectLocal.height <= 0
```

A label first measured while its `text` was still empty (typography set before the text) caches `{width: 0, height: N}` — the height is **text-independent** (`lineHeight * fontSize`), so it is non-zero even with no glyphs. When a consumer then reads `boundingRect()` **during** a render (e.g. an item component sizing a background from the label), the guard saw a non-zero height, skipped the refresh, and returned the stale **zero width**. The background was then sized to `0 + padding*2`.

## Fix

- Trigger the measuring fallback when **either** dimension is zero (`||` instead of `&&`): a degenerate rect in either axis means "not laid out yet", so it must re-measure.
- Populate all three coordinate-space rects (`rectLocal`/`rectToParent`/`rectToScene`) in `SimpleLabel.getMeasured`, so an eager `boundingRect()` query returns the measured size in every space rather than a stale zero `rectToParent`/`rectToScene`.

## Tests

- New regression in `test/extensions/scenegraph/SimpleLabel.test.js`: poisons a label's cached rect to `{width: 0, height: N}` and asserts a mid-render `boundingRect()` re-measures to the true width (fails returning 0 before the fix).
- Full suite green (2022 tests), including the fragile `getBoundingRect` hot-path regressions (`grid-measure`, re-entrant render, `HiddenMeasure`, `SubBoundingRect`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)