### PR TITLE
fix(rsg): span the focus-feedback footprint in a RowList focused item's subBoundingRect

### DIFF
--- a/src/extensions/scenegraph/nodes/RowList.ts
+++ b/src/extensions/scenegraph/nodes/RowList.ts
@@ -365,6 +365,40 @@ export class RowList extends ArrayGrid {
         return resolveRowItemSubpart(itemNumber, this.rowItemComps, this.focusIndex, this.rowFocus);
     }
 
+    /**
+     * Returns a sub part's bounding rect, extending the FOCUSED item's rect upward by the focus-feedback
+     * top margin. On a real device the focused cell's reported rect spans the focus-feedback footprint
+     * (the focus 9-patch outsets above the poster), not the bare poster — so an app that places a
+     * focused-item overlay from this rect lands the overlay on the poster. The item component's own
+     * `rectToScene` is the poster rect (it renders at `itemRect`; the focus frame is drawn separately,
+     * outset by `focusMargins`), so without this the overlay sits one focus-line too low and the poster
+     * shows above it. The outset is keyed to the focus bitmap being present, NOT `drawFocusFeedback`: a
+     * device reserves the footprint region whenever a focus bitmap is set even if the app suppresses the
+     * drawn frame (a common pattern for apps that render their own focus indicator). Only the focused
+     * cell has the footprint, so only its rect is adjusted; other sub parts pass through.
+     */
+    getSubBoundingRect(type: string, itemNumber: string, interpreter?: Interpreter): Rect {
+        const rect = super.getSubBoundingRect(type, itemNumber, interpreter);
+        const subpart = this.resolveSubpart(itemNumber);
+        const focusedItem = this.rowItemComps[this.focusIndex]?.[this.rowFocus[this.focusIndex] ?? 0];
+        // Reserve the focus-feedback footprint whenever a focus bitmap is set (the focus indicator,
+        // or its footprint when the list is unfocused). Keyed on the bitmap URI, NOT drawFocusFeedback,
+        // so it still applies when an app suppresses the drawn frame but relies on the reserved footprint
+        // (e.g. to place its own indicator). Both URIs are consulted because subBoundingRect reflects the
+        // focused item regardless of whether the list node currently holds live focus.
+        const bmpUri = this.getValueJS("focusBitmapUri") ? "focusBitmapUri" : "focusFootprintBitmapUri";
+        if (subpart && subpart === focusedItem && this.getValueJS(bmpUri)) {
+            // Match the focus frame's own outset: the 9-patch's declared top margin, falling back to
+            // marginY when the bitmap hasn't loaded (mirrors ArrayGrid.focusMargins).
+            const bmp = this.getBitmap(bmpUri);
+            const top = bmp?.isValid() ? this.focusMargins(bmp).top : this.marginY;
+            if (top) {
+                return { ...rect, y: rect.y - top, height: rect.height + top };
+            }
+        }
+        return rect;
+    }
+
     private getRowItemSize(rowIndex: number): number[] {
         const itemSize = this.getValueJS("itemSize") as number[];
         // Per Roku docs, rowItemSize is indexed by absolute row; rows beyond the array reuse the

--- a/test/extensions/scenegraph/SubBoundingRect.test.js
+++ b/test/extensions/scenegraph/SubBoundingRect.test.js
@@ -74,45 +74,74 @@ describe("ifSGNodeBoundingRect sub-part methods", () => {
     // RowList (and ZoomRowList) hold a 2-D grid of item components in rowItemComps[row][col], not the
     // flat itemComps[] array, so they need their own resolveSubpart. Apps place a focused-item overlay
     // from subBoundingRect("item<row>_<col>"); before the override every query fell back to the
-    // whole-list rect (verified against a real device, which returns the focused poster's rect). The
+    // whole-list rect (verified against a real device, which returns the focused item's rect). The
     // resolved path also must NOT force a re-render — it reads the item's cached last-frame rect.
+    // Shared fixture: two rows of three poster-sized cells, row 1 / col 2 focused.
+    const buildRowGrid = (list) => {
+        list.rectToParent = { x: 10, y: 20, width: 1000, height: 400 };
+        list.rectLocal = { x: 0, y: 0, width: 1000, height: 400 };
+        list.rectToScene = { x: 100, y: 200, width: 1000, height: 400 };
+        const cell = (x, y) => {
+            const g = new Group([], "Group");
+            g.rectToScene = { x, y, width: 200, height: 120 };
+            return g;
+        };
+        list.rowItemComps[0] = [cell(100, 200), cell(320, 200), cell(540, 200)];
+        list.rowItemComps[1] = [cell(100, 340), cell(320, 340), cell(540, 340)];
+        list.content.push(new ContentNode(), new ContentNode());
+        list.focusIndex = 1;
+        list.rowFocus[0] = 1;
+        list.rowFocus[1] = 2;
+    };
+
     for (const { label, make } of [
         { label: "RowList", make: () => new RowList() },
         { label: "ZoomRowList", make: () => new ZoomRowList() },
     ]) {
         test(`resolves item<row>_<col>/item<row>/focusItem on a ${label} from cached rects`, () => {
             const list = make();
-            list.rectToParent = { x: 10, y: 20, width: 1000, height: 400 };
-            list.rectLocal = { x: 0, y: 0, width: 1000, height: 400 };
-            list.rectToScene = { x: 100, y: 200, width: 1000, height: 400 };
+            buildRowGrid(list);
 
-            // Inject rendered item components (poster-sized, as after a normal frame — the resolver
-            // reads these cached rects and must not force a re-render that could capture a row-sized rect).
-            const cell = (x, y) => {
-                const g = new Group([], "Group");
-                g.rectToScene = { x, y, width: 200, height: 120 };
-                return g;
-            };
-            list.rowItemComps[0] = [cell(100, 200), cell(320, 200), cell(540, 200)];
-            list.rowItemComps[1] = [cell(100, 340), cell(320, 340), cell(540, 340)];
-            list.content.push(new ContentNode(), new ContentNode());
-            list.focusIndex = 1;
-            list.rowFocus[0] = 1;
-            list.rowFocus[1] = 2;
-
-            // item<row>_<col> resolves to that exact cell (the base parseInt would drop the _col).
-            expect(list.getSubBoundingRect("toScene", "item1_2")).toEqual(list.rowItemComps[1][2].rectToScene);
+            // A NON-focused cell resolves to its exact poster rect (the base parseInt would drop the _col).
             expect(list.getSubBoundingRect("toScene", "item0_0")).toEqual(list.rowItemComps[0][0].rectToScene);
-            // item<row> (no underscore) resolves to that row's focused column.
+            // item<row> (no underscore) resolves to that row's focused column (non-focused row 0 → col 1).
             expect(list.getSubBoundingRect("toScene", "item0")).toEqual(list.rowItemComps[0][1].rectToScene);
-            expect(list.getSubBoundingRect("toScene", "item1")).toEqual(list.rowItemComps[1][2].rectToScene);
-            // focusItem/focusIndicator resolve to the focused row's focused column.
-            expect(list.getSubBoundingRect("toScene", "focusItem")).toEqual(list.rowItemComps[1][2].rectToScene);
-            expect(list.getSubBoundingRect("toScene", "focusIndicator")).toEqual(list.rowItemComps[1][2].rectToScene);
             // An unrendered cell falls back to the list's own rect.
             expect(list.getSubBoundingRect("toScene", "item9_9")).toEqual(list.rectToScene);
         });
     }
+
+    // RowList extends the FOCUSED cell's rect upward by the focus-feedback top margin so an app that
+    // offsets its overlay by the focus footprint lands the overlay on the poster (the item component's
+    // own rect is the bare poster; the focus 9-patch frame is drawn outset above it). Only the focused
+    // cell draws the frame, so only its rect is adjusted.
+    test("RowList outsets the focused item's rect by the focus-feedback top margin", () => {
+        const list = new RowList();
+        buildRowGrid(list);
+        const focusedPoster = list.rowItemComps[1][2].rectToScene;
+
+        for (const id of ["item1_2", "item1", "focusItem", "focusIndicator"]) {
+            const r = list.getSubBoundingRect("toScene", id);
+            const top = focusedPoster.y - r.y;
+            expect(top).toBeGreaterThan(0); // outset above the poster
+            expect(r.x).toBe(focusedPoster.x);
+            expect(r.width).toBe(focusedPoster.width);
+            expect(r.height).toBe(focusedPoster.height + top); // grows by the same top margin
+        }
+
+        // A non-focused cell is NOT outset — it reports its bare poster rect.
+        expect(list.getSubBoundingRect("toScene", "item0_0")).toEqual(list.rowItemComps[0][0].rectToScene);
+
+        // The outset is keyed to the focus bitmap, not drawFocusFeedback: suppressing the drawn frame
+        // still reserves the footprint (apps that render their own focus indicator rely on this).
+        list.setValue("drawFocusFeedback", core.BrsBoolean.False);
+        expect(list.getSubBoundingRect("toScene", "item1_2").y).toBeLessThan(focusedPoster.y);
+
+        // With no focus bitmap there is no footprint, so the focused cell reports its bare poster rect.
+        list.setValue("focusBitmapUri", new core.BrsString(""));
+        list.setValue("focusFootprintBitmapUri", new core.BrsString(""));
+        expect(list.getSubBoundingRect("toScene", "item1_2")).toEqual(focusedPoster);
+    });
 });
 
 describe("ancestorSubBoundingRect", () => {


### PR DESCRIPTION
## Summary

Follow-up to #1029. A `RowList` item component's rect is the bare poster — it renders at `itemRect`, while the focus 9-patch frame is drawn separately, outset *above* the poster by `focusMargins`. On a real device the **focused** cell's `subBoundingRect` spans that focus-feedback footprint, not the bare poster, so an app that positions a focused-item overlay from the rect lands the overlay on the poster. Ours returned the bare poster, so such an overlay sat one focus-line too low and the poster showed above it.

## Fix

Add a `RowList.getSubBoundingRect` override that extends the **focused** item's rect upward by the focus-feedback top margin (the focus 9-patch's declared top, falling back to `marginY` when the bitmap hasn't loaded — mirroring `ArrayGrid.focusMargins`).

Key detail: the outset is gated on a **focus bitmap URI being set**, *not* on `drawFocusFeedback`. A device reserves the footprint region whenever a focus bitmap exists, even when the app suppresses the drawn frame — the pattern used by apps that render their own focus indicator. Only the focused cell has the footprint, so only its rect is adjusted; every other sub part passes through unchanged.

## Testing
- `test/extensions/scenegraph/SubBoundingRect.test.js`: the focused cell grows upward by the top margin (asserting the adjustment shape — `y` decreases, `height` grows by the same amount — rather than a fixed pixel count); non-focused cells and a list with no focus bitmap report the bare poster rect.
- Full suite green (`npm test`); `npm run lint` and `npm run prettier:write` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)