### PR TITLE
fix(rsg): fire itemFocused only when the list/grid is in the focus chain

### DIFF
--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -167,9 +167,7 @@ export class ArrayGrid extends Group {
             super.setValue(index, value, alwaysNotify, kind);
             this.itemComps.length = 0;
             this.refreshContent();
-            if (this.content.length > 0) {
-                this.setFocusedItem(0);
-            }
+            this.resetFocusForNewContent(true);
             return;
         } else if (["jumptoitem", "animatetoitem"].includes(fieldName) && isNumberComp(value)) {
             this.setFocusedItem(jsValueOf(value));
@@ -227,6 +225,52 @@ export class ArrayGrid extends Group {
         return focus;
     }
 
+    /**
+     * Reconciles the focus cursor after the content view changes (a fresh `content` assignment, or
+     * an in-place populate/mutation detected during render).
+     *
+     * On a real device `itemFocused` only changes when focus moves onto an item — loading content
+     * into a list that is not in the focus chain does NOT fire it (verified on hardware). So:
+     * - If the grid currently has focus and content is non-empty, focus item 0 now (emitting
+     *   `itemFocused`) so a focused list reflects the newly loaded content, matching Roku.
+     * - If the grid is not focused, stay silent: reset the internal cursor and, for a fresh content
+     *   assignment, clear `itemFocused` back to the "never focused" sentinel so a later focus-gain
+     *   (`setNodeFocus`) fires `itemFocused = 0`. A non-fresh in-place change on an unfocused grid
+     *   leaves any established value untouched.
+     *
+     * @param freshContent True when a brand-new `content` node was assigned (vs. an in-place
+     *   populate/mutation of the existing tree). A fresh assignment resets the cursor to item 0.
+     */
+    protected resetFocusForNewContent(freshContent: boolean) {
+        const focused = sgRoot.focused === this || this.isChildrenFocused();
+        if (focused) {
+            if (this.content.length > 0 && (freshContent || (this.getValueJS("itemFocused") as number) < 0)) {
+                this.setFocusedItem(0);
+            }
+            return;
+        }
+        if (freshContent) {
+            // Unfocused, brand-new content: reset the cursor and the sentinel silently (no observer
+            // fire). setNodeFocus will emit itemFocused = 0 when focus later lands on the grid.
+            this.focusIndex = 0;
+            this.focusLayoutDirty = true;
+            this.setValueSilent("itemFocused", new Int32(-1));
+        }
+    }
+
+    /**
+     * Moves the focus cursor to `index`, emitting the focus-move fields (`itemUnfocused`,
+     * `itemFocused`) ONLY when the grid is actually in the focus chain.
+     *
+     * On a real device `itemFocused` changes only when an item gains the key focus — writing
+     * `jumpToItem`/`animateToItem`, assigning `content`, or populating content on a grid that is
+     * NOT in the focus chain does not fire it (verified on hardware). So when the grid is unfocused
+     * this records the target index SILENTLY (no observer notification): the internal cursor and the
+     * `itemFocused` value are updated so the position is remembered, and `setNodeFocus` re-emits
+     * `itemFocused` when focus later lands on the grid. This prevents list-driven side effects (e.g.
+     * an app starting a preview video off an `itemFocused` observer) from triggering while focus is
+     * still elsewhere.
+     */
     protected setFocusedItem(index: number) {
         const newFocus = this.findContentIndex(index);
         if (newFocus === -1) {
@@ -234,12 +278,19 @@ export class ArrayGrid extends Group {
         }
         const focusedIndex = this.getValueJS("itemFocused") as number;
         const nodeFocus = sgRoot.focused === this;
+        const inFocusChain = nodeFocus || this.isChildrenFocused();
         this.updateItemFocus(this.focusIndex, false, nodeFocus);
-        super.setValue("itemUnfocused", new Int32(focusedIndex));
         this.focusIndex = newFocus;
         this.focusLayoutDirty = true;
         this.updateItemFocus(this.focusIndex, true, nodeFocus);
-        super.setValue("itemFocused", new Int32(index));
+        if (inFocusChain) {
+            super.setValue("itemUnfocused", new Int32(focusedIndex));
+            super.setValue("itemFocused", new Int32(index));
+        } else {
+            // Unfocused: remember the target without notifying observers. setNodeFocus emits it on
+            // focus-gain (it reads itemFocused, defaulting to 0 when still at the -1 sentinel).
+            this.setValueSilent("itemFocused", new Int32(index));
+        }
         if (this.itemFocusCallback) {
             this.itemFocusCallback(index);
         }
@@ -363,14 +414,14 @@ export class ArrayGrid extends Group {
             this.refreshContent();
             content.changed = false;
             // The content node was populated after being assigned (an app assigns an empty
-            // ContentNode, then a content-loading Task appends the items). Give the first item
-            // initial focus so itemFocused fires — mirroring the content-assignment path. Apps
-            // observe itemFocused to show the focused item's metadata, which otherwise appears only
-            // after the user first navigates. Gated on the -1 "never focused" sentinel so it fires
-            // once and never overrides a focus the app or user already established.
-            if (this.content.length > 0 && (this.getValueJS("itemFocused") as number) < 0) {
-                this.setFocusedItem(0);
-            }
+            // ContentNode, then a content-loading Task appends the items). If the grid already has
+            // focus but nothing has been focused yet, give the first item focus now so itemFocused
+            // fires; if the grid is not focused, do NOT emit itemFocused — on a real device the
+            // field only changes when focus moves onto an item, so loading content into an
+            // unfocused list stays silent until focus reaches it (see resetFocusForNewContent).
+            // Not a fresh-content reset: this fires on in-place mutations too, so an active focus
+            // on a focused grid must be preserved (never snapped back to item 0 mid-navigation).
+            this.resetFocusForNewContent(false);
         }
         const clipped = this.pushClippingRect(drawTrans, draw2D);
         this.renderContent(interpreter, rect, rotation, opacity, draw2D);

--- a/src/extensions/scenegraph/nodes/RowList.ts
+++ b/src/extensions/scenegraph/nodes/RowList.ts
@@ -156,8 +156,13 @@ export class RowList extends ArrayGrid {
         }
         const oldRow = this.focusIndex;
         const isChangingRow = oldRow !== rowIndex;
+        // itemFocused/rowItemFocused only change when a row gains the key focus on a real device
+        // (verified on hardware). When the list is not in the focus chain — e.g. an app writes
+        // jumpToRowItem or assigns content while focus is elsewhere — update the cursor/scroll state
+        // but do NOT notify observers; setNodeFocus re-emits on focus-gain. See ArrayGrid.setFocusedItem.
+        const inFocusChain = sgRoot.focused === this || this.isChildrenFocused();
 
-        if (isChangingRow) {
+        if (isChangingRow && inFocusChain) {
             super.setValue("itemUnfocused", new Int32(oldRow));
         }
 
@@ -219,8 +224,18 @@ export class RowList extends ArrayGrid {
             }
         }
 
-        super.setValue("itemFocused", new Int32(rowIndex));
-        this.setRowItemFocused(rowIndex, colIndex);
+        if (inFocusChain) {
+            super.setValue("itemFocused", new Int32(rowIndex));
+            this.setRowItemFocused(rowIndex, colIndex);
+        } else {
+            // Unfocused: remember the row/column silently (no observer notification). The values are
+            // re-emitted by setNodeFocus when focus lands on the list.
+            this.focusLayoutDirty = true;
+            this.setValueSilent("itemFocused", new Int32(rowIndex));
+            this.setValueSilent("currFocusRow", new Float(rowIndex));
+            this.setValueSilent("currFocusColumn", new Float(colIndex));
+            this.setValueSilent("rowItemFocused", new RoArray([new Int32(rowIndex), new Int32(colIndex)]));
+        }
     }
 
     /**

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -448,12 +448,13 @@ describe("cli", () => {
         let { stdout } = await exec(command, {
             cwd: path.join(__dirname, "resources"),
         });
-        // onSelected assigns two lists' content + focus (firing itemFocused observers) BEFORE it
-        // assigns dayList.content. On Roku those observers run from the message loop after the
-        // handler returns, so they see the assigned dayList.content. With synchronous/inline
-        // dispatch they ran reentrantly while dayList.content was still invalid -> crash. The
-        // deferred dispatch drains them after onSelected unwinds: "onSelected done" prints before
-        // any "onDateFocused", and each reads the valid 31-child dayList content.
+        // onSelected focuses two lists and moves focus via jumpToItem (firing their itemFocused
+        // observers) BEFORE it assigns dayList.content. On Roku those observers run from the message
+        // loop after the handler returns, so they see the assigned dayList.content. With
+        // synchronous/inline dispatch they ran reentrantly while dayList.content was still invalid
+        // -> crash. The deferred dispatch drains them after onSelected unwinds: "onSelected done"
+        // prints before any "onDateFocused", and each reads the valid 31-child dayList content.
+        // Each focused list fires itemFocused twice (on focus-gain, then on the jumpToItem move).
         expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
             "=== Deferred Observer Repro ===",
             "onSelected",
@@ -470,21 +471,24 @@ describe("cli", () => {
         ]);
     }, 10000);
 
-    it("Fires initial itemFocused when a list's content is populated after assignment", async () => {
+    it("Fires itemFocused only when a list gains focus, not on content population while unfocused", async () => {
         let command = ["node", brsCliPath, "-r list-initial-focus-app", "source/main.brs", "-c 0"].join(" ");
 
         let { stdout } = await exec(command, {
             cwd: path.join(__dirname, "resources"),
         });
         // The list is assigned an EMPTY content node, then that same node is populated afterwards
-        // (as a content-loading Task does). On a real Roku the first item gains focus on load and
-        // itemFocused fires, so an app's observer shows the focused item's metadata. The list is
-        // deliberately never given focus, proving the initial notification fires on content
-        // population regardless of remote focus. Before the fix itemFocused stayed at its -1
-        // sentinel and "onItemFocused" never printed until the user navigated.
+        // (as a content-loading Task does) - all while the list is NOT in the focus chain. Verified
+        // on a real Roku: itemFocused only changes when focus moves onto an item, so populating an
+        // unfocused list fires no observer and the field stays at its -1 "never focused" sentinel.
+        // Only when the list is given focus does the first item gain focus and itemFocused fire
+        // (index 0). This guards against re-emitting itemFocused on unfocused content load, which
+        // makes list-driven side effects (e.g. a focused-item preview) trigger prematurely.
         expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
             "=== List Initial Focus Repro ===",
             "itemFocused before populate = -1",
+            "itemFocused after populate (unfocused) = -1",
+            "focusing the list",
             "onItemFocused index =  0",
             "=== List Initial Focus Repro Complete ===",
             "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",

--- a/test/cli/resources/deferred-observer-app/components/MainScene.xml
+++ b/test/cli/resources/deferred-observer-app/components/MainScene.xml
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!--
     Models a real app crash exposed after ArrayGrid's `content` field began defaulting to
-    `invalid` (PR #982). A field observer (onSelected) assigns content + moves focus on two lists
-    before assigning the third list's content. Moving focus fires each list's `itemFocused`
-    observer (onDateFocused), which reads m.dayList.content. On a real Roku those observers are
-    dispatched from the message loop AFTER onSelected returns, so m.dayList.content is already set.
+    `invalid` (PR #982). A field observer (onSelected) assigns content + moves focus (jumpToItem)
+    on two FOCUSED lists before assigning the third list's content. jumpToItem on a focused list
+    fires its `itemFocused` observer (onDateFocused), which reads m.dayList.content. On a real Roku
+    those observers are dispatched from the message loop AFTER onSelected returns, so
+    m.dayList.content is already set.
 
     With the old synchronous/inline dispatch, onDateFocused ran reentrantly in the middle of
     onSelected while m.dayList.content was still `invalid` -> dot-on-invalid crash. The deferred
     dispatch queues the reentrant observers and drains them once onSelected unwinds, matching Roku.
+
+    Note: the lists are given focus before their jumpToItem write because itemFocused only fires
+    when the list is in the focus chain (verified on hardware); a jumpToItem on an unfocused list
+    updates the position silently.
 -->
 <component name="MainScene" extends="Scene">
     <interface>
@@ -30,8 +35,10 @@
     sub onSelected(event as object)
         print "onSelected"
         m.yearList.content = buildContent(6)
+        m.yearList.setFocus(true)
         m.yearList.jumpToItem = 3
         m.monthList.content = buildContent(12)
+        m.monthList.setFocus(true)
         m.monthList.jumpToItem = 5
         ' dayList content is assigned LAST, after the focus moves above have fired their observers.
         print "Setting dayList content"

--- a/test/cli/resources/list-initial-focus-app/components/MainScene.xml
+++ b/test/cli/resources/list-initial-focus-app/components/MainScene.xml
@@ -1,13 +1,17 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!--
-    Models a real library screen: a list is assigned an EMPTY content node, then a
-    content-loading Task fills that same node afterwards (appendChildren). On a real Roku the
-    first item gains focus on load and `itemFocused` fires, so the app's observer shows the
-    focused item's metadata. In the simulator the initial notification used to never fire —
-    metadata only appeared once the user navigated to another item.
+    Models a real library screen: a list is assigned an EMPTY content node, then that same node
+    is populated afterwards (as an async content-loading Task does with appendChildren).
 
-    Here the list is deliberately NOT given focus, to prove the initial `itemFocused` fires on
-    content population regardless of remote focus (mirroring the content-assignment path).
+    Verified on a real Roku device: `itemFocused` only changes when focus moves onto an item.
+    Loading content into a list that is NOT in the focus chain does NOT fire `itemFocused` — the
+    field stays at its "never focused" state until focus actually reaches the list. Only when the
+    list gains focus does the first item become focused and `itemFocused` fire (index 0).
+
+    This app proves both halves:
+      1. Populating the list while it is unfocused fires no `itemFocused` observer (the field
+         stays at the -1 "never focused" sentinel).
+      2. Giving the list focus then fires `itemFocused = 0` (the observer runs once).
 -->
 <component name="MainScene" extends="Scene">
     <script type="text/brightscript"><![CDATA[
@@ -22,7 +26,7 @@
         m.list.observeField("itemFocused", "onItemFocused")
 
         ' Assign an EMPTY content node first (as apps do before an async content-loading Task
-        ' returns), then populate that same node afterwards.
+        ' returns), then populate that same node afterwards - all while the list is unfocused.
         m.data = createObject("roSGNode", "ContentNode")
         m.list.content = m.data
         print "itemFocused before populate = "; m.list.itemFocused
@@ -32,9 +36,16 @@
             item = row.createChild("ContentNode")
             item.title = "Item " + i.toStr()
         end for
+        ' Still unfocused: no itemFocused observer should have fired, field stays at the sentinel.
+        print "itemFocused after populate (unfocused) = "; m.list.itemFocused
+
+        ' Now move focus onto the list: this is when the first item gains focus on a real device,
+        ' so itemFocused fires with index 0 (dispatched after init returns).
+        print "focusing the list"
+        m.list.setFocus(true)
     end sub
 
-    ' The metadata trigger: fires when the first item gains focus on content load.
+    ' The metadata trigger: fires only when the list actually gains focus, not on content load.
     sub onItemFocused()
         print "onItemFocused index = "; m.list.itemFocused
     end sub

--- a/test/cli/resources/list-initial-focus-app/source/main.brs
+++ b/test/cli/resources/list-initial-focus-app/source/main.brs
@@ -5,8 +5,8 @@ sub Main()
     screen.setMessagePort(port)
     scene = screen.CreateScene("MainScene")
     screen.show()
-    ' Pump a few frames so the list renders: the content node was populated after being
-    ' assigned, so the first item gains focus during render and itemFocused fires.
+    ' Pump a few frames so the list renders and the focus-driven itemFocused observer (queued
+    ' when the list gained focus in init) is dispatched from the message loop.
     for i = 0 to 5
         msg = wait(20, port)
     end for

--- a/test/extensions/scenegraph/RowList.test.js
+++ b/test/extensions/scenegraph/RowList.test.js
@@ -42,6 +42,10 @@ describe("RowList key handling", () => {
         const list = SGNodeFactory.createNode("RowList");
         list.setValue("vertFocusAnimationStyle", new BrsString("fixedFocusWrap"));
         list.setValue("content", buildContent([["A", "B"]]));
+        // Focus the list before driving keys: on a real device a list handles up/down only while
+        // focused, and itemFocused fires (index 0) on that focus-gain. Loading content into an
+        // unfocused list does not move focus, so itemFocused would otherwise stay at its sentinel.
+        list.setNodeFocus(true);
 
         expect(list.handleKey("down", true)).toBe(false);
         expect(list.handleKey("up", true)).toBe(false);
@@ -88,6 +92,10 @@ describe("RowList key handling", () => {
         const fakeInterpreter = { environment: {}, inSubEnv: () => {} };
         const list = SGNodeFactory.createNode("RowList");
         list.setValue("content", buildContent([["A", "B"], ["C", "D"], ["E"]]));
+        // Focus the list: itemFocused/rowItemFocused/currFocusRow notify observers only while the
+        // list is in the focus chain (a real device only navigates a focused list). Without focus
+        // the focus fields update silently and no observer notification is emitted.
+        list.setNodeFocus(true);
 
         // Capture the order of focus-field notifications across one vertical move.
         const port = new RoMessagePort();

--- a/test/simulator/itemfocused-focus-test/components/GridItem.brs
+++ b/test/simulator/itemfocused-focus-test/components/GridItem.brs
@@ -1,0 +1,6 @@
+sub onContentSet()
+    content = m.top.itemContent
+    if content <> invalid
+        m.top.findNode("label").text = content.title
+    end if
+end sub

--- a/test/simulator/itemfocused-focus-test/components/GridItem.xml
+++ b/test/simulator/itemfocused-focus-test/components/GridItem.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Minimal item component for the category content grid in the itemFocused focus test. -->
+<component name="GridItem" extends="Group">
+    <interface>
+        <field id="itemContent" type="node" onChange="onContentSet" />
+        <field id="width" type="float" />
+        <field id="height" type="float" />
+    </interface>
+    <children>
+        <Rectangle id="bg" width="180" height="100" color="0x303848FF" />
+        <Label id="label" width="180" height="100" horizAlign="center" vertAlign="center" color="0xFFFFFFFF" />
+    </children>
+    <script type="text/brightscript" uri="pkg:/components/GridItem.brs" />
+</component>

--- a/test/simulator/itemfocused-focus-test/components/ItemFocusedScene.brs
+++ b/test/simulator/itemfocused-focus-test/components/ItemFocusedScene.brs
@@ -1,0 +1,117 @@
+' Categories-screen probe (see ItemFocusedScene.xml header for the full experiment).
+'
+' Left category list drives the right grid's content. Focus starts on the list; the grid
+' logs every itemFocused firing together with its isInFocusChain() state, so we can see on
+' a real device whether itemFocused fires while the grid is unfocused (content load) or only
+' once focus moves onto it.
+
+sub init()
+    m.log = m.top.findNode("log")
+    m.lines = []
+
+    m.categories = m.top.findNode("categories")
+    m.grid = m.top.findNode("grid")
+
+    ' Build the left category list.
+    catData = createObject("roSGNode", "ContentNode")
+    for i = 1 to 6
+        entry = catData.createChild("ContentNode")
+        entry.title = "Category " + i.toStr()
+    end for
+    m.categories.content = catData
+
+    ' Observe BEFORE the first content load so we capture the very first firing.
+    ' - categories.itemFocused: changes as the user moves UP/DOWN in the (focused) list;
+    '   we use it to load the matching item set's content into the grid.
+    ' - grid.itemFocused: the field under investigation.
+    m.categories.observeField("itemFocused", "onCategoryFocused")
+    m.grid.observeField("itemFocused", "onGridItemFocused")
+
+    ' Focus the category list; loading grid content below happens while the grid is unfocused.
+    m.categories.setFocus(true)
+    logLine("init: focus on category list. Loading category 1 content into the grid...")
+
+    ' Load the first category's content immediately (the list starts focused on index 0).
+    loadCategory(0)
+    logLine("--- Load done. UP/DOWN changes category; RIGHT enters grid; LEFT at grid's left edge returns. ---")
+end sub
+
+' Fires when the focused category changes (user navigates the left list). A master/detail
+' screen loads the focused item's content into the right grid on each focus change.
+sub onCategoryFocused()
+    idx = m.categories.itemFocused
+    logLine(">>> category itemFocused=" + idx.toStr() + " -> loading its content into the grid")
+    loadCategory(idx)
+end sub
+
+' The field under investigation: does this fire while focus is still on the category list?
+sub onGridItemFocused()
+    logLine("*** grid itemFocused=" + m.grid.itemFocused.toStr() + " inFocusChain=" + boolStr(m.grid.isInFocusChain()))
+end sub
+
+' Assigns a fresh, already-populated content node to the grid for the given item-set index,
+' then writes jumpToItem=0 the way a master/detail app commonly does: a "jump to remembered
+' index" field defaults to 0, so a `>= 0` guard writes jumpToItem = 0 on every content load.
+' This is the suspected real trigger: does writing jumpToItem fire itemFocused while the grid
+' is NOT focused?
+sub loadCategory(catIndex as integer)
+    content = createObject("roSGNode", "ContentNode")
+    for i = 1 to 8
+        item = content.createChild("ContentNode")
+        item.title = "C" + (catIndex + 1).toStr() + "-" + i.toStr()
+    end for
+    m.grid.content = content
+
+    ' Unconditionally jump to item 0 right after loading content, while the grid is still
+    ' unfocused. Watch whether a "*** grid itemFocused=0 inFocusChain=false" line appears as a
+    ' result of this write.
+    logLine("    (writing grid.jumpToItem = 0 on every content load)")
+    m.grid.jumpToItem = 0
+end sub
+
+function onKeyEvent(key as string, press as boolean) as boolean
+    if not press then return false
+
+    ' RIGHT from the category list enters the grid. The vertical LabelList does not consume
+    ' left/right, so the press bubbles up here while the list is focused.
+    if key = "right" and m.categories.isInFocusChain()
+        m.grid.setFocus(true)
+        logLine(">>> focus moved to GRID (press LEFT at the grid's left edge to return)")
+        return true
+    end if
+
+    ' LEFT at the grid's left edge returns focus to the category list. The grid consumes LEFT
+    ' for column navigation, but at the left column it leaves the press unhandled, so it bubbles
+    ' up here. Derive the column from the flat itemFocused index and numColumns (both plain
+    ' integers) rather than reading focusColumn, which is not a scalar integer on a real device.
+    if key = "left" and m.grid.isInFocusChain()
+        numCols = m.grid.numColumns
+        if numCols < 1 then numCols = 1
+        if (m.grid.itemFocused mod numCols) = 0
+            m.categories.setFocus(true)
+            logLine(">>> focus returned to CATEGORY LIST")
+            return true
+        end if
+    end if
+
+    return false
+end function
+
+sub logLine(text as string)
+    print text
+    m.lines.push(text)
+    ' Keep only the last ~18 lines so the on-screen log stays readable.
+    if m.lines.count() > 18
+        m.lines.delete(0)
+    end if
+    joined = ""
+    for each ln in m.lines
+        joined = joined + ln + Chr(10)
+    end for
+    m.log.text = joined
+end sub
+
+function boolStr(b as boolean) as string
+    if b then return "true"
+    return "false"
+end function

--- a/test/simulator/itemfocused-focus-test/components/ItemFocusedScene.xml
+++ b/test/simulator/itemfocused-focus-test/components/ItemFocusedScene.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Roku ground-truth probe for a brs-engine behavior question, modeled on a common
+    master/detail screen where a left list drives the content of a right grid.
+
+    QUESTION: When content is loaded into the right MarkupGrid while focus is on the LEFT
+    list (so the grid is NOT in the focus chain), does the grid fire its `itemFocused`
+    observer? Two triggers are exercised on each load, both while unfocused:
+      1. assigning `grid.content = <node>`   (content-set path), and
+      2. writing `grid.jumpToItem = 0`       (a common app pattern: a "jump to remembered
+         index" field defaults to 0, so a `>= 0` guard writes jumpToItem = 0 on every load).
+
+    A master/detail app commonly drives a preview video off an itemFocused observer, so if
+    EITHER trigger fires itemFocused while the grid is unfocused, the preview starts
+    prematurely (audio plays while the video stays hidden, because visibility is separately
+    focus-gated). On a real device the preview starts only when focus reaches the grid. This
+    app settles, per trigger, whether itemFocused fires while unfocused.
+
+    NAVIGATION:
+      - Focus starts on the LEFT list.
+      - UP/DOWN in the left list changes the RIGHT grid's content (a new item set loads).
+      - RIGHT moves focus from the left list into the grid.
+      - LEFT inside the grid moves the focus left; pressing LEFT at the grid's left edge
+        returns focus to the left list.
+
+    HOW TO READ THE RESULT (watch the on-screen log and/or the console):
+      * If "*** grid itemFocused=0 inFocusChain=false" appears while focus is still on the
+        left list (on the initial load, and again each time you move UP/DOWN) -> Roku DOES
+        fire itemFocused on an unfocused grid. Note which line precedes it: the content-set
+        (line above "writing grid.jumpToItem") or the jumpToItem write.
+      * If NO grid itemFocused line appears until you press RIGHT to move focus onto the
+        grid, and it THEN fires with inFocusChain=true -> Roku fires itemFocused only when
+        focus moves in, for BOTH triggers. brs-engine must gate jumpToItem (and content-set)
+        on focus.
+-->
+<component name="ItemFocusedScene" extends="Scene">
+    <children>
+        <LabelList id="categories" translation="[60, 80]" itemSize="[300, 60]" numRows="6" />
+
+        <Label id="gridTitle" translation="[420, 60]" text="Content grid (right)" color="0xAAB4C8FF" />
+        <MarkupGrid id="grid" translation="[420, 90]" itemComponentName="GridItem"
+            itemSize="[180, 100]" numRows="2" numColumns="4" itemSpacing="[20, 20]" />
+
+        <Label id="log" translation="[60, 560]" width="1800" height="480" wrap="true"
+            color="0x8CF0A0FF" text="Focus is on the category list. Nothing should fire yet if Roku gates on focus." />
+    </children>
+    <script type="text/brightscript" uri="pkg:/components/ItemFocusedScene.brs" />
+</component>

--- a/test/simulator/itemfocused-focus-test/manifest
+++ b/test/simulator/itemfocused-focus-test/manifest
@@ -1,0 +1,10 @@
+##   Channel Details
+title=itemFocused Focus Test
+major_version=1
+minor_version=0
+build_version=00001
+
+splash_color=#0B0F14
+splash_min_time=0
+
+ui_resolutions=fhd

--- a/test/simulator/itemfocused-focus-test/source/main.brs
+++ b/test/simulator/itemfocused-focus-test/source/main.brs
@@ -1,0 +1,16 @@
+sub Main()
+    ' SceneGraph application entry point: create the screen and show the scene.
+    screen = CreateObject("roSGScreen")
+    m.port = CreateObject("roMessagePort")
+    screen.setMessagePort(m.port)
+
+    scene = screen.CreateScene("ItemFocusedScene")
+    screen.show()
+
+    while true
+        msg = wait(0, m.port)
+        if type(msg) = "roSGScreenEvent"
+            if msg.isScreenClosed() then return
+        end if
+    end while
+end sub


### PR DESCRIPTION
## Summary

`ArrayGrid` emitted `itemFocused` (and `RowList` emitted `rowItemFocused` / `currFocusRow` / `currFocusColumn`) whenever the focus cursor moved for **any** reason — assigning `content`, populating content after assignment, or writing `jumpToItem` / `animateToItem` — regardless of whether the node was in the focus chain.

Verified on a real Roku device: these fields change **only when an item gains the key focus**. Loading content into, or programmatically jumping within, a list that is **not** in the focus chain does not fire them.

## Why it matters

The divergence let a master/detail app's `itemFocused`-driven side effects run prematurely. On a screen where a left list drives the right grid's content, and the right grid starts a preview video off an `itemFocused` observer, playback started as soon as content loaded (and again on every `jumpToItem` the app issues on load) **while focus was still on the left list** — audio played under a hidden video, since visibility is separately focus-gated.

This also corrects the premise of #1037, which fired `itemFocused` on content population regardless of focus.

## Fix

Gate the emission at the choke point:

- **`ArrayGrid.setFocusedItem`** notifies observers (`itemUnfocused` / `itemFocused`) only when the node is in the focus chain. When unfocused, it updates the internal cursor and records the index via a **silent** write, so `setNodeFocus` re-emits `itemFocused` when focus later lands on the node. This covers `jumpToItem`, `animateToItem`, and the content-set path (via `resetFocusForNewContent`).
- **`RowList.setFocusedItem`** applies the same gating to `itemFocused`, `rowItemFocused`, and `currFocusRow` / `currFocusColumn`.

The fix lives in the shared `ArrayGrid` base, so `MarkupGrid`, `PosterGrid`, `RowList`, `MarkupList`, `LabelList`, and `ZoomRowList` all benefit.

## Behavior (verified on hardware)

- Content load / populate / `jumpToItem` on an **unfocused** list → silent (cursor updated, no observer fire).
- Focus lands on the list → `setNodeFocus` emits `itemFocused` (defaulting to item 0).
- A focused list still emits on content load, `jumpToItem`, and key navigation as before.

## Tests

- Reworked `list-initial-focus-app` and `deferred-observer-app`, plus one `RowList` unit test, to assert the hardware-verified contract (silent while unfocused; emits on focus-gain).
- Added `test/simulator/itemfocused-focus-test`, a sideloadable probe app (not run by the suite) used to confirm the behavior on a real device.
- Full suite green (`2054 passed`), including the new master item-clipping test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)