### PR TITLE
fix(rsg): resolve RowList/ZoomRowList focused-item subBoundingRect and correct vertical outset

### DIFF
--- a/src/extensions/scenegraph/SGUtil.ts
+++ b/src/extensions/scenegraph/SGUtil.ts
@@ -192,3 +192,52 @@ export function convertHexColor(strColor: string): number {
     }
     return color;
 }
+
+/**
+ * Maps an ifSGNodeBoundingRect sub-part id to a rendered item component in a row-based grid's
+ * `rowItemComps[row][col]` store. Shared by RowList and ZoomRowList, which both hold a 2-D grid of
+ * components (unlike the flat ArrayGrid `itemComps[]` the base resolver assumes), so
+ * `subBoundingRect("item<row>_<col>")` can resolve the focused poster instead of the whole-list rect.
+ *
+ *   - `focusItem` / `focusIndicator` → the focused row's focused column.
+ *   - `item<row>_<col>` → that exact cell (split on `_` before parsing — a plain `parseInt` drops the
+ *     `_col`).
+ *   - `item<row>` (no underscore) → the row's currently focused column, matching Roku's single-index
+ *     addressing of a row-list row.
+ *
+ * Generic over the element type to avoid a Group/Node import here (SGUtil is dependency-free). Returns
+ * undefined for an out-of-range or not-yet-rendered cell so the caller keeps its documented fallback.
+ * @param itemNumber The sub-part identifier.
+ * @param rowItemComps The grid's per-row component arrays.
+ * @param focusIndex The focused row index.
+ * @param rowFocus Per-row focused column indices.
+ */
+export function resolveRowItemSubpart<T>(
+    itemNumber: string,
+    rowItemComps: T[][],
+    focusIndex: number,
+    rowFocus: number[]
+): T | undefined {
+    const name = itemNumber.trim().toLowerCase();
+    if (name === "focusitem" || name === "focusindicator") {
+        return rowItemComps[focusIndex]?.[rowFocus[focusIndex] ?? 0];
+    }
+    if (!name.startsWith("item")) {
+        return undefined;
+    }
+    const parts = name.slice(4).split("_");
+    const row = Number.parseInt(parts[0], 10);
+    if (!Number.isInteger(row)) {
+        return undefined;
+    }
+    let col: number;
+    if (parts.length > 1) {
+        col = Number.parseInt(parts[1], 10);
+        if (!Number.isInteger(col)) {
+            return undefined;
+        }
+    } else {
+        col = rowFocus[row] ?? 0;
+    }
+    return rowItemComps[row]?.[col];
+}

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -989,12 +989,21 @@ export class Node extends RoSGNode implements BrsValue {
      * @returns Bounding rectangle of the sub part in the requested coordinate space.
      */
     getSubBoundingRect(type: string, itemNumber: string, interpreter?: Interpreter): Rect {
-        // Refresh layout the same way getBoundingRect does (guarded against re-entrant renders).
-        const ownRect = this.getBoundingRect(type, interpreter);
         const subpart = this.resolveSubpart(itemNumber);
         if (!subpart) {
-            return ownRect;
+            // No such sub part: return the node's own bounding rect, refreshing layout the same way
+            // getBoundingRect does (guarded against re-entrant renders).
+            return this.getBoundingRect(type, interpreter);
         }
+        // A resolved sub part is an already-rendered item component carrying a valid rect from the last
+        // frame. Do NOT force a full-tree re-render here (getBoundingRect): subBoundingRect is queried
+        // on every focus/scroll change, so re-rendering the whole scene per query is prohibitively slow
+        // AND can capture a transient, mid-layout size (an item briefly at the row's full itemSize
+        // instead of its poster size). The cached rects are at most one frame old, matching a real
+        // device (subBoundingRect reports the location at call time); for the fixed-focus lists that
+        // drive a focused-item overlay from this, the focused item's position is constant, so the cached
+        // value is exact. this.rect* are this node's own cached rects (it renders every frame), so they
+        // are consistent with the sub part's scene rect.
         const subScene = subpart.rectToScene;
         if (type === "toScene") {
             return { ...subScene };

--- a/src/extensions/scenegraph/nodes/RowList.ts
+++ b/src/extensions/scenegraph/nodes/RowList.ts
@@ -18,6 +18,7 @@ import { ContentNode } from "./ContentNode";
 import { brsValueOf, jsValueOf } from "../factory/Serializer";
 import { Font } from "./Font";
 import { Group } from "./Group";
+import { Node } from "./Node";
 import { ArrayGrid, FocusStyle } from "./ArrayGrid";
 import { FieldKind, FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";
@@ -93,10 +94,16 @@ export class RowList extends ArrayGrid {
 
         if (this.resolution === "FHD") {
             this.marginX = 33;
-            this.marginY = 33;
+            // Vertical bounding-rect outset. A real device reports a RowList's boundingRect (and its
+            // item subBoundingRects) outset by only ~6px on the Y axis — the focus 9-patch's own
+            // content margins drive the focus RING (see ArrayGrid.focusMargins, which prefers the
+            // bitmap's declared margins over this value), so marginY here affects ONLY the reported
+            // rects, not the drawn focus frame. A larger square value pushed subBoundingRect.y down,
+            // so an app placing a focused-item overlay from it sat the overlay too low.
+            this.marginY = 6;
         } else {
             this.marginX = 22;
-            this.marginY = 22;
+            this.marginY = 4;
         }
         this.gap = 0;
         this.setValueSilent("focusBitmapUri", new BrsString(this.focusUri));
@@ -343,6 +350,49 @@ export class RowList extends ArrayGrid {
             }
         }
         return false;
+    }
+
+    /**
+     * Resolves an ifSGNodeBoundingRect sub part to the matching rendered item component. A RowList
+     * holds a 2-D grid of components in `rowItemComps[row][col]` (not the flat ArrayGrid `itemComps[]`,
+     * which stays empty here), so the base resolver — which parses `item<row>_<col>` as one index into
+     * `itemComps[]` — never matches and every query falls back to the whole-list rect. On a real device
+     * `subBoundingRect("item<row>_<col>")` returns the focused poster's rect, which apps use to place a
+     * focused-item overlay; without this override the overlay cannot track the row's item layout.
+     *
+     *   - `focusItem` / `focusIndicator` → the focused row's focused column.
+     *   - `item<row>_<col>` → that exact cell (split on `_` before parsing — the base `parseInt` drops
+     *     the `_col`).
+     *   - `item<row>` (no underscore) → the row's currently focused column, matching Roku's single-index
+     *     addressing of a RowList row.
+     *
+     * Returns undefined for an out-of-range or not-yet-rendered cell so `getSubBoundingRect` keeps its
+     * documented fallback to the node's own bounding rect.
+     */
+    protected resolveSubpart(itemNumber: string): Node | undefined {
+        const name = itemNumber.trim().toLowerCase();
+        if (name === "focusitem" || name === "focusindicator") {
+            const row = this.focusIndex;
+            return this.rowItemComps[row]?.[this.rowFocus[row] ?? 0];
+        }
+        if (!name.startsWith("item")) {
+            return undefined;
+        }
+        const parts = name.slice(4).split("_");
+        const row = Number.parseInt(parts[0], 10);
+        if (!Number.isInteger(row)) {
+            return undefined;
+        }
+        let col: number;
+        if (parts.length > 1) {
+            col = Number.parseInt(parts[1], 10);
+            if (!Number.isInteger(col)) {
+                return undefined;
+            }
+        } else {
+            col = this.rowFocus[row] ?? 0;
+        }
+        return this.rowItemComps[row]?.[col];
     }
 
     private getRowItemSize(rowIndex: number): number[] {

--- a/src/extensions/scenegraph/nodes/RowList.ts
+++ b/src/extensions/scenegraph/nodes/RowList.ts
@@ -21,6 +21,7 @@ import { Group } from "./Group";
 import { Node } from "./Node";
 import { ArrayGrid, FocusStyle } from "./ArrayGrid";
 import { FieldKind, FieldModel } from "../SGTypes";
+import { resolveRowItemSubpart } from "../SGUtil";
 import { SGNodeType } from ".";
 
 const ValidFocusStyles = new Set(Object.values(FocusStyle).map((style) => style.toLowerCase()));
@@ -355,44 +356,13 @@ export class RowList extends ArrayGrid {
     /**
      * Resolves an ifSGNodeBoundingRect sub part to the matching rendered item component. A RowList
      * holds a 2-D grid of components in `rowItemComps[row][col]` (not the flat ArrayGrid `itemComps[]`,
-     * which stays empty here), so the base resolver — which parses `item<row>_<col>` as one index into
-     * `itemComps[]` — never matches and every query falls back to the whole-list rect. On a real device
-     * `subBoundingRect("item<row>_<col>")` returns the focused poster's rect, which apps use to place a
-     * focused-item overlay; without this override the overlay cannot track the row's item layout.
-     *
-     *   - `focusItem` / `focusIndicator` → the focused row's focused column.
-     *   - `item<row>_<col>` → that exact cell (split on `_` before parsing — the base `parseInt` drops
-     *     the `_col`).
-     *   - `item<row>` (no underscore) → the row's currently focused column, matching Roku's single-index
-     *     addressing of a RowList row.
-     *
-     * Returns undefined for an out-of-range or not-yet-rendered cell so `getSubBoundingRect` keeps its
-     * documented fallback to the node's own bounding rect.
+     * which stays empty here), so the base resolver never matches and every query falls back to the
+     * whole-list rect. On a real device `subBoundingRect("item<row>_<col>")` returns the focused
+     * poster's rect, which apps use to place a focused-item overlay; without this override the overlay
+     * cannot track the row's item layout. See `resolveRowItemSubpart` for the id mapping.
      */
     protected resolveSubpart(itemNumber: string): Node | undefined {
-        const name = itemNumber.trim().toLowerCase();
-        if (name === "focusitem" || name === "focusindicator") {
-            const row = this.focusIndex;
-            return this.rowItemComps[row]?.[this.rowFocus[row] ?? 0];
-        }
-        if (!name.startsWith("item")) {
-            return undefined;
-        }
-        const parts = name.slice(4).split("_");
-        const row = Number.parseInt(parts[0], 10);
-        if (!Number.isInteger(row)) {
-            return undefined;
-        }
-        let col: number;
-        if (parts.length > 1) {
-            col = Number.parseInt(parts[1], 10);
-            if (!Number.isInteger(col)) {
-                return undefined;
-            }
-        } else {
-            col = this.rowFocus[row] ?? 0;
-        }
-        return this.rowItemComps[row]?.[col];
+        return resolveRowItemSubpart(itemNumber, this.rowItemComps, this.focusIndex, this.rowFocus);
     }
 
     private getRowItemSize(rowIndex: number): number[] {

--- a/src/extensions/scenegraph/nodes/ZoomRowList.ts
+++ b/src/extensions/scenegraph/nodes/ZoomRowList.ts
@@ -22,6 +22,7 @@ import { Group } from "./Group";
 import { Node } from "./Node";
 import { ArrayGrid, FocusStyle } from "./ArrayGrid";
 import { FieldKind, FieldModel } from "../SGTypes";
+import { resolveRowItemSubpart } from "../SGUtil";
 import { SGNodeType } from ".";
 
 interface RowMetrics {
@@ -289,34 +290,10 @@ export class ZoomRowList extends ArrayGrid {
      * Resolves an ifSGNodeBoundingRect sub part to the matching rendered item component. Like RowList,
      * a ZoomRowList holds a 2-D grid of components in `rowItemComps[row][col]` (not the flat ArrayGrid
      * `itemComps[]`), so the base resolver never matches and every query falls back to the whole-list
-     * rect. `focusItem`/`focusIndicator` map to the focused cell; `item<row>_<col>` to that exact cell
-     * (row/col split before parsing); `item<row>` to the row's focused column. Out-of-range or
-     * not-yet-rendered cells return undefined so the caller keeps its fallback to the node's own rect.
+     * rect. See `resolveRowItemSubpart` for the id mapping.
      */
     protected resolveSubpart(itemNumber: string): Node | undefined {
-        const name = itemNumber.trim().toLowerCase();
-        if (name === "focusitem" || name === "focusindicator") {
-            const row = this.focusIndex;
-            return this.rowItemComps[row]?.[this.rowFocus[row] ?? 0];
-        }
-        if (!name.startsWith("item")) {
-            return undefined;
-        }
-        const parts = name.slice(4).split("_");
-        const row = Number.parseInt(parts[0], 10);
-        if (!Number.isInteger(row)) {
-            return undefined;
-        }
-        let col: number;
-        if (parts.length > 1) {
-            col = Number.parseInt(parts[1], 10);
-            if (!Number.isInteger(col)) {
-                return undefined;
-            }
-        } else {
-            col = this.rowFocus[row] ?? 0;
-        }
-        return this.rowItemComps[row]?.[col];
+        return resolveRowItemSubpart(itemNumber, this.rowItemComps, this.focusIndex, this.rowFocus);
     }
 
     protected renderContent(

--- a/src/extensions/scenegraph/nodes/ZoomRowList.ts
+++ b/src/extensions/scenegraph/nodes/ZoomRowList.ts
@@ -19,6 +19,7 @@ import { customNodeExists } from "../factory/NodeFactory";
 import { brsValueOf, jsValueOf } from "../factory/Serializer";
 import { Font } from "./Font";
 import { Group } from "./Group";
+import { Node } from "./Node";
 import { ArrayGrid, FocusStyle } from "./ArrayGrid";
 import { FieldKind, FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";
@@ -282,6 +283,40 @@ export class ZoomRowList extends ArrayGrid {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Resolves an ifSGNodeBoundingRect sub part to the matching rendered item component. Like RowList,
+     * a ZoomRowList holds a 2-D grid of components in `rowItemComps[row][col]` (not the flat ArrayGrid
+     * `itemComps[]`), so the base resolver never matches and every query falls back to the whole-list
+     * rect. `focusItem`/`focusIndicator` map to the focused cell; `item<row>_<col>` to that exact cell
+     * (row/col split before parsing); `item<row>` to the row's focused column. Out-of-range or
+     * not-yet-rendered cells return undefined so the caller keeps its fallback to the node's own rect.
+     */
+    protected resolveSubpart(itemNumber: string): Node | undefined {
+        const name = itemNumber.trim().toLowerCase();
+        if (name === "focusitem" || name === "focusindicator") {
+            const row = this.focusIndex;
+            return this.rowItemComps[row]?.[this.rowFocus[row] ?? 0];
+        }
+        if (!name.startsWith("item")) {
+            return undefined;
+        }
+        const parts = name.slice(4).split("_");
+        const row = Number.parseInt(parts[0], 10);
+        if (!Number.isInteger(row)) {
+            return undefined;
+        }
+        let col: number;
+        if (parts.length > 1) {
+            col = Number.parseInt(parts[1], 10);
+            if (!Number.isInteger(col)) {
+                return undefined;
+            }
+        } else {
+            col = this.rowFocus[row] ?? 0;
+        }
+        return this.rowItemComps[row]?.[col];
     }
 
     protected renderContent(

--- a/test/extensions/scenegraph/SGUtil.test.js
+++ b/test/extensions/scenegraph/SGUtil.test.js
@@ -1,6 +1,14 @@
 const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
-const { rectContainsRect, rotateRect, rotateTranslation, unionRect, convertNumber, convertLong, convertHexColor } =
-    scenegraph;
+const {
+    rectContainsRect,
+    rotateRect,
+    rotateTranslation,
+    unionRect,
+    convertNumber,
+    convertLong,
+    convertHexColor,
+    resolveRowItemSubpart,
+} = scenegraph;
 const Long = require("long");
 
 describe("SGUtil", () => {
@@ -572,6 +580,48 @@ describe("SGUtil", () => {
             test("handles no prefix", () => {
                 expect(convertHexColor("FF0000")).toBe(-16776961);
             });
+        });
+    });
+
+    describe("resolveRowItemSubpart", () => {
+        // A row-based grid stores item components as grid[row][col]. Strings tag each cell so we can
+        // assert which one the helper resolves. Row 1 is focused; its focused column is 2.
+        const grid = [
+            ["0_0", "0_1", "0_2"],
+            ["1_0", "1_1", "1_2"],
+        ];
+        const focusIndex = 1;
+        const rowFocus = [1, 2];
+
+        test("item<row>_<col> resolves that exact cell (col is not dropped)", () => {
+            expect(resolveRowItemSubpart("item1_2", grid, focusIndex, rowFocus)).toBe("1_2");
+            expect(resolveRowItemSubpart("item0_0", grid, focusIndex, rowFocus)).toBe("0_0");
+        });
+
+        test("item<row> with no underscore resolves the row's focused column", () => {
+            expect(resolveRowItemSubpart("item0", grid, focusIndex, rowFocus)).toBe("0_1");
+            expect(resolveRowItemSubpart("item1", grid, focusIndex, rowFocus)).toBe("1_2");
+        });
+
+        test("focusItem/focusIndicator resolve the focused row's focused column", () => {
+            expect(resolveRowItemSubpart("focusItem", grid, focusIndex, rowFocus)).toBe("1_2");
+            expect(resolveRowItemSubpart("focusIndicator", grid, focusIndex, rowFocus)).toBe("1_2");
+        });
+
+        test("is case-insensitive and trims whitespace", () => {
+            expect(resolveRowItemSubpart("  ITEM1_0  ", grid, focusIndex, rowFocus)).toBe("1_0");
+        });
+
+        test("returns undefined for out-of-range, non-item, or malformed ids", () => {
+            expect(resolveRowItemSubpart("item9_9", grid, focusIndex, rowFocus)).toBeUndefined();
+            expect(resolveRowItemSubpart("item1_9", grid, focusIndex, rowFocus)).toBeUndefined();
+            expect(resolveRowItemSubpart("focusRing", grid, focusIndex, rowFocus)).toBeUndefined();
+            expect(resolveRowItemSubpart("itemX", grid, focusIndex, rowFocus)).toBeUndefined();
+            expect(resolveRowItemSubpart("item1_X", grid, focusIndex, rowFocus)).toBeUndefined();
+        });
+
+        test("falls back to column 0 when the row has no recorded focus", () => {
+            expect(resolveRowItemSubpart("item0", grid, focusIndex, [])).toBe("0_0");
         });
     });
 });

--- a/test/extensions/scenegraph/SubBoundingRect.test.js
+++ b/test/extensions/scenegraph/SubBoundingRect.test.js
@@ -3,7 +3,7 @@ const path = require("path");
 const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
 const core = require("../../../packages/node/bin/brs.node.js");
 
-const { Node, Group, MarkupGrid, ContentNode, sgRoot } = scenegraph;
+const { Node, Group, MarkupGrid, RowList, ZoomRowList, ContentNode, sgRoot } = scenegraph;
 const { BrsDevice, Interpreter, BrsString } = core;
 
 describe("ifSGNodeBoundingRect sub-part methods", () => {
@@ -70,6 +70,49 @@ describe("ifSGNodeBoundingRect sub-part methods", () => {
         // An item that was never rendered (no component yet) falls back to the grid's rect.
         expect(grid.getSubBoundingRect("toParent", "item7")).toEqual(grid.rectToParent);
     });
+
+    // RowList (and ZoomRowList) hold a 2-D grid of item components in rowItemComps[row][col], not the
+    // flat itemComps[] array, so they need their own resolveSubpart. Apps place a focused-item overlay
+    // from subBoundingRect("item<row>_<col>"); before the override every query fell back to the
+    // whole-list rect (verified against a real device, which returns the focused poster's rect). The
+    // resolved path also must NOT force a re-render — it reads the item's cached last-frame rect.
+    for (const { label, make } of [
+        { label: "RowList", make: () => new RowList() },
+        { label: "ZoomRowList", make: () => new ZoomRowList() },
+    ]) {
+        test(`resolves item<row>_<col>/item<row>/focusItem on a ${label} from cached rects`, () => {
+            const list = make();
+            list.rectToParent = { x: 10, y: 20, width: 1000, height: 400 };
+            list.rectLocal = { x: 0, y: 0, width: 1000, height: 400 };
+            list.rectToScene = { x: 100, y: 200, width: 1000, height: 400 };
+
+            // Inject rendered item components (poster-sized, as after a normal frame — the resolver
+            // reads these cached rects and must not force a re-render that could capture a row-sized rect).
+            const cell = (x, y) => {
+                const g = new Group([], "Group");
+                g.rectToScene = { x, y, width: 200, height: 120 };
+                return g;
+            };
+            list.rowItemComps[0] = [cell(100, 200), cell(320, 200), cell(540, 200)];
+            list.rowItemComps[1] = [cell(100, 340), cell(320, 340), cell(540, 340)];
+            list.content.push(new ContentNode(), new ContentNode());
+            list.focusIndex = 1;
+            list.rowFocus[0] = 1;
+            list.rowFocus[1] = 2;
+
+            // item<row>_<col> resolves to that exact cell (the base parseInt would drop the _col).
+            expect(list.getSubBoundingRect("toScene", "item1_2")).toEqual(list.rowItemComps[1][2].rectToScene);
+            expect(list.getSubBoundingRect("toScene", "item0_0")).toEqual(list.rowItemComps[0][0].rectToScene);
+            // item<row> (no underscore) resolves to that row's focused column.
+            expect(list.getSubBoundingRect("toScene", "item0")).toEqual(list.rowItemComps[0][1].rectToScene);
+            expect(list.getSubBoundingRect("toScene", "item1")).toEqual(list.rowItemComps[1][2].rectToScene);
+            // focusItem/focusIndicator resolve to the focused row's focused column.
+            expect(list.getSubBoundingRect("toScene", "focusItem")).toEqual(list.rowItemComps[1][2].rectToScene);
+            expect(list.getSubBoundingRect("toScene", "focusIndicator")).toEqual(list.rowItemComps[1][2].rectToScene);
+            // An unrendered cell falls back to the list's own rect.
+            expect(list.getSubBoundingRect("toScene", "item9_9")).toEqual(list.rectToScene);
+        });
+    }
 });
 
 describe("ancestorSubBoundingRect", () => {


### PR DESCRIPTION
## Summary

`ifSGNodeBoundingRect.subBoundingRect("item<row>_<col>")` on a `RowList` or `ZoomRowList` always fell back to the node's whole bounding rect, so an app that positions a focused-item overlay from it could not track the row's actual item layout — the overlay sat misaligned and exposed the item behind it.

### Root cause (three parts)
1. **Sub-part never resolved.** `RowList`/`ZoomRowList` keep their item components in a 2-D `rowItemComps[row][col]` grid, but the base `ArrayGrid.resolveSubpart` parses `item<row>_<col>` as a single index into the flat `itemComps[]` (which stays empty for these nodes), so every query missed and returned the list's own rect.
2. **Wrong vertical outset.** `RowList` overrode its focus margin to a square `33` (FHD) / `22` (HD). A real device outsets a RowList's bounding rect — and its item sub-rects — by only ~`6` / `4` on the Y axis. The inflated value pushed `subBoundingRect().y` down, so the overlay derived from it sat too low.
3. **Forced re-render per query.** `getSubBoundingRect` refreshed layout via a full-tree render on every call; `subBoundingRect` is queried on every focus/scroll change, making it both slow and prone to returning a transient mid-layout rect.

### Fix
- Add a `resolveSubpart` override to `RowList` and `ZoomRowList` mapping `item<row>_<col>` / `item<row>` / `focusItem` / `focusIndicator` to the rendered component in `rowItemComps[row][col]` (row/col split before parsing; out-of-range or not-yet-rendered cells return `undefined` and keep the documented fallback to the node's own rect).
- `getSubBoundingRect` returns the resolved item component's **cached** last-frame rect and no longer forces a re-render — matching a real device (which reports the location at call time) and eliminating the per-query cost and the transient-size flicker.
- Lower `RowList`'s vertical margin to `6` (FHD) / `4` (HD), matching the base `ArrayGrid` value and a real device. The focus **ring** uses the focus 9-patch's own declared content margins (`ArrayGrid.focusMargins` prefers them over `marginY`), so this corrects the reported rects and the overlay position **without** changing the drawn focus frame. `marginX` is unchanged (it still drives the horizontal row clip).

## Testing
- New cases in `test/extensions/scenegraph/SubBoundingRect.test.js` cover `item<row>_<col>`, `item<row>`, `focusItem`/`focusIndicator`, and the unrendered-cell fallback for both `RowList` and `ZoomRowList`, reading cached rects (no forced render).
- Full suite green (`npm test`); `npm run lint` and `npm run prettier:write` clean; grid focus-feedback tests still pass, confirming the margin change does not affect focus rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)