### PR TITLE
fix(rsg): Fixed regression caused by #1037 affecting ArrayGrid

### DIFF
--- a/src/core/common.ts
+++ b/src/core/common.ts
@@ -153,7 +153,6 @@ export const DefaultDeviceInfo: DeviceInfo = {
     autoPlayEnabled: true, // Autoplay device setting - enabled by default, as on a real Roku device
     maxFps: 60,
     minVideoBufferMs: 700, // Simulated minimum buffering floor (ms) before playback starts; only affects instant/cached sources
-
     tmpVolSize: 32 * 1024 * 1024, // 32 MB
     cacheFSVolSize: 32 * 1024 * 1024, // 32 MB
     logLevel: LogLevel.Warning,

--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -413,15 +413,6 @@ export class ArrayGrid extends Group {
         if (content instanceof ContentNode && content.changed) {
             this.refreshContent();
             content.changed = false;
-            // The content node was populated after being assigned (an app assigns an empty
-            // ContentNode, then a content-loading Task appends the items). If the grid already has
-            // focus but nothing has been focused yet, give the first item focus now so itemFocused
-            // fires; if the grid is not focused, do NOT emit itemFocused — on a real device the
-            // field only changes when focus moves onto an item, so loading content into an
-            // unfocused list stays silent until focus reaches it (see resetFocusForNewContent).
-            // Not a fresh-content reset: this fires on in-place mutations too, so an active focus
-            // on a focused grid must be preserved (never snapped back to item 0 mid-navigation).
-            this.resetFocusForNewContent(false);
         }
         const clipped = this.pushClippingRect(drawTrans, draw2D);
         this.renderContent(interpreter, rect, rotation, opacity, draw2D);


### PR DESCRIPTION
The change in #1037 did not addressed the root cause, the issue was eventually fixed by #1039 and the original fix caused a regression on some grids not being able to move past row one, when navigating vertically.

All tests added in the original fix still pass.