### PR TITLE
fix(rsg): honor Library statements in component scripts and complete the RAF mock

### DIFF
--- a/src/core/LexerParser.ts
+++ b/src/core/LexerParser.ts
@@ -156,6 +156,45 @@ export function parseDecodedTokens(fs: FileSystem, manifest: Map<string, any>, d
 }
 
 /**
+ * Resolves a BrightScript library name to its source code on the `common:` volume,
+ * honoring the manifest entry that gates each library.
+ * @param fs The interpreter file system
+ * @param libName The library name as declared in the `Library` statement (e.g. "Roku_Ads.brs")
+ * @param manifest Map with the manifest data
+ * @returns the library source code, or `undefined` when the name is unknown or the manifest does not require it
+ */
+export function getLibrarySource(fs: FileSystem, libName: string, manifest: Map<string, any>): string | undefined {
+    switch (libName) {
+        case "v30/bslDefender.brs":
+            return fs.readFileSync("common:/LibCore/v30/bslDefender.brs", "utf8");
+        case "v30/bslCore.brs":
+            return fs.readFileSync("common:/LibCore/v30/bslCore.brs", "utf8");
+        case "Roku_Ads.brs":
+            if (manifest.get("bs_libs_required")?.includes("roku_ads_lib")) {
+                return fs.readFileSync("common:/roku_ads/Roku_Ads.brs", "utf8");
+            }
+            return undefined;
+        case "IMA3.brs":
+            if (manifest.get("bs_libs_required")?.includes("googleima3")) {
+                return fs.readFileSync("common:/roku_ads/IMA3.brs", "utf8");
+            }
+            return undefined;
+        case "Roku_Event_Dispatcher.brs":
+            if (manifest.get("sg_component_libs_required")?.includes("roku_analytics")) {
+                return fs.readFileSync("common:/roku_analytics/Roku_Event_Dispatcher.brs", "utf8");
+            }
+            return undefined;
+        case "RokuBrowser.brs":
+            if (manifest.get("bs_libs_required")?.includes("Roku_Browser")) {
+                return fs.readFileSync("common:/roku_browser/RokuBrowser.brs", "utf8");
+            }
+            return undefined;
+        default:
+            return undefined;
+    }
+}
+
+/**
  * Evaluates parsed BrightScript code and add Libraries source
  * @param fs The interpreter file system
  * @param parseResults ParseResults object with the parsed code
@@ -178,41 +217,13 @@ function parseLibraries(
         lib.set("RokuBrowser.brs", "");
     }
     // Check for Libraries and add to the collection
-    if (parseResults.libraries.get("v30/bslDefender.brs") === true && lib.get("v30/bslDefender.brs") === "") {
-        lib.set("v30/bslDefender.brs", fs.readFileSync("common:/LibCore/v30/bslDefender.brs", "utf8"));
-        lib.set("v30/bslCore.brs", fs.readFileSync("common:/LibCore/v30/bslCore.brs", "utf8"));
-    } else if (parseResults.libraries.get("v30/bslCore.brs") === true && lib.get("v30/bslCore.brs") === "") {
-        lib.set("v30/bslCore.brs", fs.readFileSync("common:/LibCore/v30/bslCore.brs", "utf8"));
+    for (const [libName, used] of parseResults.libraries) {
+        if (used && lib.get(libName) === "") {
+            lib.set(libName, getLibrarySource(fs, libName, manifest) ?? "");
+        }
     }
-    if (
-        parseResults.libraries.get("Roku_Ads.brs") === true &&
-        lib.get("Roku_Ads.brs") === "" &&
-        manifest.get("bs_libs_required")?.includes("roku_ads_lib")
-    ) {
-        lib.set("Roku_Ads.brs", fs.readFileSync("common:/roku_ads/Roku_Ads.brs", "utf8"));
-    }
-    if (
-        parseResults.libraries.get("IMA3.brs") === true &&
-        lib.get("IMA3.brs") === "" &&
-        manifest.get("bs_libs_required")?.includes("googleima3")
-    ) {
-        lib.set("IMA3.brs", fs.readFileSync("common:/roku_ads/IMA3.brs", "utf8"));
-    }
-    if (
-        parseResults.libraries.get("Roku_Event_Dispatcher.brs") === true &&
-        lib.get("Roku_Event_Dispatcher.brs") === "" &&
-        manifest.get("sg_component_libs_required")?.includes("roku_analytics")
-    ) {
-        lib.set(
-            "Roku_Event_Dispatcher.brs",
-            fs.readFileSync("common:/roku_analytics/Roku_Event_Dispatcher.brs", "utf8")
-        );
-    }
-    if (
-        parseResults.libraries.get("RokuBrowser.brs") === true &&
-        lib.get("RokuBrowser.brs") === "" &&
-        manifest.get("bs_libs_required")?.includes("Roku_Browser")
-    ) {
-        lib.set("RokuBrowser.brs", fs.readFileSync("common:/roku_browser/RokuBrowser.brs", "utf8"));
+    // bslDefender depends on bslCore, so load it as well
+    if (lib.get("v30/bslDefender.brs") !== "" && lib.get("v30/bslCore.brs") === "") {
+        lib.set("v30/bslCore.brs", getLibrarySource(fs, "v30/bslCore.brs", manifest) ?? "");
     }
 }

--- a/src/core/common/roku_ads/Roku_Ads.brs
+++ b/src/core/common/roku_ads/Roku_Ads.brs
@@ -1,34 +1,137 @@
+' Mock of the Roku Advertising Framework (RAF) library.
+' Mirrors the API surface documented in the Roku developer docs (raf-api), storing
+' configuration and firing tracking callbacks, but never contacting an ad server
+' and never rendering ad UI: getAds() only returns pods imported by the app, and
+' showAds()/renderStitchedStream() report completed playback without rendering.
 function Roku_Ads() as object
-    this = {adurl:""}
-    this.setAdUrl = sub(url="")
+    ' The RAF object has global scope on Roku: every call returns the same instance,
+    ' so wrappers/flags apps attach to it must survive re-fetching the library.
+    globalAA = GetGlobalAA()
+    if globalAA["__roku_ads_instance"] <> invalid
+        return globalAA["__roku_ads_instance"]
+    end if
+    this = {adurl: "", adpods: []}
+
+    ' Control
+    this.fireTrackingEvents = function(adStructure = invalid, ctx = invalid) as boolean
+        if m.trackingcallback <> invalid
+            evtType = invalid
+            if ctx <> invalid and ctx.type <> invalid
+                evtType = ctx.type
+            end if
+            m.trackingcallback(m.trackingobj, evtType, ctx)
+        end if
+        return true
+    end function
+    this.getAds = function(msg = invalid) as dynamic
+        if msg <> invalid
+            ' Event-listener mode: no midroll/postroll pods are ever scheduled by the mock
+            return invalid
+        end if
+        return m.adpods
+    end function
+    this.showAds = function(ads, ctx = invalid, view = invalid) as boolean
+        return true
+    end function
+
+    ' Configuration
+    this.setAdUrl = sub(url = "")
         m.adurl = url
     end sub
     this.getAdUrl = function() as string
         return m.adurl
     end function
-    this.getAds = function(msg=invalid) as object
-        return {}
+    this.setAdPrefs = sub(useRokuAdsAsFallback = true, maxRequests = 0)
+    end sub
+    this.setAdConstraints = sub(maxHeight = 0, maxWidth = 0, maxBitrate = 0, supportedMimeTypes = invalid)
+    end sub
+    this.setAdBreaks = sub(contentLength = 0, adBreakTimes = invalid)
+    end sub
+    this.setAdExit = sub(enabled = true)
+        ' deprecated and disabled on Roku - check showAds() return value instead
+    end sub
+    this.importAds = sub(adPodArray = invalid)
+        if adPodArray <> invalid
+            m.adpods = adPodArray
+        else
+            m.adpods = []
+        end if
+    end sub
+    this.enableJITPods = sub(enabled = false)
+    end sub
+    this.enableInPodStitching = sub(isIPS = false)
+    end sub
+    this.setLimitAdTracking = sub(enabled = false)
+    end sub
+    this.setTrackingCallback = sub(callback = invalid, obj = invalid)
+        m.trackingcallback = callback
+        m.trackingobj = obj
+    end sub
+    this.setDebugOutput = sub(enabled = false)
+    end sub
+    this.getLibVersion = function() as string
+        return "3.5"
     end function
-    this.showAds = function(ads,ctx=invalid,view=invalid) as boolean
-        return true
-    end function
-    this.setContentId = sub(id="")
+
+    ' General audience measurement
+    this.enableAdMeasurements = sub(enabled = false)
+    end sub
+    this.setContentGenre = sub(genres = invalid, kidsContent = false)
+    end sub
+    this.setContentId = sub(id = "")
     end sub
     this.setContentLength = sub(length = 0)
     end sub
-    this.setContentGenre = sub(genres=invalid,kids=false)
+
+    ' Nielsen DAR (deprecated on Roku, kept because existing apps still call them)
+    this.enableNielsenDAR = sub(enabled = false)
     end sub
-    this.setAdExit = sub(allow)
+    this.setNielsenGenre = sub(genre = "")
     end sub
-    this.setDebugOutput = sub(enable)
+    this.setNielsenAppId = sub(id = "")
     end sub
-    this.enableAdMeasurements = sub(enable)
+    this.setNielsenProgramId = sub(id = "")
     end sub
-    this.setAdBufferScreenLayer = sub(zOrder,content)
+
+    ' Nielsen DCR
+    this.getNielsenContentData = function() as string
+        return ""
+    end function
+
+    ' Client stitched ads
+    this.constructStitchedStream = function(contentMetaData = invalid, ads = invalid) as dynamic
+        ' No stitching in the mock: the "stitched" stream is the content itself, ad-free
+        return contentMetaData
+    end function
+    this.renderStitchedStream = function(csasStream = invalid, view = invalid) as boolean
+        return true
+    end function
+
+    ' Server stitched ads
+    this.stitchedAdsInit = sub(adPodArray = invalid)
+        if adPodArray <> invalid
+            m.adpods = adPodArray
+        else
+            m.adpods = []
+        end if
     end sub
-    this.enableAdBufferMessaging = sub(enableMsg, enablePB)
+    this.stitchedAdHandledEvent = function(msg = invalid, player = invalid) as dynamic
+        ' No stitched ad is ever being rendered by the mock
+        return invalid
+    end function
+
+    ' Buffer screen customization
+    this.setAdBufferScreenContent = sub(contentMetaData = invalid)
     end sub
-    this.setAdPrefs = sub(useRokuAdsAsFallback, maxRequests)
+    this.enableAdBufferMessaging = sub(enableMsg = true, enableProgressBar = true)
     end sub
+    this.setAdBufferScreenLayer = sub(zOrder = 0, contentMetaData = invalid)
+    end sub
+    this.clearAdBufferScreenLayers = sub()
+    end sub
+    this.setAdBufferRenderCallback = sub(callback = invalid, obj = invalid, timeout = 0)
+    end sub
+
+    globalAA["__roku_ads_instance"] = this
     return this
 end function

--- a/src/extensions/scenegraph/parser/ComponentScopeResolver.ts
+++ b/src/extensions/scenegraph/parser/ComponentScopeResolver.ts
@@ -1,4 +1,4 @@
-import { Lexer, logError, Parser, preprocessor as PP, Stmt, FileSystem } from "brs-engine";
+import { getLibrarySource, Lexer, logError, Parser, preprocessor as PP, Stmt, FileSystem } from "brs-engine";
 import { ComponentDefinition, ComponentScript } from "./ComponentDefinition";
 import { SGNodeFactory } from "../factory/NodeFactory";
 import * as path from "path";
@@ -10,6 +10,8 @@ import * as path from "path";
 export class ComponentScopeResolver {
     private readonly excludedNames: string[] = ["init"];
     private readonly parserLexerFn: (scripts: ComponentScript[]) => Stmt.Statement[];
+    /** Parsed library function statements, keyed by library name — each library is parsed once per app. */
+    private readonly memoizedLibraries = new Map<string, Stmt.Function[]>();
 
     /**
      * @param componentMap Component definition map to reference for function resolution.
@@ -18,8 +20,8 @@ export class ComponentScopeResolver {
      */
     constructor(
         readonly componentMap: Map<string, ComponentDefinition>,
-        fs: FileSystem,
-        manifest: Map<string, string>
+        private readonly fs: FileSystem,
+        private readonly manifest: Map<string, string>
     ) {
         this.parserLexerFn = this.getLexerParserFn(fs, manifest);
     }
@@ -31,7 +33,57 @@ export class ComponentScopeResolver {
      */
     public resolve(component: ComponentDefinition): Stmt.Statement[] {
         const statementMap = Array.from(this.getStatements(component));
-        return this.flatten(statementMap);
+        return this.flatten(statementMap, this.getDeclaredLibraries(statementMap));
+    }
+
+    /**
+     * Collects the names of BrightScript libraries declared via `Library` statements
+     * in any script of the component hierarchy.
+     * @param statementMap Statement collections broken up by component.
+     * @returns The set of declared library names.
+     */
+    private getDeclaredLibraries(statementMap: Stmt.Statement[][]): Set<string> {
+        const libraryNames = new Set<string>();
+        for (const statements of statementMap) {
+            for (const statement of statements) {
+                const filePath = statement instanceof Stmt.Library ? statement.tokens.filePath : undefined;
+                if (filePath) {
+                    libraryNames.add(filePath.text.slice(1, filePath.text.length - 1));
+                }
+            }
+        }
+        // bslDefender depends on bslCore, so load it as well
+        if (libraryNames.has("v30/bslDefender.brs")) {
+            libraryNames.add("v30/bslCore.brs");
+        }
+        return libraryNames;
+    }
+
+    /**
+     * Loads and parses a BrightScript library, keeping only its function definitions.
+     * Results are memoized so each library is lexed/parsed at most once per resolver.
+     * @param libName The library name as declared in the `Library` statement.
+     * @returns The library's function statements (empty when unknown or not required by the manifest).
+     */
+    private getLibraryFunctions(libName: string): Stmt.Function[] {
+        let functions = this.memoizedLibraries.get(libName);
+        if (!functions) {
+            functions = [];
+            const source = getLibrarySource(this.fs, libName, this.manifest);
+            if (source !== undefined) {
+                const lexer = new Lexer();
+                const parser = new Parser();
+                lexer.onError(logError);
+                parser.onError(logError);
+                const scanResults = lexer.scan(source, libName);
+                const parseResults = parser.parse(scanResults.tokens);
+                functions = parseResults.statements.filter(
+                    (statement): statement is Stmt.Function => statement instanceof Stmt.Function
+                );
+            }
+            this.memoizedLibraries.set(libName, functions);
+        }
+        return functions;
     }
 
     /**
@@ -40,9 +92,10 @@ export class ComponentScopeResolver {
      * given in the statement map are in order of hierarchy with the furthest
      * inheriting component first.
      * @param statementMap Statement collections broken up by component.
+     * @param libraryNames Names of libraries declared by the hierarchy's scripts.
      * @returns A collection of statements that have been flattened based on hierarchy.
      */
-    private flatten(statementMap: Stmt.Statement[][]): Stmt.Statement[] {
+    private flatten(statementMap: Stmt.Statement[][], libraryNames: Set<string>): Stmt.Statement[] {
         const isFunction = (statement: Stmt.Statement): statement is Stmt.Function =>
             statement instanceof Stmt.Function;
         // Component scripts only contribute their function definitions to the component's scope;
@@ -61,6 +114,17 @@ export class ComponentScopeResolver {
                     return !haveFnName && !this.excludedNames.includes(statementName);
                 })
             );
+        }
+        // Append the functions of any `Library` declared by the hierarchy's scripts;
+        // functions defined by the components themselves take precedence.
+        for (const libName of libraryNames) {
+            for (const libFunction of this.getLibraryFunctions(libName)) {
+                const functionName = libFunction.name.text.toLowerCase();
+                if (!statementMemo.has(functionName)) {
+                    statementMemo.add(functionName);
+                    statements.push(libFunction);
+                }
+            }
         }
         return statements;
     }

--- a/src/extensions/scenegraph/parser/ComponentScopeResolver.ts
+++ b/src/extensions/scenegraph/parser/ComponentScopeResolver.ts
@@ -48,7 +48,7 @@ export class ComponentScopeResolver {
             for (const statement of statements) {
                 const filePath = statement instanceof Stmt.Library ? statement.tokens.filePath : undefined;
                 if (filePath) {
-                    libraryNames.add(filePath.text.slice(1, filePath.text.length - 1));
+                    libraryNames.add(filePath.text.slice(1, -1));
                 }
             }
         }

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -615,6 +615,29 @@ describe("cli", () => {
         expect(stderr).toContain('Attempt to add duplicate field "sharedField" to RokuML component "XmlChildComp"');
     }, 10000);
 
+    it("Loads Library statements declared in component scripts into the component scope", async () => {
+        let command = ["node", brsCliPath, "-r component-library-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        // A `Library` statement in a component <script> must load the library's functions
+        // into that component's scope (Roku_Ads is required by the manifest), while the
+        // manifest gate still keeps out declared-but-not-required libraries (IMA3).
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "=== Component Library Repro ===",
+            "rafType = roAssociativeArray",
+            "adUrl = http://ads.example.com/preroll",
+            "podCount =  1",
+            "libVersion = 3.5",
+            "imaLoaded = not loaded",
+            "=== Component Library Repro Complete ===",
+            "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+    }, 10000);
+
     it("Guards bounding-rect refresh renders against re-entrant measurement", async () => {
         let command = ["node", brsCliPath, "-r grid-measure-app", "source/main.brs", "-c 0"].join(" ");
 

--- a/test/cli/resources/component-library-app/components/AdsComponent.brs
+++ b/test/cli/resources/component-library-app/components/AdsComponent.brs
@@ -1,0 +1,26 @@
+Library "Roku_Ads.brs"
+Library "IMA3.brs"
+
+sub init()
+    ' Roku_Ads is gated by bs_libs_required=roku_ads_lib, which the manifest has.
+    raf = Roku_Ads()
+    m.top.rafType = type(raf)
+    raf.setAdUrl("http://ads.example.com/preroll")
+    raf.importAds([{ads: [{id: "ad1"}]}])
+
+    ' RAF is a singleton on Roku: a fresh Roku_Ads() call must return the same
+    ' instance, seeing the URL and ad pods configured above.
+    raf2 = Roku_Ads()
+    m.top.adUrl = raf2.getAdUrl()
+    m.top.podCount = raf2.getAds().count()
+    m.top.libVersion = raf2.getLibVersion()
+
+    ' IMA3 is gated by bs_libs_required=googleima3, which the manifest does NOT have,
+    ' so its functions must not resolve even though the Library statement is present.
+    try
+        sdk = New_IMASDK()
+        m.top.imaLoaded = "loaded"
+    catch e
+        m.top.imaLoaded = "not loaded"
+    end try
+end sub

--- a/test/cli/resources/component-library-app/components/AdsComponent.xml
+++ b/test/cli/resources/component-library-app/components/AdsComponent.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Declares `Library "Roku_Ads.brs"` (required by the manifest, so it must load into
+    this component's scope) and `Library "IMA3.brs"` (NOT required by the manifest, so
+    the gate must keep it out even though the statement is present).
+-->
+<component name="AdsComponent" extends="Group">
+    <interface>
+        <field id="rafType" type="string" />
+        <field id="adUrl" type="string" />
+        <field id="podCount" type="integer" />
+        <field id="libVersion" type="string" />
+        <field id="imaLoaded" type="string" />
+    </interface>
+    <script type="text/brightscript" uri="pkg:/components/AdsComponent.brs" />
+</component>

--- a/test/cli/resources/component-library-app/manifest
+++ b/test/cli/resources/component-library-app/manifest
@@ -1,0 +1,5 @@
+title=Component Library Test
+major_version=1
+minor_version=0
+build_version=0
+bs_libs_required=roku_ads_lib

--- a/test/cli/resources/component-library-app/source/main.brs
+++ b/test/cli/resources/component-library-app/source/main.brs
@@ -1,0 +1,16 @@
+sub Main()
+    print "=== Component Library Repro ==="
+
+    ' A `Library` statement inside a component <script> must load the library's
+    ' functions into that component's scope (matching Roku), gated by the same
+    ' manifest entries as main-scope libraries. Before the fix the statement was
+    ' parsed and discarded, so Roku_Ads() was undefined inside the component.
+    node = CreateObject("roSGNode", "AdsComponent")
+    print "rafType = "; node.rafType
+    print "adUrl = "; node.adUrl
+    print "podCount = "; node.podCount
+    print "libVersion = "; node.libVersion
+    print "imaLoaded = "; node.imaLoaded
+
+    print "=== Component Library Repro Complete ==="
+end sub


### PR DESCRIPTION
## Problem

BrightScript libraries were only loaded for `Library` statements in `pkg:/source` files. In SceneGraph component scripts the statement was parsed and then discarded: `ComponentScopeResolver.flatten()` keeps only function definitions, so the library source was never injected into the component's sub-environment and calls like `Roku_Ads()` failed at runtime — even with the correct `bs_libs_required` manifest entry and `Library` declaration in place. On a real Roku, a `Library` statement in a component `<script>` loads the library's functions into that component's scope.

Additionally, the `common:/roku_ads/Roku_Ads.brs` mock only covered a fraction of the documented RAF API, so apps exercising the fuller surface (tracking callbacks, stitched-ad flows, Nielsen, buffer-screen customization) hit missing members.

## Fix

**Library loading (`src/core/LexerParser.ts`, `src/extensions/scenegraph/parser/ComponentScopeResolver.ts`)**
- Extracted the library-name → `common:/` source resolution (with each library's manifest gate) from `parseLibraries` into an exported `getLibrarySource()`, shared by both paths so they can't drift.
- `ComponentScopeResolver.resolve()` now collects `Stmt.Library` declarations across the `extends` hierarchy (per-script attribution — the parser's own flags map is shared/global), parses each required library once per app (memoized), and appends its functions to the component scope. Component-defined functions win name collisions, and `bslDefender` pulls in `bslCore`, matching main-scope behavior. Task threads are covered since they reuse the same sub-environments built by `setupInterpreterWithSubEnvs`.

**RAF mock (`src/core/common/roku_ads/Roku_Ads.brs`)**
- Implements every method documented in Roku's RAF API reference, grouped by the spec's sections, plus the deprecated Nielsen DAR methods that existing apps still call (no-ops).
- `Roku_Ads()` is now a singleton via `GetGlobalAA()`, matching the documented global scope of the RAF object — wrappers/flags apps attach to the instance persist across re-fetches.
- Stateful methods behave faithfully: `importAds`/`stitchedAdsInit` feed `getAds()` (an array, or `invalid` in the event-listener form), `fireTrackingEvents` invokes the `setTrackingCallback` callback, and `showAds`/`renderStitchedStream` report completed playback; `getLibVersion()` returns `"3.5"`.

## Tests

- New `component-library-app` regression in `test/cli/cli.test.js`: proves a component-script `Library` resolves in the component scope, the manifest gate still keeps out declared-but-not-required libraries, and the RAF mock's singleton / `importAds` → `getAds` round-trip / `getLibVersion` work.
- Full suite: 154 suites, 2064 tests green; lint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)