### PR TITLE
fix(rsg): honor numeric-string writes to ArrayGrid numColumns/numRows

### DIFF
--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -173,10 +173,6 @@ export class ArrayGrid extends Group {
             return;
         } else if (["jumptoitem", "animatetoitem"].includes(fieldName) && isNumberComp(value)) {
             this.setFocusedItem(jsValueOf(value));
-        } else if (fieldName === "numrows" && isNumberComp(value)) {
-            this.numRows = jsValueOf(value) as number;
-        } else if (fieldName === "numcolumns" && isNumberComp(value)) {
-            this.numCols = jsValueOf(value) as number;
         } else if (fieldName === "vertfocusanimationstyle" && isBrsString(value)) {
             const style = value.toString().toLowerCase();
             if (ValidVertStyles.has(style)) {
@@ -195,6 +191,15 @@ export class ArrayGrid extends Group {
             return;
         }
         super.setValue(index, value, alwaysNotify, kind);
+        // Refresh cached row/column counts from the (possibly coerced) field value, so a
+        // numeric string such as "7" from a settings lookup is honored — not just a raw
+        // number. super.setValue coerces the string into the integer field the same way a
+        // Roku device does, making the field the single source of truth.
+        if (fieldName === "numrows") {
+            this.numRows = this.getValueJS("numrows") as number;
+        } else if (fieldName === "numcolumns") {
+            this.numCols = this.getValueJS("numcolumns") as number;
+        }
         const rowFields = ["vertfocusanimationstyle", "numrows", "focusrow"];
         // Update the current row if some fields changed
         if (rowFields.includes(fieldName)) {

--- a/test/extensions/scenegraph/ArrayGridFields.test.js
+++ b/test/extensions/scenegraph/ArrayGridFields.test.js
@@ -4,7 +4,7 @@ const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
 const core = require("../../../packages/node/bin/brs.node.js");
 
 const { RowList, ZoomRowList, MarkupGrid } = scenegraph;
-const { BrsDevice } = core;
+const { BrsDevice, BrsString } = core;
 
 describe("ArrayGrid scrollingStatus field", () => {
     beforeAll(() => {
@@ -22,5 +22,31 @@ describe("ArrayGrid scrollingStatus field", () => {
             expect(node.hasNodeField("scrollingstatus")).toBe(true);
             expect(node.getValueJS("scrollingStatus")).toBe(false);
         }
+    });
+});
+
+describe("ArrayGrid numColumns/numRows string coercion", () => {
+    beforeAll(() => {
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    // Settings looked up from the registry come back as strings (e.g. "7"), and apps assign
+    // them straight to the integer numColumns/numRows fields. The field coerces the string,
+    // but the internal layout cache (this.numCols/this.numRows) must track that too, or the
+    // grid keeps rendering the XML-default column count.
+    test("caches a numeric string assigned to numColumns/numRows on MarkupGrid", () => {
+        const node = new MarkupGrid();
+
+        node.setValue("numColumns", new BrsString("7"));
+        node.setValue("numRows", new BrsString("3"));
+
+        // The field itself coerced the string to an integer (matches Roku).
+        expect(node.getValueJS("numColumns")).toBe(7);
+        expect(node.getValueJS("numRows")).toBe(3);
+
+        // The layout cache the render loop actually reads must match the field.
+        expect(node.numCols).toBe(7);
+        expect(node.numRows).toBe(3);
     });
 });


### PR DESCRIPTION
## Root cause

`ArrayGrid` caches `numColumns`/`numRows` in instance members (`this.numCols` / `this.numRows`) that the layout/render loop reads each frame. `ArrayGrid.setValue` only refreshed those caches when the incoming value satisfied `isNumberComp()`, which is **false** for a `BrsString`.

A numeric **string** such as `"7"` — a common shape when the value comes from a registry/settings lookup — therefore slipped past the cache update:

- `super.setValue` → `Node.setValue` coerced the string into the integer field correctly, so reading the field back returned `7`.
- But `this.numCols`/`this.numRows` stayed at the XML-declared default, so the grid kept rendering the default column/row count instead of the requested one.

(A secondary symptom of the same split-brain: key handling read the field fresh while rendering used the stale cache, so navigation and layout could disagree.)

## Fix

- Remove the pre-`super` cache updates gated on `isNumberComp(value)`.
- Refresh `this.numCols` / `this.numRows` from the **coerced field value** (`getValueJS`) after `super.setValue`, before the existing `updateCurrRow()` recompute.

This makes the field the single source of truth and handles string, float, and boxed inputs uniformly — matching how a Roku device coerces a numeric string assigned to an integer field.

## Tests

- New regression test in `ArrayGridFields.test.js`: assigning `BrsString("7")`/`BrsString("3")` to a `MarkupGrid` now updates both the field **and** the layout cache (`node.numCols`/`node.numRows`).
- Full SceneGraph suite (380 tests) and the grid CLI test pass; lint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)