### PR TITLE
fix(rsg): only defer reentrant observers for engine-initiated field emissions

### DIFF
--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -16,6 +16,7 @@ import { FieldKind, FieldModel } from "../SGTypes";
 import { Poster, SGNodeType } from ".";
 import { Group } from "./Group";
 import { Node } from "./Node";
+import { Field } from "./Field";
 import { createNode } from "../factory/NodeFactory";
 import { brsValueOf, jsValueOf } from "../factory/Serializer";
 import { sgRoot } from "../SGRoot";
@@ -276,23 +277,31 @@ export class ArrayGrid extends Group {
         if (newFocus === -1) {
             return;
         }
-        const focusedIndex = this.getValueJS("itemFocused") as number;
-        const nodeFocus = sgRoot.focused === this;
-        const inFocusChain = nodeFocus || this.isChildrenFocused();
-        this.updateItemFocus(this.focusIndex, false, nodeFocus);
-        this.focusIndex = newFocus;
-        this.focusLayoutDirty = true;
-        this.updateItemFocus(this.focusIndex, true, nodeFocus);
-        if (inFocusChain) {
-            super.setValue("itemUnfocused", new Int32(focusedIndex));
-            super.setValue("itemFocused", new Int32(index));
-        } else {
-            // Unfocused: remember the target without notifying observers. setNodeFocus emits it on
-            // focus-gain (it reads itemFocused, defaulting to 0 when still at the -1 sentinel).
-            this.setValueSilent("itemFocused", new Int32(index));
-        }
-        if (this.itemFocusCallback) {
-            this.itemFocusCallback(index);
+        // Focus fields are emitted by the grid's internal machinery, not by a direct BrightScript
+        // assignment — on Roku their observers dispatch from the message loop, so a reentrant
+        // notification defers (see Field.enterInternalUpdate).
+        Field.enterInternalUpdate();
+        try {
+            const focusedIndex = this.getValueJS("itemFocused") as number;
+            const nodeFocus = sgRoot.focused === this;
+            const inFocusChain = nodeFocus || this.isChildrenFocused();
+            this.updateItemFocus(this.focusIndex, false, nodeFocus);
+            this.focusIndex = newFocus;
+            this.focusLayoutDirty = true;
+            this.updateItemFocus(this.focusIndex, true, nodeFocus);
+            if (inFocusChain) {
+                super.setValue("itemUnfocused", new Int32(focusedIndex));
+                super.setValue("itemFocused", new Int32(index));
+            } else {
+                // Unfocused: remember the target without notifying observers. setNodeFocus emits it on
+                // focus-gain (it reads itemFocused, defaulting to 0 when still at the -1 sentinel).
+                this.setValueSilent("itemFocused", new Int32(index));
+            }
+            if (this.itemFocusCallback) {
+                this.itemFocusCallback(index);
+            }
+        } finally {
+            Field.exitInternalUpdate();
         }
     }
 

--- a/src/extensions/scenegraph/nodes/Field.ts
+++ b/src/extensions/scenegraph/nodes/Field.ts
@@ -48,17 +48,31 @@ export class Field {
     private notifying = false;
 
     // ---- Roku-accurate deferred observer dispatch (per Worker thread) -------------------------
-    // On a real Roku, a function-name field observer is dispatched from the owning thread's
-    // message loop; it does NOT run reentrantly in the middle of another observer's execution.
-    // We reproduce that: when a Callable observer would fire while another Callable observer is
-    // already executing (reentrant) — and the notification is not part of a ContentNode
-    // parentField cascade — we queue it and drain it FIFO once the outermost dispatch unwinds.
+    // On a real Roku, a DIRECT BrightScript field assignment (`node.field = x`) on the owning
+    // thread fires function-name observers synchronously, even nested inside another observer —
+    // apps rely on set-then-read-back (assign a field, immediately read a value the observer
+    // computed). What Roku dispatches from the message loop are fields changed by a node's
+    // INTERNAL machinery (e.g. `itemFocused` emitted by an ArrayGrid processing `jumpToItem`,
+    // `content`, or a focus move): those observers do not run reentrantly in the middle of another
+    // observer's execution. We reproduce that: when a Callable observer for an engine-initiated
+    // emission (`internalUpdateDepth` > 0) would fire while another Callable observer is already
+    // executing (reentrant) — and the notification is not part of a ContentNode parentField
+    // cascade — we queue it and drain it FIFO once the outermost dispatch unwinds.
     // Same-field re-notification (`notifying`) and same-ContentNode re-entry (`propagating`) are
     // still suppressed before reaching this path, so the #904/#905/#943 cascades are unaffected.
     /** Depth of Callable observers currently executing on this thread (the reentrancy gate). */
     private static observerDepth = 0;
     /** >0 while inside `ContentNode.notifyParentFields`; disables deferral for cascade observers. */
     private static parentCascadeDepth = 0;
+    /**
+     * >0 while engine machinery (not app BrightScript) is emitting field changes — grid focus
+     * bookkeeping such as `itemFocused`/`rowItemFocused`. Only those notifications defer; a direct
+     * BrightScript assignment always dispatches synchronously (Roku's set-then-read-back
+     * semantics). Stashed to 0 while an observer callback executes (`invoke`), so a handler
+     * dispatched from inside an engine emission still has its own direct assignments treated as
+     * app-initiated; a nested engine site re-enters and is again marked internal.
+     */
+    private static internalUpdateDepth = 0;
     /**
      * True while draining the deferred queue. Deferral happens only ONCE, at the boundary of the
      * original top-level handler; once we start draining, the reentrant cascade runs synchronously
@@ -81,10 +95,21 @@ export class Field {
         Field.parentCascadeDepth--;
     }
 
+    /** Marks entry into an engine-initiated field emission (message-loop dispatch on Roku). */
+    static enterInternalUpdate() {
+        Field.internalUpdateDepth++;
+    }
+
+    /** Marks exit from an engine-initiated field emission. */
+    static exitInternalUpdate() {
+        Field.internalUpdateDepth--;
+    }
+
     /** Resets deferred-dispatch state between app runs so nothing leaks across setups. */
     static resetDispatch() {
         Field.observerDepth = 0;
         Field.parentCascadeDepth = 0;
+        Field.internalUpdateDepth = 0;
         Field.draining = false;
         Field.deferredQueue.length = 0;
     }
@@ -506,12 +531,19 @@ export class Field {
             return;
         }
 
-        // Roku-accurate deferral: if another Callable observer is already executing (reentrant) and
-        // this notification is not part of a ContentNode parentField cascade, queue it and let the
-        // outermost dispatch drain it after the current handler returns.
+        // Roku-accurate deferral: if this notification comes from an engine-initiated emission
+        // (grid focus bookkeeping — a direct BrightScript assignment never defers), another
+        // Callable observer is already executing (reentrant), and it is not part of a ContentNode
+        // parentField cascade, queue it and let the outermost dispatch drain it after the current
+        // handler returns.
         // Defer only while inside the ORIGINAL top-level handler (not while draining). Once draining,
         // the cascade runs synchronously/nested so the per-field `notifying` guards terminate it.
-        if (Field.observerDepth > 0 && !Field.draining && Field.parentCascadeDepth === 0) {
+        if (
+            Field.internalUpdateDepth > 0 &&
+            Field.observerDepth > 0 &&
+            !Field.draining &&
+            Field.parentCascadeDepth === 0
+        ) {
             Field.deferredQueue.push({ field: this, callback, event });
             return;
         }
@@ -591,6 +623,23 @@ export class Field {
 
     /** Runs a single Callable observer callback with the caller's host node / m scope restored. */
     private invoke(callback: BrsCallback, event: RoSGNodeEvent) {
+        if (!(callback.observer instanceof Callable)) {
+            return;
+        }
+        // While the handler's BrightScript executes, its direct field assignments are
+        // app-initiated even when this dispatch happens inside an engine emission site (e.g. a
+        // panel callback fired from ArrayGrid.setFocusedItem). Stash the internal-update marker
+        // and restore it after; a nested engine site re-enters it on its own.
+        const stashedInternalDepth = Field.internalUpdateDepth;
+        Field.internalUpdateDepth = 0;
+        try {
+            this.invokeCallable(callback, event);
+        } finally {
+            Field.internalUpdateDepth = stashedInternalDepth;
+        }
+    }
+
+    private invokeCallable(callback: BrsCallback, event: RoSGNodeEvent) {
         const { interpreter, observer, hostNode, environment } = callback;
         if (!(observer instanceof Callable)) {
             return;

--- a/src/extensions/scenegraph/nodes/RowList.ts
+++ b/src/extensions/scenegraph/nodes/RowList.ts
@@ -19,6 +19,7 @@ import { brsValueOf, jsValueOf } from "../factory/Serializer";
 import { Font } from "./Font";
 import { Group } from "./Group";
 import { Node } from "./Node";
+import { Field } from "./Field";
 import { ArrayGrid, FocusStyle } from "./ArrayGrid";
 import { FieldKind, FieldModel } from "../SGTypes";
 import { resolveRowItemSubpart } from "../SGUtil";
@@ -163,7 +164,15 @@ export class RowList extends ArrayGrid {
         const inFocusChain = sgRoot.focused === this || this.isChildrenFocused();
 
         if (isChangingRow && inFocusChain) {
-            super.setValue("itemUnfocused", new Int32(oldRow));
+            // Engine-initiated emission (not a direct BrightScript assignment): on Roku its
+            // observers dispatch from the message loop, so a reentrant notification defers
+            // (see Field.enterInternalUpdate).
+            Field.enterInternalUpdate();
+            try {
+                super.setValue("itemUnfocused", new Int32(oldRow));
+            } finally {
+                Field.exitInternalUpdate();
+            }
         }
 
         this.focusIndex = rowIndex;
@@ -225,7 +234,13 @@ export class RowList extends ArrayGrid {
         }
 
         if (inFocusChain) {
-            super.setValue("itemFocused", new Int32(rowIndex));
+            // Engine-initiated emission: reentrant observers defer (see Field.enterInternalUpdate).
+            Field.enterInternalUpdate();
+            try {
+                super.setValue("itemFocused", new Int32(rowIndex));
+            } finally {
+                Field.exitInternalUpdate();
+            }
             this.setRowItemFocused(rowIndex, colIndex);
         } else {
             // Unfocused: remember the row/column silently (no observer notification). The values are
@@ -252,16 +267,22 @@ export class RowList extends ArrayGrid {
         // focused item synchronously via subBoundingRect, and the dirty flag makes that query refresh
         // layout first so it reports the settled focus-band position (see needsSubBoundingRectRefresh).
         this.focusLayoutDirty = true;
-        // Emit currFocusRow/currFocusColumn BEFORE rowItemFocused. On a real device the focus fields
-        // pass through in-transit (fractional) values during the scroll animation and rowItemFocused
-        // settles last, so apps treat the rowItemFocused observer as the authoritative "focus settled"
-        // callback (e.g. the one that positions a per-row overlay on the final row). Since our scroll is
-        // instant, honoring that ordering — the settle notification fires last — keeps such an app from
-        // being stranded in its transient state (an observer on currFocusRow that computes an in-transit
-        // row from the scroll direction would otherwise run last and win). Regression: RowList.test.js.
-        super.setValue("currFocusRow", new Float(rowIndex));
-        super.setValue("currFocusColumn", new Float(colIndex));
-        super.setValue("rowItemFocused", new RoArray([new Int32(rowIndex), new Int32(colIndex)]));
+        // Engine-initiated emissions: reentrant observers defer (see Field.enterInternalUpdate).
+        Field.enterInternalUpdate();
+        try {
+            // Emit currFocusRow/currFocusColumn BEFORE rowItemFocused. On a real device the focus fields
+            // pass through in-transit (fractional) values during the scroll animation and rowItemFocused
+            // settles last, so apps treat the rowItemFocused observer as the authoritative "focus settled"
+            // callback (e.g. the one that positions a per-row overlay on the final row). Since our scroll is
+            // instant, honoring that ordering — the settle notification fires last — keeps such an app from
+            // being stranded in its transient state (an observer on currFocusRow that computes an in-transit
+            // row from the scroll direction would otherwise run last and win). Regression: RowList.test.js.
+            super.setValue("currFocusRow", new Float(rowIndex));
+            super.setValue("currFocusColumn", new Float(colIndex));
+            super.setValue("rowItemFocused", new RoArray([new Int32(rowIndex), new Int32(colIndex)]));
+        } finally {
+            Field.exitInternalUpdate();
+        }
     }
 
     protected handleUpDown(key: string) {

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -497,21 +497,22 @@ describe("cli", () => {
         ]);
     }, 10000);
 
-    it("A deferred observer that rewrites its own alwaysNotify field does not loop", async () => {
+    it("A reentrant observer that rewrites its own alwaysNotify field does not loop", async () => {
         let command = ["node", brsCliPath, "-r observer-loop-app", "source/main.brs", "-c 0"].join(" ");
 
         let { stdout } = await exec(command, {
             cwd: path.join(__dirname, "resources"),
         });
         // aliasField is alwaysNotify with an onChange (onAlias) that writes the same field back to
-        // itself. When onAlias runs deferred (reassigned from inside onSelected), the per-field
-        // notifying guard must stay held across the deferred run so the self-write is suppressed;
-        // otherwise it re-enqueues forever (observer drain limit). onAlias must fire exactly once.
+        // itself. A direct BrightScript assignment dispatches synchronously even inside another
+        // observer (only engine-initiated emissions defer), so onAlias runs nested inside
+        // onSelected and the per-field notifying guard suppresses the re-entrant self-write.
+        // onAlias must fire exactly once.
         expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
             "=== Observer Loop Repro ===",
             "onSelected",
-            "onSelected done",
             "onAlias count= 1",
+            "onSelected done",
             "=== Observer Loop Repro Complete ===",
             "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
             "",
@@ -526,17 +527,40 @@ describe("cli", () => {
             cwd: path.join(__dirname, "resources"),
         });
         // fieldF.onChange writes fieldG and fieldG.onChange writes fieldF (both alwaysNotify),
-        // reassigned from inside an observer so both defer. Deferral must happen only at the
-        // original handler boundary; once draining, the cascade runs synchronously/nested so the
-        // per-field notifying guards terminate it. Each observer fires exactly once (the manual
-        // field-alias ping-pong flood).
+        // reassigned from inside an observer. Direct BrightScript assignments dispatch
+        // synchronously/nested even when reentrant (only engine-initiated emissions defer), so the
+        // per-field notifying guards (F held while G runs) terminate the cascade in one round.
+        // Each observer fires exactly once (the manual field-alias ping-pong flood).
         expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
             "=== Cross Alias Loop Repro ===",
             "onStart",
-            "onStart done",
             "onF count= 1",
             "onG count= 1",
+            "onStart done",
             "=== Cross Alias Loop Repro Complete ===",
+            "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+    }, 10000);
+
+    it("Dispatches a direct field assignment's observer synchronously inside another observer", async () => {
+        let command = ["node", brsCliPath, "-r observer-readback-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        // A panel-creation observer builds a menu by assigning a detached item component's
+        // itemContent and immediately reading back the calculatedWidth its observer computes
+        // (the fit-to-content list-sizing pattern). The assignment is direct BrightScript, so
+        // its observer must run synchronously even one observer level deep — deferring it makes
+        // the read-back see 0 and the menu collapses to zero width.
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "=== Observer Readback Repro ===",
+            "onBuild",
+            "widest > 0: true",
+            "onBuild done",
+            "=== Observer Readback Repro Complete ===",
             "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
             "",
             "",

--- a/test/cli/resources/cross-alias-loop-app/components/MainScene.xml
+++ b/test/cli/resources/cross-alias-loop-app/components/MainScene.xml
@@ -2,8 +2,9 @@
 <!--
     Reproduces the manual field-alias flood: two alwaysNotify fields whose onChange
     handlers write each other (F.onChange -> G, G.onChange -> F), reassigned from inside an
-    observer so both defer. Synchronously the nested `notifying` guards (F held while G runs)
-    terminate this in one round; the flattened deferred FIFO loses that nesting and loops.
+    observer. Direct BrightScript assignments dispatch synchronously even when reentrant (only
+    engine-initiated emissions such as itemFocused defer), so the nested `notifying` guards
+    (F held while G runs) must terminate this in one round instead of looping.
 -->
 <component name="MainScene" extends="Scene">
     <interface>
@@ -19,7 +20,7 @@
 
     sub onStart()
         print "onStart"
-        ' Reentrant: onF runs deferred.
+        ' Direct reentrant assignment: onF runs synchronously (nested).
         m.top.fieldF = [1, 1]
         print "onStart done"
     end sub

--- a/test/cli/resources/observer-loop-app/components/MainScene.xml
+++ b/test/cli/resources/observer-loop-app/components/MainScene.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!--
-    Models the "manual field alias" pattern that regressed when reentrant observers began
-    deferring: an alwaysNotify field (aliasField) whose onChange handler (onAlias) writes the SAME
-    field back to itself. Synchronously the per-field `notifying` guard suppresses that re-entrant
-    self-write; the deferred dispatch must keep that guard held across the deferred run, otherwise
-    the self-write re-enqueues onAlias forever (observer-drain-limit flood).
+    Models the "manual field alias" pattern: an alwaysNotify field (aliasField) whose onChange
+    handler (onAlias) writes the SAME field back to itself. A direct BrightScript assignment
+    dispatches its observers synchronously even when reentrant (Roku's set-then-read-back
+    semantics; only engine-initiated emissions such as itemFocused defer), so onAlias runs nested
+    inside onSelected and the per-field `notifying` guard must suppress the re-entrant self-write,
+    otherwise it recurses/floods forever.
 -->
 <component name="MainScene" extends="Scene">
     <interface>
@@ -18,7 +19,7 @@
 
     sub onSelected()
         print "onSelected"
-        ' Reentrant assignment: aliasField's onChange runs deferred.
+        ' Direct reentrant assignment: aliasField's onChange runs synchronously (nested).
         m.top.aliasField = [1, 2]
         print "onSelected done"
     end sub

--- a/test/cli/resources/observer-readback-app/components/CheckItem.xml
+++ b/test/cli/resources/observer-readback-app/components/CheckItem.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Models a fit-to-content list item: assigning `itemContent` triggers an observer that sets a
+    label's text, measures it, and publishes the result in `calculatedWidth`. Apps assign
+    `itemContent` and read `calculatedWidth` back on the very next statement, so the observer
+    must dispatch synchronously even when the assignment happens inside another observer.
+-->
+<component name="CheckItem" extends="Group">
+    <interface>
+        <field id="itemContent" type="node" />
+        <field id="calculatedWidth" type="float" value="0.0" />
+    </interface>
+    <children>
+        <Label id="itemLabel" />
+    </children>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.label = m.top.findNode("itemLabel")
+        m.top.observeFieldScoped("itemContent", "onItemContentChange")
+    end sub
+
+    sub onItemContentChange(event as object)
+        itemContent = event.getData()
+        if itemContent <> invalid
+            m.label.text = itemContent.title
+            ' Measure the label and publish the derived width for the owner to read back.
+            m.top.calculatedWidth = m.label.boundingRect().width + 32
+        end if
+    end sub
+    ]]></script>
+</component>

--- a/test/cli/resources/observer-readback-app/components/MainScene.xml
+++ b/test/cli/resources/observer-readback-app/components/MainScene.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Models a real app regression: a settings panel built inside a panel-creation observer sizes
+    its menu by creating a detached item component, assigning its `itemContent`, and immediately
+    reading back the `calculatedWidth` its observer computes. A direct BrightScript assignment
+    must dispatch the item's observer synchronously even though another observer (onBuild) is
+    already executing — deferring it makes the read-back see 0 and the menu collapses to zero
+    width. Only engine-initiated emissions (e.g. itemFocused) defer to the handler boundary.
+-->
+<component name="MainScene" extends="Scene">
+    <interface>
+        <field id="runTrigger" type="integer" onChange="onBuild" />
+    </interface>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+    end sub
+
+    sub onBuild()
+        print "onBuild"
+        widest = 0
+        for each title in ["Little Kids", "Older Kids", "Teens", "Adults"]
+            content = createObject("roSGNode", "ContentNode")
+            content.title = title
+            checkItem = createObject("roSGNode", "CheckItem")
+            ' Set-then-read-back: the itemContent observer computes calculatedWidth and it
+            ' must be visible on the very next statement.
+            checkItem.itemContent = content
+            if checkItem.calculatedWidth > widest
+                widest = checkItem.calculatedWidth
+            end if
+        end for
+        print "widest > 0: "; (widest > 0)
+        print "onBuild done"
+    end sub
+    ]]></script>
+</component>

--- a/test/cli/resources/observer-readback-app/manifest
+++ b/test/cli/resources/observer-readback-app/manifest
@@ -1,0 +1,4 @@
+title=Observer Readback Repro
+major_version=1
+minor_version=0
+build_version=1

--- a/test/cli/resources/observer-readback-app/source/main.brs
+++ b/test/cli/resources/observer-readback-app/source/main.brs
@@ -1,0 +1,16 @@
+sub Main()
+    print "=== Observer Readback Repro ==="
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+    scene = screen.CreateScene("MainScene")
+    screen.show()
+    ' Trigger the build from a top-level field set: its observer (onBuild) runs the
+    ' set-then-read-back sequence one observer level deep, like a real app building a
+    ' menu inside a panel-creation observer.
+    scene.runTrigger = 1
+    for i = 0 to 5
+        msg = wait(20, port)
+    end for
+    print "=== Observer Readback Repro Complete ==="
+end sub


### PR DESCRIPTION
## Problem

PR #1032 deferred **every** reentrant Callable field observer to the outermost handler boundary. That broke Roku's set-then-read-back contract: a **direct BrightScript assignment** (`node.field = x`) dispatches its function-name observers **synchronously** on the owning thread, even nested inside another observer. A common app pattern assigns a field and immediately reads back a value the observer computed — e.g. a fit-to-content menu creates a detached item component, assigns its `itemContent`, and reads the `calculatedWidth` its observer derives from `label.boundingRect().width` on the very next statement. With the broad deferral the readback saw `0`, the menu's `itemSize` collapsed to zero width, and the list rendered invisible (sibling labels unaffected).

What Roku actually dispatches from the render thread's message loop are fields changed by a node's **internal machinery** — grid focus bookkeeping such as `itemFocused` emitted while processing `jumpToItem`, which is the exact reentrant-crash scenario #1032 fixed.

## Fix

Gate the deferral on that distinction:

- `Field` gains a static `internalUpdateDepth` marker (`enterInternalUpdate`/`exitInternalUpdate`, cleared by `resetDispatch`); `executeCallbacks` defers only when it is `> 0`, in addition to the existing `observerDepth`/`draining`/`parentCascade` conditions.
- `ArrayGrid.setFocusedItem` and `RowList.setFocusedItem`/`setRowItemFocused` wrap their focus-field emissions (`itemFocused`, `itemUnfocused`, `currFocusRow`, `currFocusColumn`, `rowItemFocused`) in the marker, preserving the focus-chain gating from #1037/#1039/#1040.
- `Field.invoke` stashes the marker to 0 while a callback's BrightScript executes and restores it after: a handler dispatched from inside an engine emission site (e.g. a panel's `createNextPanelIndex` observer fired via `itemFocusCallback` inside `setFocusedItem`) has its own direct assignments treated as app-initiated; a nested engine site re-enters the marker itself.

Direct assignments return to synchronous nested dispatch, where the per-field `notifying` guards terminate self-writes and cross-field ping-pongs exactly as before #1032; the `observer-loop-app` and `cross-alias-loop-app` expectations now reflect that ordering. The #1032 deferral fixtures (`deferred-observer-app`, `rowlist-subrect-app`) are unchanged.

## Tests

- New `observer-readback-app` CLI fixture pins the set-then-read-back contract one observer level deep (readback must be non-zero).
- Full suite green: 154 suites / 2063 tests, including the four #1032 fixtures and the #1037–#1040 itemFocused suites.
- Validated in a full production app: the fit-to-content settings list renders again, and the preview-overlay and grid-autoplay flows show no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)