### PR TITLE
fix(rsg): silence the local mirror of a rendezvous field add so observers fire once

### DIFF
--- a/src/extensions/scenegraph/components/RoSGNode.ts
+++ b/src/extensions/scenegraph/components/RoSGNode.ts
@@ -187,7 +187,13 @@ export abstract class RoSGNode extends BrsComponent implements BrsValue, ISGNode
     abstract getValues(): BrsType[];
     abstract setValue(index: string, value: BrsType, alwaysNotify?: boolean, kind?: FieldKind, sync?: boolean): void;
     abstract setValueSilent(fieldName: string, value: BrsType, alwaysNotify?: boolean): void;
-    abstract addNodeField(fieldName: string, type: string, alwaysNotify: boolean, sync: boolean): void;
+    abstract addNodeField(
+        fieldName: string,
+        type: string,
+        alwaysNotify: boolean,
+        sync: boolean,
+        silent?: boolean
+    ): void;
     abstract getAddress(): string;
     abstract setAddress(address: string): void;
     abstract getOwner(): number;
@@ -216,7 +222,7 @@ export abstract class RoSGNode extends BrsComponent implements BrsValue, ISGNode
     protected abstract getFieldByRef(fieldName: string): RoAssociativeArray | string;
     protected abstract updateFields(interpreter: Interpreter, content: BrsType, createFields: boolean): void;
     protected abstract appendNodeFields(fieldsToAppend: BrsType): void;
-    protected abstract setNodeFields(fieldsToAppend: BrsType, addFields?: boolean): void;
+    protected abstract setNodeFields(fieldsToAppend: BrsType, addFields?: boolean, silent?: boolean): void;
     protected abstract removeFieldEntry(fieldName: string): boolean;
     protected abstract getNodeFieldsAsAA(): RoAssociativeArray;
     protected abstract getNodeFieldTypes(): RoAssociativeArray;
@@ -449,8 +455,11 @@ export abstract class RoSGNode extends BrsComponent implements BrsValue, ISGNode
                 if (remote !== undefined) {
                     // Mirror the field on this thread's copy: subsequent local reads/writes consult
                     // hasNodeField before rendezvousing, so without the mirror a field added through
-                    // a rendezvous stays invisible here (set fails, get returns invalid).
-                    this.addNodeField(fieldName.getValue(), type.getValue(), alwaysNotify.toBoolean(), true);
+                    // a rendezvous stays invisible here (set fails, get returns invalid). The mirror is
+                    // silent — the owning thread already notified observers and fanned the change out,
+                    // so notifying/re-syncing here would double-fire (e.g. a parentField observer that
+                    // counts content rows would over-count).
+                    this.addNodeField(fieldName.getValue(), type.getValue(), alwaysNotify.toBoolean(), true, true);
                     return remote;
                 }
                 this.location = interpreter.formatLocation();
@@ -470,9 +479,10 @@ export abstract class RoSGNode extends BrsComponent implements BrsValue, ISGNode
             impl: (interpreter: Interpreter, fields: RoAssociativeArray) => {
                 const remote = this.rendezvousCall(interpreter, "addFields", [fields]);
                 if (remote !== undefined) {
-                    // Mirror the fields on this thread's copy (see addField).
+                    // Mirror the fields on this thread's copy (see addField) — silently, so the local
+                    // copy is visible without re-notifying observers already notified by the owner.
                     if (fields instanceof RoAssociativeArray) {
-                        this.setNodeFields(fields, true);
+                        this.setNodeFields(fields, true, true);
                     }
                     return remote;
                 }

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -624,13 +624,19 @@ export class Node extends RoSGNode implements BrsValue {
      * @param type Roku field type string.
      * @param alwaysNotify Whether observers should always fire for the field.
      * @param sync Whether the field update should be synchronized with other threads.
+     * @param silent When true the field is created without notifying observers or rendezvousing
+     *        (used to mirror a field already added authoritatively on the owning thread).
      */
-    addNodeField(fieldName: string, type: string, alwaysNotify: boolean, sync?: boolean) {
+    addNodeField(fieldName: string, type: string, alwaysNotify: boolean, sync?: boolean, silent = false) {
         let defaultValue = getBrsValueFromFieldType(type);
         let fieldKind = FieldKind.fromString(type);
 
         if (defaultValue !== Uninitialized.Instance && !this.hasNodeField(fieldName.toLowerCase())) {
-            this.setValue(fieldName, defaultValue, alwaysNotify, fieldKind, sync);
+            if (silent) {
+                this.setValueSilent(fieldName, defaultValue, undefined, fieldKind);
+            } else {
+                this.setValue(fieldName, defaultValue, alwaysNotify, fieldKind, sync);
+            }
             this.makeDirty();
         }
     }
@@ -670,11 +676,17 @@ export class Node extends RoSGNode implements BrsValue {
      * Sets one or more fields from an associative array.
      * @param fieldsToSet Data source.
      * @param addFields If true, missing fields are created.
+     * @param silent When true the fields are set without notifying observers or rendezvousing
+     *        (used to mirror fields already added authoritatively on the owning thread).
      */
-    protected setNodeFields(fieldsToSet: RoAssociativeArray, addFields: boolean) {
+    protected setNodeFields(fieldsToSet: RoAssociativeArray, addFields: boolean, silent = false) {
         for (const [key, value] of fieldsToSet.elements) {
             if (addFields || (!addFields && this.hasNodeField(key.toLowerCase()))) {
-                this.setValue(key, value, false);
+                if (silent) {
+                    this.setValueSilent(key, value);
+                } else {
+                    this.setValue(key, value, false);
+                }
                 this.makeDirty();
             }
         }

--- a/test/extensions/scenegraph/RemoteFieldMirror.test.js
+++ b/test/extensions/scenegraph/RemoteFieldMirror.test.js
@@ -1,7 +1,7 @@
 const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
 const core = require("../../../packages/node/bin/brs.node.js");
 
-const { Node } = scenegraph;
+const { Node, ContentNode, Field } = scenegraph;
 const { Interpreter } = core;
 const { BrsString, BrsBoolean, RoAssociativeArray, RoArray, Int32 } = core;
 
@@ -38,6 +38,33 @@ describe("remote field management mirrors on the local node copy", () => {
         addFields.call(interpreter, new RoAssociativeArray([{ name: new BrsString("counter"), value: new Int32(1) }]));
 
         expect(node.hasNodeField("counter")).toBe(true);
+    });
+
+    test("the add mirror is silent — it does not re-notify observers already fired by the owner", () => {
+        // A ContentNode held in a parent's Node-typed field registers that field as a parentField;
+        // adding a field to the ContentNode notifies it. When the ContentNode is remote, the owning
+        // thread already performed that notification, so the local mirror must NOT fire it again —
+        // a double-notify over-counts observers that tally content rows (the #1001 regression).
+        const parent = new Node([], "Node");
+        const child = new ContentNode();
+        parent.addNodeField("content", "node", false); // create the node-typed field
+        parent.setValue("content", child); // child.parentFields now includes parent's "content" field
+
+        // Force the child remote so addFields rendezvouses (the mirror branch under test).
+        child.rendezvousCall = () => BrsBoolean.True;
+
+        const notifySpy = jest.spyOn(Field.prototype, "notifyObservers");
+        try {
+            const addFields = child.getMethod("addFields");
+            addFields.call(interpreter, new RoAssociativeArray([{ name: new BrsString("0"), value: new Int32(7) }]));
+
+            // Mirror still applied locally so later reads/writes work...
+            expect(child.hasNodeField("0")).toBe(true);
+            // ...but it did not notify (before the fix the parentField observer fired here).
+            expect(notifySpy).not.toHaveBeenCalled();
+        } finally {
+            notifySpy.mockRestore();
+        }
     });
 
     test("removeField/removeFields remove the fields locally when served via rendezvous", () => {


### PR DESCRIPTION
## Problem

PR #1001 mirrors a field added/removed via rendezvous onto the calling thread's local node copy, so later local `get`/`set` (which gate on `hasNodeField`) still work. For the **add** paths, the mirror re-applied the mutation through the *notifying* code path (`addNodeField`/`setNodeFields` → `setValue`). On a `ContentNode`, `setValue` re-runs `notifyParentFields()` and `rendezvousSet()`, so a single `addField`/`addFields` from a Task thread produced **two** parent-field notifications instead of one.

This breaks a common content-loading pattern: a loader running in a Task thread signals "another row is ready" by adding a field to a shared `ContentNode`, and the render thread counts that parent field's notifications to decide when all rows have arrived. The double-notify made the count reach its target after only half the rows had actually loaded, so the UI committed early and the trailing sections never appeared.

## Fix

- Add an optional `silent` flag (default `false`, preserving all existing callers) to `Node.addNodeField` and `Node.setNodeFields`. When set, the field is written via the existing non-notifying `setValueSilent` instead of `setValue`.
- Pass `silent: true` from the `addField`/`addFields` mirror branches in `RoSGNode.ts`. The owning thread already notified observers and fanned the change out, so the local mirror must not re-fire.
- `removeField`/`removeFields` already mirror via the non-notifying `removeFieldEntry` — left unchanged.

## Testing

- New case in `test/extensions/scenegraph/RemoteFieldMirror.test.js` — asserts the add mirror still applies locally (`hasNodeField` true) but does **not** notify observers. Verified out-of-band that the pre-fix (non-silent) path *does* notify, so the test genuinely guards the regression.
- Full sweep `npx jest test/extensions/scenegraph test/cli/cli.test.js` — 35 suites, 394 pass, no other regressions.
- `npm run lint` + `npm run prettier:write` clean.

> Note: Tasks/Rendezvous do not run under `brs-cli`; the fix was validated end-to-end in the desktop app (all sections render again).

🤖 Generated with [Claude Code](https://claude.com/claude-code)