### PR TITLE
fix(rsg): emit vertFocusDirection + settle-last focus order, and honor Video asyncStopSemantics

### DIFF
--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -91,6 +91,11 @@ export class ArrayGrid extends Group {
         { name: "currFocusRow", type: "float", value: "0.0" },
         { name: "currFocusColumn", type: "float", value: "0.0" },
         { name: "currFocusSection", type: "float", value: "0.0" },
+        // Read-only on device: the direction ("up"/"down"/"none") of the most recent vertical focus
+        // move. Undocumented in the public reference but present on real Roku ArrayGrid-derived nodes;
+        // apps observe it to track scroll direction (e.g. to position an in-transit overlay toward the
+        // incoming row). Emitted as up/down on a vertical nav then reset to "none".
+        { name: "vertFocusDirection", type: "string", value: "none" },
     ];
     protected readonly dividerUri = "common:/images/dividerHorizontal.9.png";
     protected readonly content: ContentNode[] = [];

--- a/src/extensions/scenegraph/nodes/RowList.ts
+++ b/src/extensions/scenegraph/nodes/RowList.ts
@@ -223,9 +223,16 @@ export class RowList extends ArrayGrid {
      * app driving a focused-item overlay from currFocusRow/currFocusColumn never leaves item [0,0].
      */
     protected setRowItemFocused(rowIndex: number, colIndex: number) {
-        super.setValue("rowItemFocused", new RoArray([new Int32(rowIndex), new Int32(colIndex)]));
+        // Emit currFocusRow/currFocusColumn BEFORE rowItemFocused. On a real device the focus fields
+        // pass through in-transit (fractional) values during the scroll animation and rowItemFocused
+        // settles last, so apps treat the rowItemFocused observer as the authoritative "focus settled"
+        // callback (e.g. the one that positions a per-row overlay on the final row). Since our scroll is
+        // instant, honoring that ordering — the settle notification fires last — keeps such an app from
+        // being stranded in its transient state (an observer on currFocusRow that computes an in-transit
+        // row from the scroll direction would otherwise run last and win). Regression: RowList.test.js.
         super.setValue("currFocusRow", new Float(rowIndex));
         super.setValue("currFocusColumn", new Float(colIndex));
+        super.setValue("rowItemFocused", new RoArray([new Int32(rowIndex), new Int32(colIndex)]));
     }
 
     protected handleUpDown(key: string) {
@@ -283,7 +290,12 @@ export class RowList extends ArrayGrid {
 
             const rowItem = new RoArray([new Int32(nextRow), new Int32(targetColIndex)]);
             this.currRow += this.wrap ? 0 : offset; // Update currRow before setFocusedItem
+            // Publish the vertical scroll direction BEFORE the focus change so observers of the focus
+            // fields see the correct direction, then reset it to "none" after (mirroring a real device,
+            // where the direction is transient and settles back to none once scrolling completes).
+            super.setValue("vertFocusDirection", new BrsString(offset > 0 ? "down" : "up"));
             this.setValue("jumpToRowItem", rowItem);
+            super.setValue("vertFocusDirection", new BrsString("none"));
             handled = true;
         }
         return handled;

--- a/src/extensions/scenegraph/nodes/Video.ts
+++ b/src/extensions/scenegraph/nodes/Video.ts
@@ -272,6 +272,19 @@ export class Video extends Group {
                     if (["play", "prebuffer", "resume", "replay"].includes(control) && sgRoot.video !== this) {
                         sgRoot.setVideo(this);
                     }
+                    // asyncStopSemantics (Roku OS 12.5+): a "stop" is non-blocking and reports its
+                    // progress through the state field — "stopping" the moment the stop begins, then
+                    // "stopped" once it completes. Apps use that transition to serialize a following
+                    // play/prebuffer (which needs the underlying player freed) behind the stop; without
+                    // the "stopping" edge, such an app never learns the stop started and its queued play
+                    // is dropped, leaving the next content unplayed. The completing "stopped" is emitted
+                    // by setState when the main thread's stop lands (MediaEvent.Partial). If the player
+                    // is already stopped there is no event to come, so settle synchronously instead of
+                    // stranding the node in "stopping".
+                    if (control === "stop" && this.getValueJS("asyncStopSemantics") === true) {
+                        const settled = this.getValueJS("state") === "stopped" || this.getValueJS("state") === "none";
+                        super.setValue("state", new BrsString(settled ? "stopped" : "stopping"));
+                    }
                     postMessage(`video,${control}`);
                 }
             } else if (control !== "none") {

--- a/test/extensions/scenegraph/RowList.test.js
+++ b/test/extensions/scenegraph/RowList.test.js
@@ -78,6 +78,46 @@ describe("RowList key handling", () => {
         expect(list.getValueJS("currFocusColumn")).toBe(0);
     });
 
+    test("vertical nav emits vertFocusDirection (then resets to none) and settles rowItemFocused last", () => {
+        // Regression: an app that positions a per-row overlay reads the vertical scroll direction from
+        // vertFocusDirection and treats the rowItemFocused observer as the authoritative "settled"
+        // callback. (1) vertFocusDirection must report up/down during the move and reset to "none"
+        // afterward; (2) currFocusRow must be emitted BEFORE rowItemFocused so the settle notification
+        // fires last (an observer on rowItemFocused must already see the final row).
+        const { RoMessagePort } = core;
+        const fakeInterpreter = { environment: {}, inSubEnv: () => {} };
+        const list = SGNodeFactory.createNode("RowList");
+        list.setValue("content", buildContent([["A", "B"], ["C", "D"], ["E"]]));
+
+        // Capture the order of focus-field notifications across one vertical move.
+        const port = new RoMessagePort();
+        const order = [];
+        const originalPush = port.pushMessage.bind(port);
+        port.pushMessage = (event) => {
+            order.push(event.fieldName ? event.fieldName.getValue() : "");
+            originalPush(event);
+        };
+        list.addObserver(fakeInterpreter, "unscoped", new BrsString("currFocusRow"), port);
+        list.addObserver(fakeInterpreter, "unscoped", new BrsString("rowItemFocused"), port);
+
+        list.handleKey("down", true);
+
+        // Down moved to row 1 and the direction settled back to none.
+        expect(list.getValueJS("rowItemFocused")[0]).toBe(1);
+        expect(list.getValueJS("vertFocusDirection")).toBe("none");
+
+        // currFocusRow was notified before rowItemFocused (settle fires last).
+        const rowIdx = order.indexOf("currFocusRow");
+        const itemIdx = order.lastIndexOf("rowItemFocused");
+        expect(rowIdx).toBeGreaterThanOrEqual(0);
+        expect(itemIdx).toBeGreaterThan(rowIdx);
+
+        // Up reports the opposite direction, then resets.
+        list.handleKey("up", true);
+        expect(list.getValueJS("rowItemFocused")[0]).toBe(0);
+        expect(list.getValueJS("vertFocusDirection")).toBe("none");
+    });
+
     test("a multi-row fixedFocusWrap list still wraps (down/up stay handled)", () => {
         const list = SGNodeFactory.createNode("RowList");
         list.setValue("vertFocusAnimationStyle", new BrsString("fixedFocusWrap"));

--- a/test/extensions/scenegraph/Video.test.js
+++ b/test/extensions/scenegraph/Video.test.js
@@ -4,7 +4,7 @@ const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
 const core = require("../../../packages/node/bin/brs.node.js");
 
 const { SGNodeFactory, sgRoot } = scenegraph;
-const { BrsDevice, BrsString, Int32, RoAssociativeArray } = core;
+const { BrsDevice, BrsString, BrsBoolean, Int32, RoAssociativeArray, DataType, MediaEvent } = core;
 
 describe("Video bufferingBar and retrievingBar fields", () => {
     let originalPostMessage;
@@ -192,5 +192,66 @@ describe("Video cross-thread deserialization guard", () => {
 
         other.setValue("control", new BrsString("stop"));
         expect(sgRoot.video).toBe(active); // stop/pause don't hijack routing
+    });
+});
+
+describe("Video asyncStopSemantics stopping->stopped transition", () => {
+    let originalPostMessage;
+
+    beforeAll(() => {
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    beforeEach(() => {
+        originalPostMessage = global.postMessage;
+        global.postMessage = jest.fn();
+        sgRoot.setVideo();
+    });
+
+    afterEach(() => {
+        global.postMessage = originalPostMessage;
+        sgRoot.setVideo();
+    });
+
+    test("a stop while playing reports 'stopping' immediately, then 'stopped' when the stop lands", () => {
+        // Roku OS 12.5+ async stop: control="stop" is non-blocking and surfaces its progress through
+        // the state field so an app can serialize a following play behind the stop. Without the
+        // "stopping" edge the app never learns the stop began and its queued play is dropped.
+        const video = SGNodeFactory.createNode("Video");
+        sgRoot.setVideo(video);
+        video.setValue("asyncStopSemantics", BrsBoolean.from(true));
+
+        // Drive it to playing, then async-stop.
+        video.setState(MediaEvent.StartStream, 0);
+        expect(video.getValueJS("state")).toBe("playing");
+
+        video.setValue("control", new BrsString("stop"));
+        // The stop is in progress; the state reflects that synchronously.
+        expect(video.getValueJS("state")).toBe("stopping");
+
+        // The main thread confirms the stop (Partial); the node then settles to stopped.
+        video.setState(MediaEvent.Partial, 0);
+        expect(video.getValueJS("state")).toBe("stopped");
+    });
+
+    test("a stop when already stopped settles synchronously (no hang in 'stopping')", () => {
+        const video = SGNodeFactory.createNode("Video");
+        sgRoot.setVideo(video);
+        video.setValue("asyncStopSemantics", BrsBoolean.from(true));
+
+        // Fresh node is in "none"; an async stop must not strand it in "stopping" (no event will come).
+        video.setValue("control", new BrsString("stop"));
+        expect(video.getValueJS("state")).toBe("stopped");
+    });
+
+    test("without asyncStopSemantics a stop does NOT enter 'stopping'", () => {
+        const video = SGNodeFactory.createNode("Video");
+        sgRoot.setVideo(video);
+        video.setState(MediaEvent.StartStream, 0);
+
+        video.setValue("control", new BrsString("stop"));
+        // Synchronous stop semantics: state is unchanged by the control write itself.
+        expect(video.getValueJS("state")).not.toBe("stopping");
     });
 });


### PR DESCRIPTION
## Summary

Two independent SceneGraph fixes for correct focus/scroll signaling on `RowList` and correct stop→play sequencing on `Video`, both discovered while running a large production SceneGraph app and validated end-to-end.

### RowList — vertical focus signaling
- **Add the `vertFocusDirection` field** to the `ArrayGrid` defaults. It exists on real Roku `ArrayGrid`-derived nodes (used by apps to track scroll direction, e.g. to position an in-transit overlay toward the incoming row) but is absent from the public reference, so we never emitted it. `RowList.handleUpDown` now publishes `"up"`/`"down"` before the focus change and resets to `"none"` afterward, mirroring a device where the direction is transient.
- **Emit `currFocusRow`/`currFocusColumn` before `rowItemFocused`** in `setRowItemFocused`. On a real device the focus fields pass through in-transit (fractional) values during the scroll animation and `rowItemFocused` settles last, so apps treat the `rowItemFocused` observer as the authoritative "focus settled" callback. With our instant (non-animated) scrolling, an observer on `currFocusRow` that computes an in-transit row from the scroll direction would otherwise fire last and win, leaving the app stranded in its transient state (e.g. a per-row overlay applied to the wrong row until the next horizontal move).

### Video — asyncStopSemantics (Roku OS 12.5+)
- Implement the non-blocking stop: `control="stop"` with `asyncStopSemantics=true` now sets `state="stopping"` synchronously, then settles to `"stopped"` when the stop completes (`MediaEvent.Partial`), or settles synchronously when the player is already idle. Apps use that `stopping→stopped` transition to serialize a following `play`/`prebuffer` behind the stop; without the `"stopping"` edge the queued command was dropped and the next content never played.

## Testing
- New regression tests in `test/extensions/scenegraph/RowList.test.js` (vertFocusDirection emit + settle-last ordering) and `test/extensions/scenegraph/Video.test.js` (stopping→stopped transition, synchronous settle when idle, and no `"stopping"` without the flag).
- Full suite green (`npm test`), `npm run lint` and `npm run prettier:write` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)