### PR TITLE
fix(rsg): honor vertAlign in ScrollingLabel by centering against the node height

### DIFF
--- a/src/extensions/scenegraph/nodes/ScrollingLabel.ts
+++ b/src/extensions/scenegraph/nodes/ScrollingLabel.ts
@@ -141,6 +141,7 @@ export class ScrollingLabel extends Label {
         const textHeight = drawFont.measureTextHeight();
         const horizAlign = (this.getValueJS("horizAlign") as string) || "left";
         const constrainedWidth = maxWidth > 0 ? maxWidth : rect.width;
+        const boxHeight = rect.height;
         rect.width = constrainedWidth;
         rect.height = textHeight;
         const color = this.getValueJS("color") as number;
@@ -209,13 +210,15 @@ export class ScrollingLabel extends Label {
             // Static case: Text fits or scrolling is disabled/not needed
             textToDraw = text;
         }
-        const clipRect: Rect = { ...rect };
+        const clipRect: Rect = { ...rect, height: Math.max(boxHeight, textHeight) };
         let drawX = rect.x + drawOffset;
         let drawY = rect.y;
-        if (vertAlign === "center") {
-            drawY += (rect.height - textHeight) / 2;
-        } else if (vertAlign === "bottom") {
-            drawY += rect.height - textHeight;
+        if (boxHeight > textHeight) {
+            if (vertAlign === "center") {
+                drawY += (boxHeight - textHeight) / 2;
+            } else if (vertAlign === "bottom") {
+                drawY += boxHeight - textHeight;
+            }
         }
         if (drawOffset === 0 && constrainedWidth > 0) {
             const measuredWidth = drawFont.measureTextWidth(textToDraw).width;

--- a/test/extensions/scenegraph/ScrollingLabel.test.js
+++ b/test/extensions/scenegraph/ScrollingLabel.test.js
@@ -1,0 +1,91 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsDevice, BrsString, Float } = core;
+
+/** Minimal interpreter accepted by renderNode → renderChildren (never dereferenced when draw2D is absent). */
+const fakeInterpreter = {};
+
+/** Renders the label with a stub draw surface, capturing the y of the drawn text. */
+function captureTextY(label) {
+    let capturedY;
+    const draw2D = {
+        pushClip() {},
+        popClip() {},
+        doDrawRotatedText(text, x, y) {
+            if (text.trim() !== "") capturedY = y;
+        },
+    };
+    label.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+    return capturedY;
+}
+
+describe("ScrollingLabel node vertAlign", () => {
+    beforeAll(() => {
+        // ScrollingLabel resolves its font from the common: volume; mount it once.
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    /** Short, non-scrolling label so the text is drawn statically. */
+    function scrollingLabel({ vertAlign = "top", height } = {}) {
+        const label = SGNodeFactory.createNode("ScrollingLabel");
+        label.setValue("font", new BrsString("font:MediumSystemFont"));
+        label.setValue("width", new Float(200));
+        label.setValue("vertAlign", new BrsString(vertAlign));
+        if (height !== undefined) label.setValue("height", new Float(height));
+        label.setValue("text", new BrsString("Search"));
+        return label;
+    }
+
+    function textHeightOf(label) {
+        return label.getValue("font").createDrawFont().measureTextHeight();
+    }
+
+    /**
+     * Regression: a ScrollingLabel with an explicit height taller than the text and
+     * vertAlign="center" must center the text within its box. The bug overwrote rect.height
+     * with the measured text height before applying the offset, so it always drew at the top
+     * (y = 0) — the symptom being the Jellyfin home Search/Settings button labels sitting at
+     * the top of the button instead of centered next to the icon.
+     */
+    test("explicit height centers the text (vertAlign=center)", () => {
+        const label = scrollingLabel({ vertAlign: "center", height: 50 });
+        const expected = (50 - textHeightOf(label)) / 2;
+        expect(expected).toBeGreaterThan(1); // sanity: the box is meaningfully taller than the text
+
+        expect(captureTextY(label)).toBeCloseTo(expected, 5);
+    });
+
+    /** vertAlign="bottom" pushes the text to the bottom of the taller box. */
+    test("explicit height honors vertAlign=bottom", () => {
+        const label = scrollingLabel({ vertAlign: "bottom", height: 50 });
+        const expected = 50 - textHeightOf(label);
+
+        expect(captureTextY(label)).toBeCloseTo(expected, 5);
+    });
+
+    /** vertAlign="top" (and the default) draws at the box top. */
+    test("explicit height with vertAlign=top draws at the top", () => {
+        expect(captureTextY(scrollingLabel({ vertAlign: "top", height: 50 }))).toBeCloseTo(0, 5);
+    });
+
+    /**
+     * When height is unset (0), the box is not taller than the text, so vertAlign is a no-op
+     * and the text must NOT be shifted up above its own origin (guarded by boxHeight > textHeight).
+     */
+    test("height=0 does not shift the text up", () => {
+        const centerYs = captureTextY(scrollingLabel({ vertAlign: "center" }));
+        const bottomYs = captureTextY(scrollingLabel({ vertAlign: "bottom" }));
+
+        expect(centerYs).toBeCloseTo(0, 5);
+        expect(bottomYs).toBeCloseTo(0, 5);
+    });
+});


### PR DESCRIPTION
## Problem

A `ScrollingLabel` with an explicit `height` taller than its text and `vertAlign="center"` (or `"bottom"`) rendered its text pinned to the top of the box instead of vertically centered.

## Root cause

`ScrollingLabel.renderLabel` overrides the plain `Label`/`Group.drawText` path with its own text drawing, and overwrote `rect.height` with the measured text height **before** computing the vertical-align offset. As a result `(rect.height - textHeight) / 2` always evaluated to `0`, so the text drew at `rect.y` (top) regardless of `vertAlign` or the node's real height. Plain `Label` was unaffected because it delegates to `Group.drawText`, which centers against the node's height.

## Fix

- Capture the node's box height before `rect.height` is overwritten.
- Compute the center/bottom offset against that box height, guarded by `boxHeight > textHeight` (mirroring `Group.drawText`) so an unset height (`0`) is a no-op and never shifts text above its own origin.
- Grow the clip box to `max(boxHeight, textHeight)` so the shifted-down text is not cropped.

## Tests

- New regression suite `test/extensions/scenegraph/ScrollingLabel.test.js` covering center, bottom, top, and the height=0 no-shift case.
- Full `test/extensions/scenegraph/` suite passes (379 tests); lint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)