### PR TITLE
fix(rsg): defer reentrant field observers and refresh subBoundingRect on pending focus change

### DIFF
--- a/src/extensions/scenegraph/index.ts
+++ b/src/extensions/scenegraph/index.ts
@@ -30,6 +30,7 @@ import {
 import { loadComponentLibrary } from "./parser/ComponentLibrary";
 import { sgRoot } from "./SGRoot";
 import { Task } from "./nodes/Task";
+import { Field } from "./nodes/Field";
 import { initializeTask, createNode, updateTypeDefHierarchy, getNodeType } from "./factory/NodeFactory";
 import { RoSGScreen } from "./components/RoSGScreen";
 import { getRenderThreadQueue } from "./components/RoRenderThreadQueue";
@@ -53,6 +54,8 @@ export class BrightScriptExtension implements BrsExtension {
     readonly version = packageInfo.version;
 
     onInit() {
+        // Reset per-thread deferred observer-dispatch state so nothing leaks across app runs.
+        Field.resetDispatch();
         // Register SceneGraph components with BrsObjects so they can be created with CreateObject()
         BrsObjects.set("roSGScreen", () => new RoSGScreen(), 0);
         BrsObjects.set(

--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -110,6 +110,11 @@ export class ArrayGrid extends Group {
     protected numCols: number = 0;
     protected currRow: number = 0;
     protected topRow: number = 0;
+    // Set when the focus/scroll position changes and cleared once renderNode re-lays-out the grid.
+    // While set, a subBoundingRect query refreshes layout first so it reports the settled focus-band
+    // position instead of the newly focused item's stale, pre-scroll cached rect (see
+    // needsSubBoundingRectRefresh / Node.getSubBoundingRect).
+    protected focusLayoutDirty: boolean = false;
     protected wrap: boolean = false;
     protected lastPressHandled: string;
     protected hasNinePatch: boolean;
@@ -227,6 +232,7 @@ export class ArrayGrid extends Group {
         this.updateItemFocus(this.focusIndex, false, nodeFocus);
         super.setValue("itemUnfocused", new Int32(focusedIndex));
         this.focusIndex = newFocus;
+        this.focusLayoutDirty = true;
         this.updateItemFocus(this.focusIndex, true, nodeFocus);
         super.setValue("itemFocused", new Int32(index));
         if (this.itemFocusCallback) {
@@ -251,6 +257,10 @@ export class ArrayGrid extends Group {
      * undefined and the caller falls back to the node's own bounding rect (matching Roku's
      * "if the subpart does not exist" behavior).
      */
+    protected needsSubBoundingRectRefresh(): boolean {
+        return this.focusLayoutDirty;
+    }
+
     protected resolveSubpart(itemNumber: string): Node | undefined {
         const name = itemNumber.trim().toLowerCase();
         let compIndex = -1;
@@ -350,6 +360,8 @@ export class ArrayGrid extends Group {
         }
         const clipped = this.pushClippingRect(drawTrans, draw2D);
         this.renderContent(interpreter, rect, rotation, opacity, draw2D);
+        // The grid was just laid out for the current focus/scroll state, so item rects are fresh.
+        this.focusLayoutDirty = false;
         this.updateBoundingRects(rect, origin, rotation);
         this.renderChildren(interpreter, drawTrans, rotation, opacity, draw2D);
         if (clipped) {

--- a/src/extensions/scenegraph/nodes/ContentNode.ts
+++ b/src/extensions/scenegraph/nodes/ContentNode.ts
@@ -11,7 +11,7 @@ import {
     BrsInvalid,
 } from "brs-engine";
 import { Node } from "./Node";
-import type { Field } from "./Field";
+import { Field } from "./Field";
 import { FieldKind, FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";
 import { sgRoot } from "../SGRoot";
@@ -211,11 +211,15 @@ export class ContentNode extends Node {
             return;
         }
         this.propagating = true;
+        // Mark this as a ContentNode parentField cascade so its observers dispatch synchronously
+        // (inline) rather than being deferred — the #904/#905/#943 termination guards rely on it.
+        Field.enterParentCascade();
         try {
             for (const field of this.parentFields) {
                 field.notifyObservers();
             }
         } finally {
+            Field.exitParentCascade();
             this.propagating = false;
         }
     }

--- a/src/extensions/scenegraph/nodes/Field.ts
+++ b/src/extensions/scenegraph/nodes/Field.ts
@@ -69,7 +69,7 @@ export class Field {
      */
     private static draining = false;
     /** Deferred reentrant observer invocations, drained at the outermost unwind. */
-    private static deferredQueue: { field: Field; callback: BrsCallback; event: RoSGNodeEvent }[] = [];
+    private static readonly deferredQueue: { field: Field; callback: BrsCallback; event: RoSGNodeEvent }[] = [];
 
     /** Marks entry into a ContentNode parentField cascade, so its observers dispatch inline. */
     static enterParentCascade() {

--- a/src/extensions/scenegraph/nodes/Field.ts
+++ b/src/extensions/scenegraph/nodes/Field.ts
@@ -28,6 +28,7 @@ import {
     RuntimeError,
     DebugMode,
     Uninitialized,
+    BrsDevice,
 } from "brs-engine";
 import { Node } from "./Node";
 import { RoSGNodeEvent } from "../events/RoSGNodeEvent";
@@ -45,6 +46,48 @@ export class Field {
     private scopedObservers?: Map<Node, BrsCallback[]>;
     /** True while this field's observers are dispatching, to break re-entrant cascades. */
     private notifying = false;
+
+    // ---- Roku-accurate deferred observer dispatch (per Worker thread) -------------------------
+    // On a real Roku, a function-name field observer is dispatched from the owning thread's
+    // message loop; it does NOT run reentrantly in the middle of another observer's execution.
+    // We reproduce that: when a Callable observer would fire while another Callable observer is
+    // already executing (reentrant) — and the notification is not part of a ContentNode
+    // parentField cascade — we queue it and drain it FIFO once the outermost dispatch unwinds.
+    // Same-field re-notification (`notifying`) and same-ContentNode re-entry (`propagating`) are
+    // still suppressed before reaching this path, so the #904/#905/#943 cascades are unaffected.
+    /** Depth of Callable observers currently executing on this thread (the reentrancy gate). */
+    private static observerDepth = 0;
+    /** >0 while inside `ContentNode.notifyParentFields`; disables deferral for cascade observers. */
+    private static parentCascadeDepth = 0;
+    /**
+     * True while draining the deferred queue. Deferral happens only ONCE, at the boundary of the
+     * original top-level handler; once we start draining, the reentrant cascade runs synchronously
+     * (nested, with the normal per-field `notifying` stack) — the pre-existing behavior that
+     * terminates same-field and cross-field observer cascades. Without this, flattening the nested
+     * dispatch into a FIFO loses the guard nesting and two alwaysNotify fields whose observers write
+     * each other (a manual field-alias ping-pong) loop forever.
+     */
+    private static draining = false;
+    /** Deferred reentrant observer invocations, drained at the outermost unwind. */
+    private static deferredQueue: { field: Field; callback: BrsCallback; event: RoSGNodeEvent }[] = [];
+
+    /** Marks entry into a ContentNode parentField cascade, so its observers dispatch inline. */
+    static enterParentCascade() {
+        Field.parentCascadeDepth++;
+    }
+
+    /** Marks exit from a ContentNode parentField cascade. */
+    static exitParentCascade() {
+        Field.parentCascadeDepth--;
+    }
+
+    /** Resets deferred-dispatch state between app runs so nothing leaks across setups. */
+    static resetDispatch() {
+        Field.observerDepth = 0;
+        Field.parentCascadeDepth = 0;
+        Field.draining = false;
+        Field.deferredQueue.length = 0;
+    }
 
     constructor(
         private readonly name: string = "",
@@ -454,8 +497,43 @@ export class Field {
             // Prevent stack overflow by not re-entering a running callback
             return;
         }
-        const { interpreter, observer, hostNode, environment, eventParams } = callback;
+        // Snapshot the event (value + info fields) at notification time, matching the RoMessagePort
+        // branch which also builds the event before deferring via pushMessage.
+        const event = this.buildEvent(callback);
 
+        if (callback.observer instanceof RoMessagePort) {
+            callback.observer.pushMessage(event);
+            return;
+        }
+
+        // Roku-accurate deferral: if another Callable observer is already executing (reentrant) and
+        // this notification is not part of a ContentNode parentField cascade, queue it and let the
+        // outermost dispatch drain it after the current handler returns.
+        // Defer only while inside the ORIGINAL top-level handler (not while draining). Once draining,
+        // the cascade runs synchronously/nested so the per-field `notifying` guards terminate it.
+        if (Field.observerDepth > 0 && !Field.draining && Field.parentCascadeDepth === 0) {
+            Field.deferredQueue.push({ field: this, callback, event });
+            return;
+        }
+
+        Field.observerDepth++;
+        try {
+            this.invoke(callback, event);
+            if (Field.observerDepth === 1 && !Field.draining) {
+                this.drainDeferred();
+            }
+        } finally {
+            Field.observerDepth--;
+            if (Field.observerDepth === 0) {
+                // Safety: on an exception unwinding through the drain, don't leave stale work queued.
+                Field.deferredQueue.length = 0;
+            }
+        }
+    }
+
+    /** Builds the event delivered to an observer, snapshotting the field value and info fields. */
+    private buildEvent(callback: BrsCallback): RoSGNodeEvent {
+        const { eventParams } = callback;
         // Get info fields current value, if exists.
         let infoFields: RoAssociativeArray | undefined;
         if (eventParams.infoFields) {
@@ -471,13 +549,52 @@ export class Field {
             infoFields = toAssociativeArray(fieldsMap);
         }
         // Every time a callback happens, a new event is created.
-        const event = new RoSGNodeEvent(eventParams.node, eventParams.fieldName, this.value, infoFields);
+        return new RoSGNodeEvent(eventParams.node, eventParams.fieldName, this.value, infoFields);
+    }
 
-        if (observer instanceof RoMessagePort) {
-            observer.pushMessage(event);
+    /**
+     * Drains deferred reentrant observer invocations FIFO. `observerDepth` stays at 1 for the whole
+     * drain, so a callback that itself triggers a reentrant notification re-enqueues and is picked
+     * up by the loop — iterating until quiescent, in the order the fields changed.
+     */
+    private drainDeferred() {
+        Field.draining = true;
+        try {
+            let guard = 0;
+            while (Field.deferredQueue.length > 0) {
+                if (++guard > 100000) {
+                    BrsDevice.stderr.write("error,[sg] observer drain exceeded limit; possible observer loop");
+                    Field.deferredQueue.length = 0;
+                    break;
+                }
+                const deferred = Field.deferredQueue.shift()!;
+                const field = deferred.field;
+                // Run the deferred callback synchronously (nested): while it executes, hold the
+                // field's `notifying` guard and count it in `observerDepth`, so any notifications it
+                // triggers dispatch inline with the normal per-field guard stack. This mirrors what
+                // the original synchronous dispatch did before the handler-boundary deferral, and is
+                // what terminates same-field self-writes and cross-field alias ping-pongs.
+                const wasNotifying = field.notifying;
+                field.notifying = true;
+                Field.observerDepth++;
+                try {
+                    field.invoke(deferred.callback, deferred.event);
+                } finally {
+                    Field.observerDepth--;
+                    field.notifying = wasNotifying;
+                }
+            }
+        } finally {
+            Field.draining = false;
+        }
+    }
+
+    /** Runs a single Callable observer callback with the caller's host node / m scope restored. */
+    private invoke(callback: BrsCallback, event: RoSGNodeEvent) {
+        const { interpreter, observer, hostNode, environment } = callback;
+        if (!(observer instanceof Callable)) {
             return;
         }
-
         interpreter.inSubEnv((subInterpreter) => {
             callback.running = true;
             subInterpreter.environment.hostNode = hostNode;

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -916,6 +916,37 @@ export class Node extends RoSGNode implements BrsValue {
     }
 
     /**
+     * Refreshes layout by rendering the whole tree from the root, guarding against re-entrant
+     * renders. Mark this refresh as an active render: BrightScript that runs inside it (an item
+     * component's init() or a field observer measuring a Label) must not start another full-tree
+     * refresh, or the passes recurse until the JS stack overflows — the same guard RoSGScreen
+     * applies around frame renders, extended to refreshes initiated by a bounding-rect query.
+     * Nested queries return the rects this pass computes. Callers must first check `!sgRoot.rendering`.
+     */
+    private refreshLayoutFromRoot(interpreter: Interpreter) {
+        const root = this.createPath()[0];
+        sgRoot.rendering = true;
+        try {
+            root.renderNode(interpreter, [0, 0], 0, 1);
+        } finally {
+            sgRoot.rendering = false;
+        }
+    }
+
+    /**
+     * Whether a `subBoundingRect` query must refresh layout before reading the cached sub-part rect.
+     * Overridden by ArrayGrid-derived nodes: after a focus/scroll change the newly focused item's
+     * cached rect is stale (it still sits at its previous, pre-scroll position) until the next frame
+     * re-lays-out the grid — but an app's `rowItemFocused` observer measures it synchronously before
+     * that frame. Refreshing then makes the query report the settled focus-band position, matching a
+     * real device (where the observer fires after the render thread laid out the new focus). Default
+     * false so non-grid nodes keep returning their cached, at-most-one-frame-old sub-part rects.
+     */
+    protected needsSubBoundingRectRefresh(): boolean {
+        return false;
+    }
+
+    /**
      * Forces a render pass and returns the requested bounding rectangle.
      * @param type Rectangle type: `local`, `toScene`, or any other value for parent space.
      * @param interpreter Interpreter used to render the root path.
@@ -929,18 +960,7 @@ export class Node extends RoSGNode implements BrsValue {
         // RowList items measuring labels). Skip the refresh while a render is in progress and return
         // the rects already computed by the active pass.
         if (interpreter && !sgRoot.rendering) {
-            const root = this.createPath()[0];
-            // Mark this refresh as an active render. BrightScript that runs inside it (an item
-            // component's init() or a field observer measuring a Label) must not start another
-            // full-tree refresh, or the passes recurse until the JS stack overflows — the same
-            // guard RoSGScreen applies around frame renders, extended to refreshes initiated by
-            // a bounding-rect query itself. Nested queries return the rects this pass computes.
-            sgRoot.rendering = true;
-            try {
-                root.renderNode(interpreter, [0, 0], 0, 1);
-            } finally {
-                sgRoot.rendering = false;
-            }
+            this.refreshLayoutFromRoot(interpreter);
         } else if (
             interpreter &&
             sgRoot.rendering &&
@@ -989,6 +1009,16 @@ export class Node extends RoSGNode implements BrsValue {
      * @returns Bounding rectangle of the sub part in the requested coordinate space.
      */
     getSubBoundingRect(type: string, itemNumber: string, interpreter?: Interpreter): Rect {
+        // If a focus/scroll change is pending (e.g. a vertical row change just fired its
+        // rowItemFocused observer before the next frame re-laid-out the grid), the cached item rects
+        // are stale — the newly focused item still sits at its previous, pre-scroll position. Refresh
+        // layout the same guarded way getBoundingRect does so subBoundingRect reports the settled
+        // focus-band position, matching a real device where the observer fires post-layout. Only when
+        // safe (not already inside a render) and only when actually needed (the dirty flag), so
+        // steady-state queries still read the cached rect without re-rendering per call.
+        if (interpreter && !sgRoot.rendering && this.needsSubBoundingRectRefresh()) {
+            this.refreshLayoutFromRoot(interpreter);
+        }
         const subpart = this.resolveSubpart(itemNumber);
         if (!subpart) {
             // No such sub part: return the node's own bounding rect, refreshing layout the same way

--- a/src/extensions/scenegraph/nodes/RowList.ts
+++ b/src/extensions/scenegraph/nodes/RowList.ts
@@ -231,6 +231,12 @@ export class RowList extends ArrayGrid {
      * app driving a focused-item overlay from currFocusRow/currFocusColumn never leaves item [0,0].
      */
     protected setRowItemFocused(rowIndex: number, colIndex: number) {
+        // The focus/scroll position is about to change, so the item components' cached rects no
+        // longer match it (the newly focused row/column has not been re-laid-out yet). Mark layout
+        // dirty BEFORE firing the focus fields below: an app's rowItemFocused observer measures the
+        // focused item synchronously via subBoundingRect, and the dirty flag makes that query refresh
+        // layout first so it reports the settled focus-band position (see needsSubBoundingRectRefresh).
+        this.focusLayoutDirty = true;
         // Emit currFocusRow/currFocusColumn BEFORE rowItemFocused. On a real device the focus fields
         // pass through in-transit (fractional) values during the scroll animation and rowItemFocused
         // settles last, so apps treat the rowItemFocused observer as the authoritative "focus settled"

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -442,6 +442,80 @@ describe("cli", () => {
         ]);
     }, 10000);
 
+    it("Reentrant field observers are deferred until the current handler returns", async () => {
+        let command = ["node", brsCliPath, "-r deferred-observer-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        // onSelected assigns two lists' content + focus (firing itemFocused observers) BEFORE it
+        // assigns dayList.content. On Roku those observers run from the message loop after the
+        // handler returns, so they see the assigned dayList.content. With synchronous/inline
+        // dispatch they ran reentrantly while dayList.content was still invalid -> crash. The
+        // deferred dispatch drains them after onSelected unwinds: "onSelected done" prints before
+        // any "onDateFocused", and each reads the valid 31-child dayList content.
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "=== Deferred Observer Repro ===",
+            "onSelected",
+            "Setting dayList content",
+            "onSelected done",
+            "onDateFocused dayCount= 31",
+            "onDateFocused dayCount= 31",
+            "onDateFocused dayCount= 31",
+            "onDateFocused dayCount= 31",
+            "=== Deferred Observer Repro Complete ===",
+            "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+    }, 10000);
+
+    it("A deferred observer that rewrites its own alwaysNotify field does not loop", async () => {
+        let command = ["node", brsCliPath, "-r observer-loop-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        // aliasField is alwaysNotify with an onChange (onAlias) that writes the same field back to
+        // itself. When onAlias runs deferred (reassigned from inside onSelected), the per-field
+        // notifying guard must stay held across the deferred run so the self-write is suppressed;
+        // otherwise it re-enqueues forever (observer drain limit). onAlias must fire exactly once.
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "=== Observer Loop Repro ===",
+            "onSelected",
+            "onSelected done",
+            "onAlias count= 1",
+            "=== Observer Loop Repro Complete ===",
+            "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+    }, 10000);
+
+    it("Two cross-aliased alwaysNotify fields whose observers write each other do not loop", async () => {
+        let command = ["node", brsCliPath, "-r cross-alias-loop-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        // fieldF.onChange writes fieldG and fieldG.onChange writes fieldF (both alwaysNotify),
+        // reassigned from inside an observer so both defer. Deferral must happen only at the
+        // original handler boundary; once draining, the cascade runs synchronously/nested so the
+        // per-field notifying guards terminate it. Each observer fires exactly once (the manual
+        // field-alias ping-pong flood).
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "=== Cross Alias Loop Repro ===",
+            "onStart",
+            "onStart done",
+            "onF count= 1",
+            "onG count= 1",
+            "=== Cross Alias Loop Repro Complete ===",
+            "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+    }, 10000);
+
     it("Poster preload-and-swap: the loadStatus observer's uri clear is not clobbered", async () => {
         let command = ["node", brsCliPath, "-r poster-preload-swap-app", "source/main.brs", "-c 0"].join(" ");
 
@@ -509,6 +583,31 @@ describe("cli", () => {
             "onHeightChange measured height =  72",
             "grid rect height =  300",
             "=== Grid Measure Repro Complete ===",
+            "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+    }, 10000);
+    it("Reports a RowList's newly focused item at the settled focus band, not its pre-scroll position", async () => {
+        let command = ["node", brsCliPath, "-r rowlist-subrect-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+
+        // A RowList lays out its focused row at the fixed focus band (renderNode sets currRow =
+        // focusIndex). After a vertical focus change, an app's rowItemFocused observer measures the
+        // newly focused item synchronously via subBoundingRect BEFORE the next frame re-lays-out the
+        // grid, so the cached item rect is stale (the item still sits at its previous, pre-scroll
+        // stacked position). subBoundingRect must refresh layout when a focus change is pending so it
+        // reports the settled band position — matching a real device where the observer fires
+        // post-layout. Without the refresh, row 1 reads its stacked y (band + one row height).
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "=== RowList SubRect Repro ===",
+            "band row0 y = -15",
+            "focused row1 y = -15",
+            "SAME BAND: true",
+            "=== RowList SubRect Repro Complete ===",
             "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
             "",
             "",

--- a/test/cli/resources/cross-alias-loop-app/components/MainScene.xml
+++ b/test/cli/resources/cross-alias-loop-app/components/MainScene.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Reproduces the manual field-alias flood: two alwaysNotify fields whose onChange
+    handlers write each other (F.onChange -> G, G.onChange -> F), reassigned from inside an
+    observer so both defer. Synchronously the nested `notifying` guards (F held while G runs)
+    terminate this in one round; the flattened deferred FIFO loses that nesting and loops.
+-->
+<component name="MainScene" extends="Scene">
+    <interface>
+        <field id="runTrigger" type="integer" onChange="onStart" />
+        <field id="fieldF" type="vector2d" alwaysNotify="true" onChange="onF" />
+        <field id="fieldG" type="vector2d" alwaysNotify="true" onChange="onG" />
+    </interface>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.fCount = 0
+        m.gCount = 0
+    end sub
+
+    sub onStart()
+        print "onStart"
+        ' Reentrant: onF runs deferred.
+        m.top.fieldF = [1, 1]
+        print "onStart done"
+    end sub
+
+    sub onF()
+        m.fCount = m.fCount + 1
+        if m.fCount <= 3 then print "onF count="; m.fCount
+        m.top.fieldG = [2, 2]
+    end sub
+
+    sub onG()
+        m.gCount = m.gCount + 1
+        if m.gCount <= 3 then print "onG count="; m.gCount
+        m.top.fieldF = [1, 1]
+    end sub
+    ]]></script>
+</component>

--- a/test/cli/resources/cross-alias-loop-app/manifest
+++ b/test/cli/resources/cross-alias-loop-app/manifest
@@ -1,0 +1,4 @@
+title=Cross Alias Loop
+major_version=1
+minor_version=0
+build_version=1

--- a/test/cli/resources/cross-alias-loop-app/source/main.brs
+++ b/test/cli/resources/cross-alias-loop-app/source/main.brs
@@ -1,0 +1,13 @@
+sub Main()
+    print "=== Cross Alias Loop Repro ==="
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+    scene = screen.CreateScene("MainScene")
+    screen.show()
+    scene.runTrigger = 1
+    for i = 0 to 5
+        msg = wait(20, port)
+    end for
+    print "=== Cross Alias Loop Repro Complete ==="
+end sub

--- a/test/cli/resources/deferred-observer-app/components/MainScene.xml
+++ b/test/cli/resources/deferred-observer-app/components/MainScene.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Models a real app crash exposed after ArrayGrid's `content` field began defaulting to
+    `invalid` (PR #982). A field observer (onSelected) assigns content + moves focus on two lists
+    before assigning the third list's content. Moving focus fires each list's `itemFocused`
+    observer (onDateFocused), which reads m.dayList.content. On a real Roku those observers are
+    dispatched from the message loop AFTER onSelected returns, so m.dayList.content is already set.
+
+    With the old synchronous/inline dispatch, onDateFocused ran reentrantly in the middle of
+    onSelected while m.dayList.content was still `invalid` -> dot-on-invalid crash. The deferred
+    dispatch queues the reentrant observers and drains them once onSelected unwinds, matching Roku.
+-->
+<component name="MainScene" extends="Scene">
+    <interface>
+        <field id="runTrigger" type="integer" />
+    </interface>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.yearList = createObject("roSGNode", "LabelList")
+        m.monthList = createObject("roSGNode", "LabelList")
+        m.dayList = createObject("roSGNode", "LabelList")
+        m.top.appendChild(m.yearList)
+        m.top.appendChild(m.monthList)
+        m.top.appendChild(m.dayList)
+        m.yearList.observeField("itemFocused", "onDateFocused")
+        m.monthList.observeField("itemFocused", "onDateFocused")
+        m.top.observeField("runTrigger", "onSelected")
+    end sub
+
+    sub onSelected(event as object)
+        print "onSelected"
+        m.yearList.content = buildContent(6)
+        m.yearList.jumpToItem = 3
+        m.monthList.content = buildContent(12)
+        m.monthList.jumpToItem = 5
+        ' dayList content is assigned LAST, after the focus moves above have fired their observers.
+        print "Setting dayList content"
+        m.dayList.content = buildContent(31)
+        print "onSelected done"
+    end sub
+
+    ' Fires when a list's itemFocused changes. Reads m.dayList.content, which is only valid once
+    ' onSelected has assigned it - so this must run deferred (after onSelected), not reentrantly.
+    sub onDateFocused(event as object)
+        childCount = m.dayList.content.getChildCount()
+        print "onDateFocused dayCount="; childCount
+    end sub
+
+    function buildContent(count as integer) as object
+        content = createObject("roSGNode", "ContentNode")
+        for i = 1 to count
+            item = createObject("roSGNode", "ContentNode")
+            item.title = i.toStr()
+            content.appendChild(item)
+        end for
+        return content
+    end function
+    ]]></script>
+</component>

--- a/test/cli/resources/deferred-observer-app/manifest
+++ b/test/cli/resources/deferred-observer-app/manifest
@@ -1,0 +1,4 @@
+title=Deferred Observer Repro
+major_version=1
+minor_version=0
+build_version=1

--- a/test/cli/resources/deferred-observer-app/source/main.brs
+++ b/test/cli/resources/deferred-observer-app/source/main.brs
@@ -1,0 +1,16 @@
+sub Main()
+    print "=== Deferred Observer Repro ==="
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+    scene = screen.CreateScene("MainScene")
+    screen.show()
+    ' Set a plain trigger field at the top level (not from inside another observer). Its observer
+    ' runs the list-loading sequence; the itemFocused observers it fires reentrantly must be
+    ' deferred until it returns, by which point dayList.content is assigned (Roku behavior).
+    scene.runTrigger = 1
+    for i = 0 to 5
+        msg = wait(20, port)
+    end for
+    print "=== Deferred Observer Repro Complete ==="
+end sub

--- a/test/cli/resources/observer-loop-app/components/MainScene.xml
+++ b/test/cli/resources/observer-loop-app/components/MainScene.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Models the "manual field alias" pattern that regressed when reentrant observers began
+    deferring: an alwaysNotify field (aliasField) whose onChange handler (onAlias) writes the SAME
+    field back to itself. Synchronously the per-field `notifying` guard suppresses that re-entrant
+    self-write; the deferred dispatch must keep that guard held across the deferred run, otherwise
+    the self-write re-enqueues onAlias forever (observer-drain-limit flood).
+-->
+<component name="MainScene" extends="Scene">
+    <interface>
+        <field id="runTrigger" type="integer" onChange="onSelected" />
+        <field id="aliasField" type="vector2d" alwaysNotify="true" onChange="onAlias" />
+    </interface>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.aliasCount = 0
+    end sub
+
+    sub onSelected()
+        print "onSelected"
+        ' Reentrant assignment: aliasField's onChange runs deferred.
+        m.top.aliasField = [1, 2]
+        print "onSelected done"
+    end sub
+
+    sub onAlias()
+        m.aliasCount = m.aliasCount + 1
+        print "onAlias count="; m.aliasCount
+        ' Self-write back to the same alwaysNotify field must NOT re-trigger onAlias.
+        m.top.aliasField = m.top.aliasField
+    end sub
+    ]]></script>
+</component>

--- a/test/cli/resources/observer-loop-app/manifest
+++ b/test/cli/resources/observer-loop-app/manifest
@@ -1,0 +1,4 @@
+title=Observer Loop Repro
+major_version=1
+minor_version=0
+build_version=1

--- a/test/cli/resources/observer-loop-app/source/main.brs
+++ b/test/cli/resources/observer-loop-app/source/main.brs
@@ -1,0 +1,15 @@
+sub Main()
+    print "=== Observer Loop Repro ==="
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+    scene = screen.CreateScene("MainScene")
+    screen.show()
+    ' Trigger from the top level; onSelected then reassigns aliasField from inside its own handler,
+    ' so aliasField's onChange (onAlias) runs deferred. onAlias writes aliasField back to itself.
+    scene.runTrigger = 1
+    for i = 0 to 5
+        msg = wait(20, port)
+    end for
+    print "=== Observer Loop Repro Complete ==="
+end sub

--- a/test/cli/resources/rowlist-subrect-app/components/RowItem.xml
+++ b/test/cli/resources/rowlist-subrect-app/components/RowItem.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Minimal RowList item component: a colored rectangle sized to the item's width/height so the
+    component has a non-degenerate bounding rect for subBoundingRect to report.
+-->
+<component name="RowItem" extends="Group">
+    <interface>
+        <field id="width" type="float" />
+        <field id="height" type="float" />
+        <field id="itemContent" type="node" />
+    </interface>
+    <script type="text/brightscript">
+    <![CDATA[
+        sub init()
+            m.rect = m.top.createChild("Rectangle")
+            m.rect.color = "0xFF0000FF"
+            m.top.observeFieldScoped("width", "onSize")
+            m.top.observeFieldScoped("height", "onSize")
+        end sub
+
+        sub onSize()
+            m.rect.width = m.top.width
+            m.rect.height = m.top.height
+        end sub
+    ]]>
+    </script>
+</component>

--- a/test/cli/resources/rowlist-subrect-app/manifest
+++ b/test/cli/resources/rowlist-subrect-app/manifest
@@ -1,0 +1,4 @@
+title=RowList SubRect Test
+major_version=1
+minor_version=0
+build_version=0

--- a/test/cli/resources/rowlist-subrect-app/source/main.brs
+++ b/test/cli/resources/rowlist-subrect-app/source/main.brs
@@ -1,0 +1,36 @@
+sub Main()
+    print "=== RowList SubRect Repro ==="
+
+    grid = CreateObject("roSGNode", "RowList")
+    grid.itemComponentName = "RowItem"
+    grid.itemSize = [300, 200]
+    grid.rowItemSize = [[300, 200]]
+    grid.itemSpacing = [0, 0]
+    grid.numRows = 2
+
+    content = CreateObject("roSGNode", "ContentNode")
+    for r = 0 to 1
+        row = content.createChild("ContentNode")
+        item = row.createChild("ContentNode")
+        item.title = "R" + r.toStr()
+    end for
+    grid.content = content
+
+    ' Force an initial render so both rows' item components are created and cached.
+    discard = grid.boundingRect()
+
+    band = grid.subBoundingRect("item0_0")
+    print "band row0 y = "; band.y
+
+    ' Move focus down to row 1. A real device keeps the focused row at the fixed focus
+    ' band, so an app that measures the newly focused item from its rowItemFocused
+    ' observer reads the settled band position, not the pre-scroll stacked position.
+    grid.jumpToRowItem = [1, 0]
+
+    rect1 = grid.subBoundingRect("item1_0")
+    print "focused row1 y = "; rect1.y
+
+    same = Abs(rect1.y - band.y) < 50
+    print "SAME BAND: "; same
+    print "=== RowList SubRect Repro Complete ==="
+end sub


### PR DESCRIPTION
## Summary

Two related fixes that make reentrant SceneGraph field-observer dispatch match a real device's message-loop model.

### 1. Deferred reentrant observer dispatch
On a real device a function-name field observer is dispatched from the owning thread's message loop; it does **not** run reentrantly in the middle of another observer's execution. The engine previously dispatched `observeField(field, "fn")` callbacks synchronously and inline at the point of `Field.setValue`, so a reentrant cross-field observer could run mid-handler — reading state a later statement in the current handler had not yet assigned (a dot-on-`invalid` crash), or, for two `alwaysNotify` fields whose observers write each other (a manual field-alias ping-pong), flooding until the observer-drain limit tripped.

Now a reentrant `Callable` observer is deferred at the boundary of the original top-level handler and the queue is drained once that handler unwinds. Deferral happens only **once**: while draining, the cascade runs synchronously/nested so the per-field `notifying` guard still terminates same-field self-writes and cross-field alias ping-pongs. The `ContentNode` parentField cascade is explicitly excluded, so the existing overflow-guarded recursion paths stay synchronous and unchanged.

### 2. `subBoundingRect` layout refresh on a pending focus change
A `RowList`/`ArrayGrid` lays out its focused row at the fixed focus band (`renderNode` sets `currRow = focusIndex`). The focus fields (`rowItemFocused`/`itemFocused`) are emitted during key handling, **before** the next frame re-lays-out the grid, so an app's `rowItemFocused` observer that measures the newly focused item via `subBoundingRect` read the item's **stale, pre-scroll cached rect** (its previous stacked position) instead of the settled band. On a real device the observer fires post-layout and reads the band position.

This surfaced as a regression exposed by fix (1), which reordered the reentrant observer that previously forced a re-render before the measurement. `ArrayGrid` now tracks `focusLayoutDirty` (set on focus change, cleared once `renderNode` re-lays-out), and `Node.getSubBoundingRect` performs the **same guarded full-tree refresh** `getBoundingRect` uses (gated on `!sgRoot.rendering`) when `needsSubBoundingRectRefresh()` is true. The dirty gate keeps steady-state queries reading the cached rect (no per-call re-render) and preserves the re-entrant render guard.

## Testing
New CLI regressions in `test/cli/cli.test.js`:
- `deferred-observer-app` — a reentrant observer reads a sibling list's not-yet-assigned field; must not crash (deferred until the handler returns).
- `observer-loop-app` — an `alwaysNotify` field whose observer rewrites itself; fires once.
- `cross-alias-loop-app` — two `alwaysNotify` fields whose observers write each other; each fires once.
- `rowlist-subrect-app` — after a vertical focus change, the newly focused item reports the settled focus-band position, not its pre-scroll stacked rect.

Full suite green (2043 passed; the only failures locally are the ECP `r2d2-bitmaps` tests, which need port 8060 free). Existing overflow/measurement regressions (`contentnode-recursion`, `sharedcontent-recursion`, `contentnode-parentfield`, `button-label`, `grid-measure`, `button-measure`, `poster-preload-swap`, `anon-observer`) and the full SceneGraph unit suite (375) stay green. `npm run lint` and `npm run prettier:write` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)