### PR TITLE
fix(rsg): fire initial itemFocused when list/grid content is populated after assignment

### DIFF
--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -362,6 +362,15 @@ export class ArrayGrid extends Group {
         if (content instanceof ContentNode && content.changed) {
             this.refreshContent();
             content.changed = false;
+            // The content node was populated after being assigned (an app assigns an empty
+            // ContentNode, then a content-loading Task appends the items). Give the first item
+            // initial focus so itemFocused fires — mirroring the content-assignment path. Apps
+            // observe itemFocused to show the focused item's metadata, which otherwise appears only
+            // after the user first navigates. Gated on the -1 "never focused" sentinel so it fires
+            // once and never overrides a focus the app or user already established.
+            if (this.content.length > 0 && (this.getValueJS("itemFocused") as number) < 0) {
+                this.setFocusedItem(0);
+            }
         }
         const clipped = this.pushClippingRect(drawTrans, draw2D);
         this.renderContent(interpreter, rect, rotation, opacity, draw2D);

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -470,6 +470,29 @@ describe("cli", () => {
         ]);
     }, 10000);
 
+    it("Fires initial itemFocused when a list's content is populated after assignment", async () => {
+        let command = ["node", brsCliPath, "-r list-initial-focus-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        // The list is assigned an EMPTY content node, then that same node is populated afterwards
+        // (as a content-loading Task does). On a real Roku the first item gains focus on load and
+        // itemFocused fires, so an app's observer shows the focused item's metadata. The list is
+        // deliberately never given focus, proving the initial notification fires on content
+        // population regardless of remote focus. Before the fix itemFocused stayed at its -1
+        // sentinel and "onItemFocused" never printed until the user navigated.
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "=== List Initial Focus Repro ===",
+            "itemFocused before populate = -1",
+            "onItemFocused index =  0",
+            "=== List Initial Focus Repro Complete ===",
+            "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+    }, 10000);
+
     it("A deferred observer that rewrites its own alwaysNotify field does not loop", async () => {
         let command = ["node", brsCliPath, "-r observer-loop-app", "source/main.brs", "-c 0"].join(" ");
 

--- a/test/cli/resources/list-initial-focus-app/components/GridItem.xml
+++ b/test/cli/resources/list-initial-focus-app/components/GridItem.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Minimal RowList item component so the list renders without an item-creation error. -->
+<component name="GridItem" extends="Group">
+    <children>
+        <Poster id="poster" width="120" height="180" />
+    </children>
+</component>

--- a/test/cli/resources/list-initial-focus-app/components/MainScene.xml
+++ b/test/cli/resources/list-initial-focus-app/components/MainScene.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Models a real library screen: a list is assigned an EMPTY content node, then a
+    content-loading Task fills that same node afterwards (appendChildren). On a real Roku the
+    first item gains focus on load and `itemFocused` fires, so the app's observer shows the
+    focused item's metadata. In the simulator the initial notification used to never fire —
+    metadata only appeared once the user navigated to another item.
+
+    Here the list is deliberately NOT given focus, to prove the initial `itemFocused` fires on
+    content population regardless of remote focus (mirroring the content-assignment path).
+-->
+<component name="MainScene" extends="Scene">
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.list = createObject("roSGNode", "RowList")
+        m.list.itemComponentName = "GridItem"
+        m.list.itemSize = [1700, 210]
+        m.list.rowItemSize = [[120, 180]]
+        m.list.numRows = 2
+        m.top.appendChild(m.list)
+
+        m.list.observeField("itemFocused", "onItemFocused")
+
+        ' Assign an EMPTY content node first (as apps do before an async content-loading Task
+        ' returns), then populate that same node afterwards.
+        m.data = createObject("roSGNode", "ContentNode")
+        m.list.content = m.data
+        print "itemFocused before populate = "; m.list.itemFocused
+
+        row = m.data.createChild("ContentNode")
+        for i = 1 to 3
+            item = row.createChild("ContentNode")
+            item.title = "Item " + i.toStr()
+        end for
+    end sub
+
+    ' The metadata trigger: fires when the first item gains focus on content load.
+    sub onItemFocused()
+        print "onItemFocused index = "; m.list.itemFocused
+    end sub
+    ]]></script>
+</component>

--- a/test/cli/resources/list-initial-focus-app/manifest
+++ b/test/cli/resources/list-initial-focus-app/manifest
@@ -1,0 +1,4 @@
+title=List Initial Focus Repro
+major_version=1
+minor_version=0
+build_version=1

--- a/test/cli/resources/list-initial-focus-app/source/main.brs
+++ b/test/cli/resources/list-initial-focus-app/source/main.brs
@@ -1,0 +1,14 @@
+sub Main()
+    print "=== List Initial Focus Repro ==="
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+    scene = screen.CreateScene("MainScene")
+    screen.show()
+    ' Pump a few frames so the list renders: the content node was populated after being
+    ' assigned, so the first item gains focus during render and itemFocused fires.
+    for i = 0 to 5
+        msg = wait(20, port)
+    end for
+    print "=== List Initial Focus Repro Complete ==="
+end sub


### PR DESCRIPTION
## Problem

`itemFocused` (fired by `ArrayGrid.setFocusedItem`) reached only two paths: `setValue("content")` when content was assigned **with items already present**, and the node **gaining focus**. The common content-loading pattern hits neither — an app assigns an empty `ContentNode`, then that same node is populated afterwards (e.g. by a content-loading `Task` calling `appendChildren`). In that case `itemFocused` stayed at its `-1` "never focused" sentinel, so an app's `itemFocused` observer (which typically drives the focused item's metadata display) never fired until the user navigated to another item.

On a real device the first item gains focus on content load and the observer runs immediately.

## Fix

Extend `ArrayGrid.renderNode`'s existing `content.changed` re-parse branch to give the first item initial focus when content just became non-empty and nothing has been focused yet — mirroring the content-assignment path:

```ts
if (this.content.length > 0 && (this.getValueJS("itemFocused") as number) < 0) {
    this.setFocusedItem(0);
}
```

- Gated on the `-1` sentinel, so it fires once and never overrides a focus the app or user already established, and never double-fires with the existing paths.
- Runs after the `!isVisible()` early-return (hidden lists don't fire) and before `renderContent` (focus index is correct for the same frame).
- Fix lives in the shared `ArrayGrid` base, so `MarkupGrid`, `PosterGrid`, `RowList`, `MarkupList`, `LabelList` and `ZoomRowList` all benefit.

## Testing

- **New regression** `list-initial-focus-app` in `test/cli/cli.test.js`: a `RowList` assigned an empty content node then populated (and deliberately never given focus) now fires `itemFocused = 0` on load — the observer prints on load instead of only after navigation.
- Full SceneGraph + CLI suites pass (421 tests).
- `npm run lint` and `npm run prettier:write` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)