### PR TITLE
fix(api): enforce a minimum video buffering floor before playback starts

### DIFF
--- a/src/api/video.ts
+++ b/src/api/video.ts
@@ -41,6 +41,9 @@ let videoMuted = false;
 let uiMuted = false;
 let previousBuffered = 0;
 let previousTime = Date.now();
+const DEFAULT_MIN_VIDEO_BUFFER_MS = 700; // fallback floor if DeviceInfo omits minVideoBufferMs
+let bufferFloorStart = 0; // Date.now() when the current load began
+let playFloorTimer: ReturnType<typeof setTimeout> | undefined; // pending deferred play
 const audioTracks: MediaTrack[] = [];
 const textTracks: MediaTrack[] = [];
 
@@ -351,6 +354,7 @@ export function resetVideo() {
     videosState = false;
     bufferOnly = false;
     canPlay = false;
+    clearPlayFloor(); // stopVideo() is a no-op when already stopped, so clear unconditionally here
 }
 
 /**
@@ -439,6 +443,9 @@ function loadAudioTracks() {
         playList[playIndex].audioTrack = activeTrack;
         if (activeTrack > -1 && playerState !== "play") {
             player.currentTime = 1; // Force HLS to load audio track
+            // Intentionally not gated by the buffering floor: HLS is network-fed and already has a
+            // natural buffering gap, and this play() primes the audio track load rather than the
+            // preview start that the floor targets.
             player.play();
         }
     }
@@ -546,6 +553,10 @@ function loadVideo(buffer = false) {
     const video = playList[playIndex];
     if (video && player) {
         notifyAll("load");
+        // Start the buffering floor now and cancel any deferred play from the previous content,
+        // so a rapid navigation can never fire a stale play onto the wrong item.
+        bufferFloorStart = Date.now();
+        clearPlayFloor();
         let videoSrc = getVideoUrl(video);
         clearVideoTracking();
         bufferOnly = buffer;
@@ -619,28 +630,71 @@ function getVideoUrl(video: any): string {
 }
 
 /**
+ * Cancels any pending deferred play scheduled by the buffering floor.
+ */
+function clearPlayFloor() {
+    if (playFloorTimer !== undefined) {
+        clearTimeout(playFloorTimer);
+        playFloorTimer = undefined;
+    }
+}
+
+/**
  * Plays the loaded video.
  * Loads video first if not ready, handles autoplay restrictions.
  */
 function playVideo() {
     if (canPlay) {
-        previousBuffered = 0;
-        previousTime = Date.now();
-        const promise = player.play();
-        if (promise !== undefined) {
-            promise
-                .then(function () {
-                    player.muted = uiMuted || videoMuted;
-                })
-                .catch(function (error) {
-                    notifyAll(
-                        "warning",
-                        `[video] Browser prevented the auto-play, press pause and play to start the video.`
-                    );
-                });
-        }
+        scheduleBufferedPlay();
     } else {
         loadVideo();
+    }
+}
+
+/**
+ * Enforces a minimum buffering floor before actual playback starts, mirroring a real Roku
+ * device where network buffering guarantees a visible gap before the video appears. The floor
+ * is measured from load-start (see loadVideo), so it is self-limiting: real network video
+ * already spends longer than the floor loading and incurs no added latency, while instant
+ * (cached/local) sources are held back just enough to let a preceding poster overlay render
+ * first, restoring the "poster first, then video" ordering.
+ */
+function scheduleBufferedPlay() {
+    clearPlayFloor();
+    const floor = deviceData?.minVideoBufferMs ?? DEFAULT_MIN_VIDEO_BUFFER_MS;
+    const remaining = floor - (Date.now() - bufferFloorStart);
+    if (remaining <= 0) {
+        beginPlayback();
+    } else {
+        playFloorTimer = setTimeout(() => {
+            playFloorTimer = undefined;
+            // A stop or a new load cancels this timer via clearPlayFloor(); canPlay guards
+            // against the source having been torn down while the floor was pending.
+            if (canPlay) {
+                beginPlayback();
+            }
+        }, remaining);
+    }
+}
+
+/**
+ * Starts the actual media playback and handles autoplay restrictions.
+ */
+function beginPlayback() {
+    previousBuffered = 0;
+    previousTime = Date.now();
+    const promise = player.play();
+    if (promise !== undefined) {
+        promise
+            .then(function () {
+                player.muted = uiMuted || videoMuted;
+            })
+            .catch(function (error) {
+                notifyAll(
+                    "warning",
+                    `[video] Browser prevented the auto-play, press pause and play to start the video.`
+                );
+            });
     }
 }
 
@@ -711,6 +765,7 @@ function stopVideo(error?: boolean) {
         clearVideoTracking();
         startPosition = 0;
         canPlay = false;
+        clearPlayFloor(); // drop any pending deferred play so it can't fire after stop
     }
 }
 
@@ -723,6 +778,7 @@ function pauseVideo() {
         player.pause();
         notifyAll("pause");
         Atomics.store(sharedArray, DataType.VDO, MediaEvent.Paused);
+        clearPlayFloor(); // pausing during the buffering floor drops the deferred start
     }
 }
 

--- a/src/core/common.ts
+++ b/src/core/common.ts
@@ -44,6 +44,7 @@ export interface DeviceInfo {
     audioLanguage: SupportedLanguage;
     autoPlayEnabled: boolean;
     maxFps: number;
+    minVideoBufferMs?: number;
     tmpVolSize: number;
     cacheFSVolSize: number;
     logLevel: LogLevel;
@@ -151,6 +152,8 @@ export const DefaultDeviceInfo: DeviceInfo = {
     audioLanguage: "en",
     autoPlayEnabled: true, // Autoplay device setting - enabled by default, as on a real Roku device
     maxFps: 60,
+    minVideoBufferMs: 700, // Simulated minimum buffering floor (ms) before playback starts; only affects instant/cached sources
+
     tmpVolSize: 32 * 1024 * 1024, // 32 MB
     cacheFSVolSize: 32 * 1024 * 1024, // 32 MB
     logLevel: LogLevel.Warning,


### PR DESCRIPTION
## Problem

On a real device, network buffering guarantees a visible gap before a video appears. An app that shows a poster overlay when a grid item is focused and hides it once the video reaches `state="playing"` therefore always renders the poster first, then the video.

In the simulator, a cached/local/fast source starts nearly instantly: the video plane goes live and the `"playing"` state is reported back to BrightScript before the synchronously-shown poster has been given any render frames. The app's `"playing"`-keyed poster-hide then runs at the natural (later) time — but by then the poster is drawing **on top of** the already-playing video, so audio is audible while the still image covers it. It is worse when navigating rapidly between items while a preview plays.

## Root cause

- Poster image load and `loadStatus="ready"` are fully **synchronous** (`Poster.setValue` → `loadUri`).
- Video `state` is reported only via `SGRoot.processVideo()`, polled once per render tick.
- The main-thread player (`src/api/video.ts`) starts playback with **no minimum buffering floor**: the `canplay` listener auto-calls `playVideo()` instantly for fast sources, and the `playing` listener then reports `MediaEvent.StartStream` immediately. There is no Roku-like buffering gap.

## Fix

Defer the actual `player.play()` until a minimum buffering interval has elapsed, **measured from load-start** so it is self-limiting:

- Real network video already spends longer than the floor loading → `remaining <= 0` → **zero added latency**.
- Only instant (cached/local) sources are held back, just enough to let a preceding poster overlay render first — restoring the "poster first, then video" ordering.

Details:
- `playVideo()` routes the ready case through `scheduleBufferedPlay()`; the real start moved into `beginPlayback()`.
- Floor is configurable via **`DeviceInfo.minVideoBufferMs`** (default **700 ms**).
- `loadVideo()` stamps `bufferFloorStart` and cancels any pending deferred play, so rapid navigation can never start a stale playback on the wrong content.
- `stopVideo`/`pauseVideo`/`resetVideo` also cancel the pending timer.
- Buffering progress (`VLP`/`prebufferDone`) keeps flowing during the floor. `pause`→`resume` and the HLS audio-track prime are intentionally not gated (commented inline).

## Testing

- `npm run lint` and `npm run prettier` clean.
- `test/extensions/scenegraph/Video.test.js` (14 tests) green — it drives `Video.setState` directly on the node, so it is unaffected by the main-thread player change.
- Verified end-to-end in a SceneGraph app running in brs-desktop: startup video plays, home screen loads, and grid previews now show the poster first with the video following ~700 ms later; no added latency on full-screen network playback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)