### PR TITLE
fix(rsg): honor descending key arrays in FieldInterpolator segment resolution

### DIFF
--- a/src/extensions/scenegraph/nodes/Interpolator.ts
+++ b/src/extensions/scenegraph/nodes/Interpolator.ts
@@ -35,6 +35,12 @@ export abstract class Interpolator extends Node {
     /**
      * Given a normalized fraction, returns the surrounding keyframe indices and a local interpolation
      * parameter. This matches the behavior of Roku's Segment data structure.
+     *
+     * Each keyframe pairs `key[i]` (its position on the 0-1 progress axis) with `keyValue[i]` (the value
+     * at that position) BY ARRAY INDEX, so the animation fraction is compared DIRECTLY against the key
+     * positions — it is never remapped into the key domain. The `key` array is normally ascending, but
+     * apps also express a reversed sequence with a descending array (e.g. `key="[1.0,0.0]"` with
+     * `keyValue="[0,1]"` for a fade-out); handling each segment by its own direction supports both.
      */
     protected resolveSegment(fraction: number): { index: number; localT: number } {
         const keys = this.getKeyframes();
@@ -45,49 +51,29 @@ export abstract class Interpolator extends Node {
         }
 
         const lastIndex = keys.length - 1;
-        const startKey = keys[0];
-        const endKey = keys[lastIndex];
-        const domainSpan = endKey - startKey;
-        const monotonicAscending = endKey >= startKey;
-        let keyFraction = normalized;
 
-        if (domainSpan !== 0 && Number.isFinite(domainSpan)) {
-            keyFraction = startKey + domainSpan * normalized;
-        }
-
-        if (monotonicAscending) {
-            if (keyFraction <= startKey) {
-                return { index: 0, localT: 0 };
-            }
-            if (keyFraction >= endKey) {
-                return { index: lastIndex - 1, localT: 1 };
-            }
-        } else {
-            if (keyFraction >= startKey) {
-                return { index: 0, localT: 0 };
-            }
-            if (keyFraction <= endKey) {
-                return { index: lastIndex - 1, localT: 1 };
-            }
-        }
-
+        // Find the segment [key[i], key[i+1]] whose position range contains `normalized`, honoring
+        // whichever direction that segment runs.
         for (let i = 0; i < lastIndex; i++) {
             const start = keys[i];
             const end = keys[i + 1];
-            const segmentAscending = end >= start;
-            const inRange = segmentAscending
-                ? keyFraction >= start && keyFraction <= end
-                : keyFraction <= start && keyFraction >= end;
-
-            if (!inRange) {
-                continue;
+            const lo = Math.min(start, end);
+            const hi = Math.max(start, end);
+            if (normalized >= lo && normalized <= hi) {
+                const span = end - start;
+                const localT = span === 0 ? 0 : (normalized - start) / span;
+                return { index: i, localT };
             }
-
-            const span = end - start;
-            const localT = span === 0 ? 0 : (keyFraction - start) / span;
-            return { index: i, localT };
         }
 
+        // `normalized` falls outside every segment (a keyframe sequence that does not span the full
+        // 0-1 axis): clamp to the value of the nearest keyframe by position, matching Roku's behavior
+        // of holding the first/last keyValue beyond the first/last key percentage.
+        const firstPos = keys[0];
+        const lastPos = keys[lastIndex];
+        if (Math.abs(normalized - firstPos) <= Math.abs(normalized - lastPos)) {
+            return { index: 0, localT: 0 };
+        }
         return { index: lastIndex - 1, localT: 1 };
     }
 

--- a/test/extensions/scenegraph/Animation.test.js
+++ b/test/extensions/scenegraph/Animation.test.js
@@ -44,6 +44,32 @@ describe("Animation target resolution", () => {
         expect(container.getValueJS("opacity")).toBe(1);
     });
 
+    test("fade-out defined with a descending key array reaches 0 (not back to 1)", () => {
+        // An overlay poster reveals a video underneath by fading its opacity 1 -> 0. Apps express this
+        // reversed keyframe sequence with a DESCENDING key array (key="[1.0,0.0]", keyValue="[0,1]"):
+        // at fraction 0 the field is keyValue-for-key-1.0 = 1 (opaque), at fraction 1 it is
+        // keyValue-for-key-0.0 = 0 (transparent). The fraction must be compared directly against the key
+        // positions, not remapped into the key domain -- otherwise the fade lands on 1 and the overlay
+        // stays covering the video.
+        const poster = SGNodeFactory.createNode("Poster");
+        poster.setValue("id", new BrsString("overlayPoster"));
+        poster.setValue("opacity", new Float(1)); // starts fully opaque, covering the video
+
+        const animation = SGNodeFactory.createNode("Animation");
+        animation.setValue("duration", new Float(0.9));
+        const interp = SGNodeFactory.createNode("FloatFieldInterpolator");
+        interp.setValue("fieldToInterp", new BrsString("overlayPoster.opacity"));
+        interp.setValue("key", floatArray([1.0, 0.0])); // descending key: reversed sequence
+        interp.setValue("keyValue", floatArray([0.0, 1.0]));
+        animation.appendChildToParent(interp);
+        poster.appendChildToParent(animation);
+
+        animation.setValue("control", new BrsString("finish"));
+
+        // The fade-out must end transparent, revealing the video beneath.
+        expect(poster.getValueJS("opacity")).toBeCloseTo(0, 5);
+    });
+
     test("interpolator resolves to its own enclosing node when no descendant matches", () => {
         // Mirrors LoadingIndicator's fade: an Animation nested inside <Group id="loadingIndicatorGroup">
         // targets "loadingIndicatorGroup.opacity" — its own parent. The target must still resolve.


### PR DESCRIPTION
## Problem

A `FloatFieldInterpolator` (and its Color/Vector2D siblings) pairs `key[i]` — its position on the 0–1 progress axis — with `keyValue[i]` **by array index**, per the [FloatFieldInterpolator spec](https://developer.roku.com/docs/references/scenegraph/animation-nodes/floatfieldinterpolator.md). The animation fraction should therefore be compared **directly** against the key positions.

`Interpolator.resolveSegment` instead remapped the fraction *into* the key domain:

```ts
keyFraction = startKey + domainSpan * normalized;
```

This happens to produce the right answer for the usual ascending `key="[0.0,1.0]"`, but **inverts** the result for a descending key array.

Apps express a reversed keyframe sequence with a descending `key`, e.g. a fade-out:

```xml
<FloatFieldInterpolator key="[1.0,0.0]" keyValue="[0,1]" fieldToInterp="overlay.opacity" />
```

Here fraction 0 should yield opacity 1 and fraction 1 should yield opacity 0. With the remap, the animation ended on value **1** instead of **0** — an opacity fade-out meant to reveal content underneath instead drove the overlay back to fully opaque, leaving it covering the content (audio of the revealed video was audible, but the picture stayed hidden).

## Fix

Resolve the containing segment by comparing the fraction directly against the key positions, handle each segment by its own direction, and clamp an out-of-range fraction to the nearest keyframe (matching Roku holding the first/last `keyValue` beyond the first/last key percentage). Since all three interpolators (`Float`/`Color`/`Vector2D`) share `resolveSegment`, this fixes them uniformly.

## Testing

- New regression: **"fade-out defined with a descending key array reaches 0"** in `test/extensions/scenegraph/Animation.test.js`.
- Full scenegraph suite (380 tests) passes; existing ascending-key and target-resolution tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)