### PR TITLE
fix(rsg): clip ArrayGrid/PosterGrid items to their cell so overflow is hidden

### DIFF
--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -431,9 +431,35 @@ export class ArrayGrid extends Group {
             this.renderFocus(itemRect, opacity, nodeFocus, draw2D);
         }
         const itemOrigin = [itemRect.x, itemRect.y];
-        this.itemComps[index].renderNode(interpreter, itemOrigin, rotation, opacity, draw2D);
+        this.renderItemClipped(interpreter, this.itemComps[index], itemOrigin, itemRect, rotation, opacity, draw2D);
         if (focused && drawFocus && drawFocusOnTop) {
             this.renderFocus(itemRect, opacity, nodeFocus, draw2D);
+        }
+    }
+
+    /**
+     * Renders an item component clipped to its cell (`itemRect`, i.e. the grid's `itemSize`), matching
+     * Roku: content an item draws beyond its own width/height is not shown. Apps rely on this to collapse
+     * item content by shrinking `itemSize` — e.g. a vertical button bar whose label is parked just past the
+     * item's right edge so only the icon shows until the bar expands. Clipping only happens on a real draw
+     * pass; a measurement pass (no `draw2D`) must stay unclipped so hidden-UI bounding rects still compute.
+     * The focus feedback is drawn by the caller outside this clip so its indicator can outset the item.
+     */
+    protected renderItemClipped(
+        interpreter: Interpreter,
+        itemComp: Group,
+        itemOrigin: number[],
+        itemRect: Rect,
+        rotation: number,
+        opacity: number,
+        draw2D?: IfDraw2D
+    ) {
+        if (draw2D) {
+            draw2D.pushClip({ x: itemRect.x, y: itemRect.y, width: itemRect.width, height: itemRect.height });
+        }
+        itemComp.renderNode(interpreter, itemOrigin, rotation, opacity, draw2D);
+        if (draw2D) {
+            draw2D.popClip();
         }
     }
 

--- a/src/extensions/scenegraph/nodes/PosterGrid.ts
+++ b/src/extensions/scenegraph/nodes/PosterGrid.ts
@@ -402,7 +402,7 @@ export class PosterGrid extends ArrayGrid {
             this.focusLayoutOverride = undefined;
         }
         const itemOrigin = [itemRect.x, itemRect.y];
-        itemComp.renderNode(interpreter, itemOrigin, rotation, opacity, draw2D);
+        this.renderItemClipped(interpreter, itemComp, itemOrigin, itemRect, rotation, opacity, draw2D);
         if (focused && drawFocus && drawFocusOnTop) {
             this.focusLayoutOverride = layout;
             this.renderFocus(itemRect, opacity, nodeFocus, draw2D);

--- a/test/extensions/scenegraph/GridItemClipping.test.js
+++ b/test/extensions/scenegraph/GridItemClipping.test.js
@@ -1,0 +1,86 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsDevice, Float, RoArray } = core;
+
+/** Minimal interpreter accepted by renderNode → renderChildren. */
+const fakeInterpreter = {};
+
+function vector(values) {
+    return new RoArray(values.map((v) => new Float(v)));
+}
+
+/**
+ * Regression: on Roku, each ArrayGrid/MarkupGrid item is clipped to its cell (`itemSize`). Content
+ * an item draws beyond its own width/height is not shown. Apps use this to collapse item content by
+ * shrinking `itemSize` — e.g. the SGDEX-style vertical button bar whose title label is parked just
+ * past the item's right edge (translation x == itemSize width) so only the icon shows until the bar
+ * expands. The simulator used to render item components unclipped, so those labels always drew.
+ */
+describe("grid items are clipped to their cell", () => {
+    beforeAll(() => {
+        // Grids resolve fonts/focus bitmaps from the common: volume; mount it once.
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    function record() {
+        const events = [];
+        const draw2D = {
+            pushClip: (rect) => events.push(["push", { ...rect }]),
+            popClip: () => events.push(["pop"]),
+            doDrawRotatedRect: (rect) => events.push(["draw", { ...rect }]),
+        };
+        return { events, draw2D };
+    }
+
+    test("wraps the item render in a clip equal to the item cell", () => {
+        const grid = SGNodeFactory.createNode("MarkupGrid");
+        const item = SGNodeFactory.createNode("Group");
+        // A label-like child parked at the cell's right edge (x = itemSize width) — visible only once
+        // the cell grows wider than 108.
+        const label = SGNodeFactory.createNode("Rectangle");
+        label.setValue("width", new Float(80));
+        label.setValue("height", new Float(20));
+        label.setValue("translation", vector([108, 0]));
+        item.appendChildToParent(label);
+
+        const { events, draw2D } = record();
+        const itemRect = { x: 0, y: 0, width: 108, height: 52 };
+        grid.renderItemClipped(fakeInterpreter, item, [0, 0], itemRect, 0, 1, draw2D);
+
+        // A clip equal to the item cell is pushed first and popped last...
+        expect(events[0]).toEqual(["push", { x: 0, y: 0, width: 108, height: 52 }]);
+        expect(events[events.length - 1]).toEqual(["pop"]);
+        // ...and the child draw happens while that clip is active (between the push and the pop).
+        const drawIdx = events.findIndex((e) => e[0] === "draw");
+        expect(drawIdx).toBeGreaterThan(0);
+        expect(drawIdx).toBeLessThan(events.length - 1);
+    });
+
+    test("a measurement pass (no draw2D) is not clipped so bounding rects still compute", () => {
+        const grid = SGNodeFactory.createNode("MarkupGrid");
+        const item = SGNodeFactory.createNode("Group");
+        const label = SGNodeFactory.createNode("Rectangle");
+        label.setValue("width", new Float(80));
+        label.setValue("height", new Float(20));
+        label.setValue("translation", vector([108, 0]));
+        item.appendChildToParent(label);
+
+        const itemRect = { x: 0, y: 0, width: 108, height: 52 };
+        // No draw2D → the label is laid out (measured) beyond the cell without being clipped.
+        grid.renderItemClipped(fakeInterpreter, item, [0, 0], itemRect, 0, 1, undefined);
+
+        const rect = item.getBoundingRect("toScene");
+        // The label is laid out at its true position beyond the 108-wide cell, not clipped away.
+        expect(rect.x).toBe(108);
+        expect(rect.width).toBe(80);
+    });
+});


### PR DESCRIPTION
## Problem

A collapsible side menu (icons-only when collapsed, icons + labels when expanded) rendered its labels **at all times**, even while collapsed.

The menu's buttons are a `MarkupGrid` of item components that position their title `Label` at the item's right edge (`translation.x == itemSize width`) and their icon well inside the cell. Collapse/expand is driven purely by the grid's `itemSize`:

- **Collapsed:** narrow `itemSize` → the label sits at/just past the cell's right edge (icon fits inside).
- **Expanded:** wider `itemSize` → the label now fits within the cell.

On a real device, `ArrayGrid`/`MarkupGrid`/`PosterGrid` clip each item to its cell (`itemSize`), so the overflowing label is not drawn while collapsed. The simulator rendered item components **unclipped**, so the label always drew.

## Fix

Wrap each item component's render in a `pushClip`/`popClip` of its cell rect (`itemRect` = `itemSize`/column-width × row-height) via a shared `renderItemClipped` helper, used by both `ArrayGrid.renderItemComponent` (MarkupGrid/MarkupList) and `PosterGrid.renderItemComponent`.

Invariants preserved:
- **Focus feedback stays outside the clip** — the caller draws it before/after, so 9-patch indicators can still outset the item.
- **Measurement passes (no `draw2D`) stay unclipped** — hidden-UI bounding rects keep computing (consistent with `Group.pushClippingRect`).
- RowList is unaffected — it renders rows via its own path, which already clips row items.

## Tests

- New `test/extensions/scenegraph/GridItemClipping.test.js`: confirms the item render is wrapped in a cell-sized clip, and that a measurement pass remains unclipped.
- SceneGraph suite: **383 passed**; e2e: **112 passed**; lint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)