### PR TITLE
fix: reliable media event and buffering-progress delivery for preview playback

### DIFF
--- a/src/api/video.ts
+++ b/src/api/video.ts
@@ -62,8 +62,16 @@ if (typeof document !== "undefined") {
 export function initVideoModule(array: Int32Array, deviceInfo: DeviceInfo, mute: boolean = false) {
     if (player) {
         player.addEventListener("canplay", (e: Event) => {
-            loadProgress = 1000;
-            Atomics.store(sharedArray, DataType.VLP, loadProgress);
+            // Publish load progress only while a load is in progress (loadVideo resets it to 0
+            // per load): canplay also refires after every seek and when the buffer refills
+            // during playback, and per the Roku spec bufferingStatus / state "buffering" are
+            // only valid at stream startup or during an actual rebuffer — a republished 1000
+            // would surface as a spurious buffering transition that resets the trick-play
+            // state machine (stuck spinner, pause/FF/REW keys gated off).
+            if (loadProgress < 1000) {
+                loadProgress = 1000;
+                Atomics.store(sharedArray, DataType.VLP, loadProgress);
+            }
             canPlay = true;
             if (playerState !== "play" && !bufferOnly) {
                 playVideo();
@@ -388,8 +396,12 @@ function startProgress(e: Event) {
             startPosition = 0;
         }
     }
-    loadProgress += 200;
-    Atomics.store(sharedArray, DataType.VLP, loadProgress);
+    // Only progress an in-flight load: durationchange can refire after playback started
+    // (e.g. HLS updates while paused) and must not publish stale load progress.
+    if (loadProgress < 1000) {
+        loadProgress += 200;
+        Atomics.store(sharedArray, DataType.VLP, loadProgress);
+    }
 }
 
 /**

--- a/src/api/video.ts
+++ b/src/api/video.ts
@@ -44,6 +44,7 @@ let previousTime = Date.now();
 const DEFAULT_MIN_VIDEO_BUFFER_MS = 700; // fallback floor if DeviceInfo omits minVideoBufferMs
 let bufferFloorStart = 0; // Date.now() when the current load began
 let playFloorTimer: ReturnType<typeof setTimeout> | undefined; // pending deferred play
+let priming = false; // HLS audio-track priming play in flight; suppress its "playing" side effects
 const audioTracks: MediaTrack[] = [];
 const textTracks: MediaTrack[] = [];
 
@@ -69,8 +70,18 @@ export function initVideoModule(array: Int32Array, deviceInfo: DeviceInfo, mute:
             }
         });
         player.addEventListener("playing", (e: Event) => {
+            if (priming) {
+                // HLS audio-track priming play: halt immediately and report nothing to the
+                // worker (no StartStream, no notifyAll("play") — playerState stays non-"play"
+                // so the canplay handler still routes the real start through the buffering
+                // floor). The actual playback begins later via beginPlayback().
+                priming = false;
+                player.pause();
+                return;
+            }
             if (playerState !== "pause") {
                 setAudioTrack(playList[playIndex]?.audioTrack ?? -1);
+                // VDX must be stored before VDO — VDO is the publish flag the worker consumes.
                 Atomics.store(sharedArray, DataType.VDX, currentFrame);
                 Atomics.store(sharedArray, DataType.VDO, MediaEvent.StartStream);
             }
@@ -355,6 +366,7 @@ export function resetVideo() {
     bufferOnly = false;
     canPlay = false;
     clearPlayFloor(); // stopVideo() is a no-op when already stopped, so clear unconditionally here
+    priming = false;
 }
 
 /**
@@ -443,10 +455,14 @@ function loadAudioTracks() {
         playList[playIndex].audioTrack = activeTrack;
         if (activeTrack > -1 && playerState !== "play") {
             player.currentTime = 1; // Force HLS to load audio track
-            // Intentionally not gated by the buffering floor: HLS is network-fed and already has a
-            // natural buffering gap, and this play() primes the audio track load rather than the
-            // preview start that the floor targets.
-            player.play();
+            // This play() only primes the audio-track load; the "playing" handler pauses it and
+            // swallows its side effects (priming flag), so the real start still goes through the
+            // buffering floor and prebuffer never starts audible playback.
+            priming = true;
+            const promise = player.play();
+            promise?.catch(() => {
+                priming = false; // autoplay rejection: no "playing" event will fire to swallow
+            });
         }
     }
     return activeTrack;
@@ -557,6 +573,7 @@ function loadVideo(buffer = false) {
         // so a rapid navigation can never fire a stale play onto the wrong item.
         bufferFloorStart = Date.now();
         clearPlayFloor();
+        priming = false; // a stale armed priming flag would swallow this load's first real "playing"
         let videoSrc = getVideoUrl(video);
         clearVideoTracking();
         bufferOnly = buffer;
@@ -681,6 +698,10 @@ function scheduleBufferedPlay() {
  * Starts the actual media playback and handles autoplay restrictions.
  */
 function beginPlayback() {
+    // A real start supersedes any pending priming pause: if the floor elapses before the
+    // priming "playing" event fires, that single event must take the normal branch and
+    // publish StartStream (play() on an already-playing element fires no second event).
+    priming = false;
     previousBuffered = 0;
     previousTime = Date.now();
     const promise = player.play();
@@ -766,6 +787,7 @@ function stopVideo(error?: boolean) {
         startPosition = 0;
         canPlay = false;
         clearPlayFloor(); // drop any pending deferred play so it can't fire after stop
+        priming = false; // a stop before the priming "playing" fires must not leave the flag armed
     }
 }
 

--- a/src/core/brsTypes/components/RoVideoPlayer.ts
+++ b/src/core/brsTypes/components/RoVideoPlayer.ts
@@ -162,11 +162,16 @@ export class RoVideoPlayer extends BrsComponent implements BrsValue, BrsHttpAgen
             }
         }
         const progress = Atomics.load(BrsDevice.sharedArray, DataType.VLP);
-        if (this.progress !== progress && progress >= 0 && progress <= 1000) {
-            this.progress = progress;
-            events.push(new RoVideoPlayerEvent(MediaEvent.Loading, progress));
-            if (progress === 1000) {
-                events.push(new RoVideoPlayerEvent(MediaEvent.StartPlay, 0));
+        if (progress >= 0 && progress <= 1000) {
+            // Consume the slot so an identical value published by a later load is still seen
+            // (a snapshot compare would skip the whole progression when a fast reload climbs
+            // back to the same value before this thread observes the load-start reset).
+            if (Atomics.compareExchange(BrsDevice.sharedArray, DataType.VLP, progress, -1) === progress) {
+                this.progress = progress;
+                events.push(new RoVideoPlayerEvent(MediaEvent.Loading, progress));
+                if (progress === 1000) {
+                    events.push(new RoVideoPlayerEvent(MediaEvent.StartPlay, 0));
+                }
             }
         }
         if (this.notificationPeriod >= 1) {

--- a/src/core/brsTypes/components/RoVideoPlayer.ts
+++ b/src/core/brsTypes/components/RoVideoPlayer.ts
@@ -23,8 +23,6 @@ export class RoVideoPlayer extends BrsComponent implements BrsValue, BrsHttpAgen
     private port?: RoMessagePort;
     private contentList: RoAssociativeArray[];
     private notificationPeriod: number;
-    private eventType: number;
-    private eventIndex: number;
     private position: number;
     private progress: number;
     private selected: number;
@@ -38,8 +36,6 @@ export class RoVideoPlayer extends BrsComponent implements BrsValue, BrsHttpAgen
         super("roVideoPlayer");
         this.contentList = new Array();
         this.notificationPeriod = 0;
-        this.eventType = -1;
-        this.eventIndex = -1;
         this.position = 0;
         this.progress = -1;
         this.selected = 0;
@@ -154,13 +150,14 @@ export class RoVideoPlayer extends BrsComponent implements BrsValue, BrsHttpAgen
             }
         }
         const eventType = Atomics.load(BrsDevice.sharedArray, DataType.VDO);
-        const eventIndex = Atomics.load(BrsDevice.sharedArray, DataType.VDX);
-        if (eventType !== this.eventType || eventIndex !== this.eventIndex) {
-            this.eventType = eventType;
-            this.eventIndex = eventIndex;
-            if (this.eventType >= 0) {
-                events.push(new RoVideoPlayerEvent(this.eventType, this.eventIndex, this.selected));
-                Atomics.store(BrsDevice.sharedArray, DataType.VDO, -1);
+        if (eventType >= 0) {
+            const eventIndex = Atomics.load(BrsDevice.sharedArray, DataType.VDX);
+            // Consume the event exactly once: the CAS clears the slot so a same-type event
+            // published right after this one is still seen (a snapshot compare would drop it
+            // and leave the slot stuck). If the CAS fails, the render thread published a newer
+            // event between the load and the exchange; it is picked up next call.
+            if (Atomics.compareExchange(BrsDevice.sharedArray, DataType.VDO, eventType, -1) === eventType) {
+                events.push(new RoVideoPlayerEvent(eventType, eventIndex, this.selected));
                 Atomics.store(BrsDevice.sharedArray, DataType.VDX, -1);
             }
         }

--- a/src/extensions/scenegraph/SGRoot.ts
+++ b/src/extensions/scenegraph/SGRoot.ts
@@ -598,21 +598,32 @@ export class SGRoot {
         }
         let isDirty = false;
         const progress = Atomics.load(BrsDevice.sharedArray, DataType.VLP);
-        if (progress >= 0 && progress <= 1000 && this.videoProgress !== progress) {
-            // Emit the intermediate buffering steps between the last reported value and the
-            // current one, so a consumer that gates on a specific percentage never misses a
-            // threshold when the render loop is starved (e.g. during Task startup) and the load
-            // progress jumps. Apps commonly start playback at ~33% ("prebufferDone") and reveal
-            // UI at ~99%; delivering only a jump straight to 100% would skip the 33% callback and
-            // the video would never start. Mirrors a real device's gradual buffering progression.
-            let reported = Math.max(this.videoProgress, 0);
-            while (reported + 200 < progress) {
-                reported += 200;
-                this._video.setState(MediaEvent.Loading, Math.trunc(reported / 10));
+        if (progress >= 0 && progress <= 1000) {
+            // Consume the slot so an identical value published by a LATER load is still seen.
+            // Apps commonly reuse a single Video node across content: nothing resets
+            // `videoProgress` between loads, and a fast (cached) load can climb back to the same
+            // value before this thread ever observes the main thread's load-start reset. A
+            // snapshot compare would then skip the whole buffering progression, and an app that
+            // requires bufferingStatus to reach 100% before state turns "playing" (a real-device
+            // guarantee) would never reveal its player.
+            if (Atomics.compareExchange(BrsDevice.sharedArray, DataType.VLP, progress, -1) === progress) {
+                // Emit the intermediate buffering steps between the last reported value and the
+                // current one, so a consumer that gates on a specific percentage never misses a
+                // threshold when the render loop is starved (e.g. during Task startup) and the
+                // load progress jumps. Apps commonly start playback at ~33% ("prebufferDone") and
+                // reveal UI at ~99%; delivering only a jump straight to 100% would skip the 33%
+                // callback and the video would never start. Mirrors a real device's gradual
+                // buffering progression. A regressed value means a new load began, so the
+                // progression restarts from zero.
+                let reported = progress < this.videoProgress ? 0 : Math.max(this.videoProgress, 0);
+                while (reported + 200 < progress) {
+                    reported += 200;
+                    this._video.setState(MediaEvent.Loading, Math.trunc(reported / 10));
+                }
+                this._video.setState(MediaEvent.Loading, Math.trunc(progress / 10));
+                this.videoProgress = progress;
             }
-            this._video.setState(MediaEvent.Loading, Math.trunc(progress / 10));
         }
-        this.videoProgress = progress;
         const eventType = Atomics.load(BrsDevice.sharedArray, DataType.VDO);
         if (eventType >= 0) {
             const eventIndex = Atomics.load(BrsDevice.sharedArray, DataType.VDX);

--- a/src/extensions/scenegraph/SGRoot.ts
+++ b/src/extensions/scenegraph/SGRoot.ts
@@ -194,7 +194,6 @@ export class SGRoot {
     private audioIndex: number = -1;
     private audioDuration: number = -1;
     private audioPosition: number = -1;
-    private videoEvent: number = -1;
     private videoIndex: number = -1;
     private videoProgress: number = -1;
     private videoDuration: number = -1;
@@ -575,7 +574,6 @@ export class SGRoot {
      */
     setVideo(video: Video) {
         this._video = video;
-        this.videoEvent = -1;
         this.videoIndex = -1;
         this.videoProgress = -1;
         this.videoDuration = -1;
@@ -616,12 +614,14 @@ export class SGRoot {
         }
         this.videoProgress = progress;
         const eventType = Atomics.load(BrsDevice.sharedArray, DataType.VDO);
-        const eventIndex = Atomics.load(BrsDevice.sharedArray, DataType.VDX);
-        if (eventType !== this.videoEvent) {
-            this.videoEvent = eventType;
-            if (eventType >= 0) {
+        if (eventType >= 0) {
+            const eventIndex = Atomics.load(BrsDevice.sharedArray, DataType.VDX);
+            // Consume the event exactly once: the CAS clears the slot so a same-type event
+            // published right after this one is still seen (a snapshot compare would drop it
+            // and leave the slot stuck). If the CAS fails, the main thread published a newer
+            // event between the load and the exchange; it is picked up next tick.
+            if (Atomics.compareExchange(BrsDevice.sharedArray, DataType.VDO, eventType, -1) === eventType) {
                 this._video.setState(eventType, eventIndex);
-                Atomics.store(BrsDevice.sharedArray, DataType.VDO, -1);
                 isDirty = true;
             }
         }

--- a/test/extensions/scenegraph/VideoEventConsumption.test.js
+++ b/test/extensions/scenegraph/VideoEventConsumption.test.js
@@ -89,6 +89,58 @@ describe("SGRoot.processVideo exactly-once event consumption", () => {
         expect(Atomics.load(sharedArray, DataType.VDO)).toBe(-1);
     });
 
+    test("a reused Video node gets the buffering progression again when a fast reload republishes the same progress", () => {
+        // Apps commonly keep ONE Video node and swap its content per item, gating their poster
+        // overlay on bufferingStatus reaching 100% BEFORE state turns "playing" (a real-device
+        // guarantee). Nothing resets the worker's progress snapshot between loads of the same
+        // node, and a cached source can climb back to the same final value between two worker
+        // ticks — the progression must still be delivered, or the app never reveals the video.
+        const video = SGNodeFactory.createNode("Video");
+        sgRoot.setVideo(video);
+
+        // First content: load completes, then playback starts.
+        Atomics.store(sharedArray, DataType.VLP, 1000);
+        sgRoot.processVideo();
+        expect(video.getValueJS("state")).toBe("buffering");
+        expect(video.getValueJS("bufferingStatus").percentage).toBe(100);
+        publishEvent(MediaEvent.StartStream);
+        sgRoot.processVideo();
+        expect(video.getValueJS("state")).toBe("playing");
+
+        // Second content on the SAME node: the load-start reset and the whole climb back to
+        // 1000 happened between two worker ticks, so the worker only observes 1000 again.
+        Atomics.store(sharedArray, DataType.VLP, 1000);
+        sgRoot.processVideo();
+        expect(video.getValueJS("state")).toBe("buffering");
+        expect(video.getValueJS("bufferingStatus").percentage).toBe(100);
+
+        // ...and only then the play start.
+        publishEvent(MediaEvent.StartStream);
+        sgRoot.processVideo();
+        expect(video.getValueJS("state")).toBe("playing");
+    });
+
+    test("a regressed progress value restarts the buffering progression (new load on a reused node)", () => {
+        const video = SGNodeFactory.createNode("Video");
+        sgRoot.setVideo(video);
+
+        Atomics.store(sharedArray, DataType.VLP, 1000);
+        sgRoot.processVideo();
+        publishEvent(MediaEvent.StartStream);
+        sgRoot.processVideo();
+        expect(video.getValueJS("state")).toBe("playing");
+
+        // The next load is first observed mid-climb: lower than the stale base.
+        Atomics.store(sharedArray, DataType.VLP, 400);
+        sgRoot.processVideo();
+        expect(video.getValueJS("state")).toBe("buffering");
+        expect(video.getValueJS("bufferingStatus").percentage).toBe(40);
+
+        Atomics.store(sharedArray, DataType.VLP, 1000);
+        sgRoot.processVideo();
+        expect(video.getValueJS("bufferingStatus").percentage).toBe(100);
+    });
+
     test("distinct event transitions are consumed one per tick", () => {
         const video = SGNodeFactory.createNode("Video");
         sgRoot.setVideo(video);
@@ -152,6 +204,20 @@ describe("roVideoPlayer getNewEvents exactly-once event consumption", () => {
         expect(events.length).toBe(1);
         expect(events[0]).toBeInstanceOf(RoVideoPlayerEvent);
         expect(Atomics.load(sharedArray, DataType.VDO)).toBe(-1);
+    });
+
+    test("a fast reload republishing the same load progress still emits Loading and StartPlay", () => {
+        const videoPlayer = new RoVideoPlayer();
+
+        Atomics.store(sharedArray, DataType.VLP, 1000);
+        let events = videoPlayer.getNewEvents();
+        expect(events.length).toBe(2); // Loading(1000) + StartPlay
+
+        // Second load on the same player climbs back to 1000 between two polls.
+        Atomics.store(sharedArray, DataType.VLP, 1000);
+        events = videoPlayer.getNewEvents();
+        expect(events.length).toBe(2); // old snapshot compare: 0 — progression lost
+        expect(Atomics.load(sharedArray, DataType.VLP)).toBe(-1);
     });
 
     test("an empty slot produces no event and does not clear a later publish", () => {

--- a/test/extensions/scenegraph/VideoEventConsumption.test.js
+++ b/test/extensions/scenegraph/VideoEventConsumption.test.js
@@ -4,7 +4,7 @@ const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
 const core = require("../../../packages/node/bin/brs.node.js");
 
 const { SGNodeFactory, sgRoot } = scenegraph;
-const { BrsDevice, DataType, MediaEvent } = core;
+const { BrsDevice, DataType, MediaEvent, RoVideoPlayer, RoVideoPlayerEvent } = core;
 
 // The main thread publishes media events by storing MediaEvent values into the shared
 // array's VDO slot (VDX carries the event index). A consumer that dedupes on a snapshot
@@ -104,6 +104,65 @@ describe("SGRoot.processVideo exactly-once event consumption", () => {
         publishEvent(MediaEvent.StartStream);
         sgRoot.processVideo();
         expect(video.getValueJS("state")).toBe("playing");
+        expect(Atomics.load(sharedArray, DataType.VDO)).toBe(-1);
+    });
+});
+
+describe("roVideoPlayer getNewEvents exactly-once event consumption", () => {
+    let originalPostMessage;
+    let originalSharedArray;
+    let sharedArray;
+
+    beforeAll(() => {
+        originalSharedArray = BrsDevice.sharedArray;
+        sharedArray = new Int32Array(new SharedArrayBuffer(4096 * Int32Array.BYTES_PER_ELEMENT));
+        BrsDevice.setSharedArray(sharedArray);
+    });
+
+    beforeEach(() => {
+        // The roVideoPlayer constructor posts player-reset messages to the render thread.
+        originalPostMessage = global.postMessage;
+        global.postMessage = jest.fn();
+        sharedArray.fill(-1);
+    });
+
+    afterEach(() => {
+        global.postMessage = originalPostMessage;
+    });
+
+    afterAll(() => {
+        BrsDevice.setSharedArray(originalSharedArray);
+    });
+
+    test("two consecutive events with identical type and index both produce an event", () => {
+        const videoPlayer = new RoVideoPlayer();
+
+        Atomics.store(sharedArray, DataType.VDX, 5);
+        Atomics.store(sharedArray, DataType.VDO, MediaEvent.StartStream);
+        let events = videoPlayer.getNewEvents();
+        expect(events.length).toBe(1);
+        expect(events[0]).toBeInstanceOf(RoVideoPlayerEvent);
+        expect(Atomics.load(sharedArray, DataType.VDO)).toBe(-1);
+
+        // Republish the identical event before the next poll: the old type+index snapshot
+        // dedupe dropped it and left VDO stuck at StartStream.
+        Atomics.store(sharedArray, DataType.VDX, 5);
+        Atomics.store(sharedArray, DataType.VDO, MediaEvent.StartStream);
+        events = videoPlayer.getNewEvents();
+        expect(events.length).toBe(1);
+        expect(events[0]).toBeInstanceOf(RoVideoPlayerEvent);
+        expect(Atomics.load(sharedArray, DataType.VDO)).toBe(-1);
+    });
+
+    test("an empty slot produces no event and does not clear a later publish", () => {
+        const videoPlayer = new RoVideoPlayer();
+
+        expect(videoPlayer.getNewEvents().length).toBe(0);
+
+        Atomics.store(sharedArray, DataType.VDX, 0);
+        Atomics.store(sharedArray, DataType.VDO, MediaEvent.Paused);
+        const events = videoPlayer.getNewEvents();
+        expect(events.length).toBe(1);
         expect(Atomics.load(sharedArray, DataType.VDO)).toBe(-1);
     });
 });

--- a/test/extensions/scenegraph/VideoEventConsumption.test.js
+++ b/test/extensions/scenegraph/VideoEventConsumption.test.js
@@ -1,0 +1,109 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsDevice, DataType, MediaEvent } = core;
+
+// The main thread publishes media events by storing MediaEvent values into the shared
+// array's VDO slot (VDX carries the event index). A consumer that dedupes on a snapshot
+// of the last-seen value drops the second of two same-type events published between two
+// ticks (e.g. a stale StartStream from the previous item followed by the real one), and
+// the slot then sticks at that value forever — the app never sees the real "playing".
+// These suites pin the exactly-once consume (compareExchange) on both consumers.
+describe("SGRoot.processVideo exactly-once event consumption", () => {
+    let originalPostMessage;
+    let originalSharedArray;
+    let sharedArray;
+
+    beforeAll(() => {
+        // Video builds labels/posters/spinner from the common: volume; mount it once.
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+        originalSharedArray = BrsDevice.sharedArray;
+        sharedArray = new Int32Array(new SharedArrayBuffer(4096 * Int32Array.BYTES_PER_ELEMENT));
+        BrsDevice.setSharedArray(sharedArray);
+    });
+
+    beforeEach(() => {
+        // The Video constructor posts control/state messages to the render thread.
+        originalPostMessage = global.postMessage;
+        global.postMessage = jest.fn();
+        sharedArray.fill(-1);
+        sgRoot.setVideo();
+    });
+
+    afterEach(() => {
+        global.postMessage = originalPostMessage;
+        sgRoot.setVideo();
+    });
+
+    afterAll(() => {
+        BrsDevice.setSharedArray(originalSharedArray);
+    });
+
+    function publishEvent(eventType, eventIndex = 0) {
+        // VDX must be stored before VDO — VDO is the publish flag the worker consumes.
+        Atomics.store(sharedArray, DataType.VDX, eventIndex);
+        Atomics.store(sharedArray, DataType.VDO, eventType);
+    }
+
+    test("a same-type event republished before the next tick is still delivered (poster-over-video regression)", () => {
+        const video = SGNodeFactory.createNode("Video");
+        sgRoot.setVideo(video);
+
+        // A stale/premature StartStream (e.g. from the previously focused item) is consumed.
+        publishEvent(MediaEvent.StartStream);
+        sgRoot.processVideo();
+        expect(video.getValueJS("state")).toBe("playing");
+        expect(Atomics.load(sharedArray, DataType.VDO)).toBe(-1);
+
+        // Before the next worker tick, the new item's load reports buffering progress (the
+        // separate VLP slot) AND the real StartStream lands in VDO. A snapshot dedupe reads
+        // StartStream === last-seen StartStream, drops it, and the state sticks at
+        // "buffering" — the app never hides its poster over the playing video.
+        Atomics.store(sharedArray, DataType.VLP, 330);
+        publishEvent(MediaEvent.StartStream);
+        sgRoot.processVideo();
+
+        expect(video.getValueJS("state")).toBe("playing");
+        expect(Atomics.load(sharedArray, DataType.VDO)).toBe(-1);
+    });
+
+    test("the VDO slot never sticks after a same-type republish", () => {
+        const video = SGNodeFactory.createNode("Video");
+        sgRoot.setVideo(video);
+
+        publishEvent(MediaEvent.StartStream);
+        sgRoot.processVideo();
+        publishEvent(MediaEvent.StartStream);
+        sgRoot.processVideo();
+        // With the snapshot dedupe the slot stayed at StartStream forever; it must be cleared.
+        expect(Atomics.load(sharedArray, DataType.VDO)).toBe(-1);
+
+        // And a subsequent different event still lands normally.
+        publishEvent(MediaEvent.Paused);
+        sgRoot.processVideo();
+        expect(video.getValueJS("state")).toBe("paused");
+        expect(Atomics.load(sharedArray, DataType.VDO)).toBe(-1);
+    });
+
+    test("distinct event transitions are consumed one per tick", () => {
+        const video = SGNodeFactory.createNode("Video");
+        sgRoot.setVideo(video);
+
+        publishEvent(MediaEvent.StartStream);
+        sgRoot.processVideo();
+        expect(video.getValueJS("state")).toBe("playing");
+
+        publishEvent(MediaEvent.Partial);
+        sgRoot.processVideo();
+        expect(video.getValueJS("state")).toBe("stopped");
+
+        publishEvent(MediaEvent.StartStream);
+        sgRoot.processVideo();
+        expect(video.getValueJS("state")).toBe("playing");
+        expect(Atomics.load(sharedArray, DataType.VDO)).toBe(-1);
+    });
+});


### PR DESCRIPTION
## Problem

Apps that show a preview overlay per focused list item (poster first, then an inline Video) intermittently ended up with the poster stuck on top while the preview's audio kept playing. Raising the minimum buffering floor from #1033 did not help.

Such apps typically reuse a **single Video node** across items and follow the real-device contract: per playback start, `bufferingStatus.percentage` climbs to **100 before** `state` turns `"playing"`; the overlay is only revealed on `"playing"` *with* buffering complete, and a `"playing"` that arrives without it actively hides the player (poster on top, audio behind).

## Root causes (three related defects in the shared-array media channel)

1. **`SGRoot.processVideo` dropped same-type events (VDO slot).** The snapshot dedupe skipped an event whose value equaled the last-seen one, so a same-type event republished before the worker observed the cleared slot was lost forever and the slot stuck.
2. **`SGRoot.processVideo` skipped the buffering progression on fast reloads (VLP slot).** With a reused Video node nothing resets the worker's progress snapshot between loads; a fast (cached) load climbs back to the same final value before the worker ever observes the main thread's load-start reset, so the snapshot compare silently skipped the whole progression — no `bufferingStatus`, no 100%, and the subsequent `"playing"` landed in the app's "buffering incomplete" branch. This was the dominant cause of the stuck poster.
3. **The #1033 buffering floor was fully bypassed for HLS content with audio tracks.** The `player.play()` that primes HLS audio-track loading started real playback immediately, published `StartStream`, and set `playerState="play"` — which made the `canplay` handler skip the floor path entirely (and let `prebuffer` start audible playback).

## Fixes

- `SGRoot.processVideo`: consume the `VDO` event slot and the `VLP` progress slot **exactly once** via `Atomics.compareExchange` — every published value is delivered, identical re-publishes are recognized as fresh, and a regressed progress value restarts the buffering interpolation (a new load).
- `src/api/video.ts`: a `priming` flag makes the HLS audio-track priming play side-effect free — the `playing` handler pauses and swallows it, so the real start always routes through the buffering floor; `beginPlayback` clears the flag first (covers the reverse interleaving), and load/stop/reset all clear it.
- `RoVideoPlayer.getNewEvents`: same exactly-once consumption for the legacy player (both slots).

Known accepted limitation (unchanged): the single `VDO` slot is last-writer-wins for two *different* events between ticks; state converges.

## Tests

New regression suite `test/extensions/scenegraph/VideoEventConsumption.test.js` (8 tests), including the exact overlay scenario: a reused node whose fast reload republishes the same progress value must still deliver `bufferingStatus.percentage = 100` (state `"buffering"`) **before** `"playing"`. Verified the key tests fail against the previous code. Full suite: 154 suites / 2062 tests green. Manually verified in the browser with the affected app: rapid row navigation no longer leaves the poster over an audible preview.

## Follow-up (deferred): load-generation attribution (`DataType.VGN`)

Stale events written for the previous content can still race `setVideo()`'s reset by one tick (now a transient, not a stuck state). A monotonic load-generation echoed by the main thread in a new `DataType.VGN` slot (written before each `VDX`/`VDO` pair, checked after the CAS consume) would let the worker positively discard them. Design notes are recorded separately; `VDO` encoding stays unchanged so the legacy player is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)