### PR TITLE
fix(rsg): apply an interface field's default value through its alias targets

### DIFF
--- a/src/extensions/scenegraph/factory/NodeFactory.ts
+++ b/src/extensions/scenegraph/factory/NodeFactory.ts
@@ -782,6 +782,16 @@ function addFields(interpreter: Interpreter, node: Node, typeDef: ComponentDefin
             // An unresolvable alias target only warns (like a device): the remaining targets are
             // still tried, and the fields declared after this one are still added.
             addAliases(fieldName, fieldValue.alias, node, typeDef);
+            // Apply the XML default, mirroring the non-alias branch below. Alias targets share the
+            // parent field's Field instance, so this single write propagates the default to every
+            // target child (e.g. a `height` field defaulting to "42" and aliased to a child Poster's
+            // height, which would otherwise stay 0 and fall back to the bitmap's native size).
+            // An aliased field typically has no `type` attribute — its type comes from the shared
+            // target field — so coerce the value using the resolved field's type, not fieldValue.type.
+            const aliasField = node.resolveField(fieldName.toLowerCase());
+            if (fieldValue.value && aliasField) {
+                node.setValueSilent(fieldName, getBrsValueFromFieldType(aliasField.getType(), fieldValue.value));
+            }
         } else {
             // resolveField materializes a ContentNode hidden metadata default so a component that
             // redeclares one (e.g. "title") is still detected and routed through replaceField.

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -267,6 +267,31 @@ describe("cli", () => {
         ]);
     }, 10000);
 
+    it("applies an interface field's default value through its alias targets", async () => {
+        // Regression: addFields applied a field's XML default only on the non-alias branch, so an
+        // aliased field with a default (e.g. `height` value="42" aliased to a child's height) never
+        // wrote the default. The aliased child then read 0 — and a background Poster sized this way
+        // would fall back to its bitmap's native size instead of the intended height.
+        let command = ["node", brsCliPath, "-r alias-default-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "=== Testing Aliased Field Default ===",
+            "scene.boxHeight = 42",
+            "box1.height = 42",
+            "box2.height = 42",
+            "scene.boxWidth = 100",
+            "box1.width = 100",
+            "scene.trailing = present",
+            "=== Test Complete ===",
+            "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+    }, 10000);
+
     it("findNode resolves ids breadth-first (shallow sibling wins over a child component's internals)", async () => {
         // Regression: findNodeById was depth-first, so it descended into an earlier sibling's
         // subtree — including a custom component's INTERNAL children — and returned a deep node

--- a/test/cli/resources/alias-default-app/components/AliasDefaultTest.xml
+++ b/test/cli/resources/alias-default-app/components/AliasDefaultTest.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="AliasDefaultTest" extends="Scene">
+  <interface>
+    <!-- An interface field with BOTH a default value and an alias to child fields must apply the
+         default through the alias. The child Rectangles declare no height, so their height comes
+         only from this default; without it they read 0 (and a Poster would fall back to its
+         bitmap's native size). Also covers a single-target aliased default.
+         NOTE: no `type` attribute — an aliased field's type comes from its target child field.
+         Coercing the default off a missing `type` must NOT throw (which would abort addFields and
+         drop every field declared after this one). A trailing field asserts no such cascade. -->
+    <field id="boxHeight" alias="box1.height, box2.height" value="42" />
+    <field id="boxWidth" alias="box1.width" value="100" />
+    <field id="trailing" type="string" value="present" />
+  </interface>
+  <children>
+    <Rectangle id="box1" />
+    <Rectangle id="box2" />
+  </children>
+</component>

--- a/test/cli/resources/alias-default-app/manifest
+++ b/test/cli/resources/alias-default-app/manifest
@@ -1,0 +1,4 @@
+title=Alias Default Test
+major_version=1
+minor_version=0
+build_version=0

--- a/test/cli/resources/alias-default-app/source/main.brs
+++ b/test/cli/resources/alias-default-app/source/main.brs
@@ -1,0 +1,24 @@
+sub Main()
+    print "=== Testing Aliased Field Default ==="
+
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+
+    scene = screen.CreateScene("AliasDefaultTest")
+    screen.show()
+
+    ' The default must reach the parent alias field and every aliased child field.
+    print "scene.boxHeight = "; scene.boxHeight.toStr()
+    print "box1.height = "; scene.findNode("box1").height.toStr()
+    print "box2.height = "; scene.findNode("box2").height.toStr()
+
+    ' Single-target aliased default.
+    print "scene.boxWidth = "; scene.boxWidth.toStr()
+    print "box1.width = "; scene.findNode("box1").width.toStr()
+
+    ' A field declared after the aliased defaults must still exist (no addFields cascade).
+    print "scene.trailing = "; scene.trailing
+
+    print "=== Test Complete ==="
+end sub


### PR DESCRIPTION
## Problem

A `<Poster>` used as a 9-patch background can grow on the width axis but not the height axis when its height is supplied through an aliased interface field default. More generally: an `<interface>` field that declares **both** a default `value` **and** an `alias` to child fields never wrote its default.

```xml
<field id="height" alias="background.height, border.height" value="42" />
```

The aliased children read `0`, so a background Poster sized this way fell back to its bitmap's native size instead of the intended height.

## Root cause

In `addFields` (`src/extensions/scenegraph/factory/NodeFactory.ts`), the XML default `value` was applied **only on the non-alias branch**. The alias branch wired up the alias and did nothing with `fieldValue.value`. Width appeared to work only because apps commonly set it directly in BrightScript, masking the identical gap.

## Fix

Apply the default after wiring the alias, mirroring the non-alias branch. Alias targets share the parent field's `Field` instance, so a single `setValueSilent` on the parent field name propagates the default to every target child.

An aliased field typically has **no `type` attribute** — its type is inherited from the shared target field — so the value is coerced off the resolved field's type (`aliasField.getType()`), **not** `fieldValue.type`. Reading `.toLowerCase()` on an absent type would throw and abort `addFields`, dropping every field declared after the aliased one (this was caught and fixed before merge).

No change to the 9-patch parser, renderer, or Poster — those are correct and symmetric.

## Testing

- New CLI regression app `alias-default-app` (wired into `test/cli/cli.test.js`): typeless aliased defaults, both multi-target and single-target, plus a trailing field asserting no `addFields` cascade.
- Full test suite green (151 suites / 2028 tests / 178 snapshots), lint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)