### PR TITLE
fix(rsg): reparent a node when it is attached to a different parent

### DIFF
--- a/src/extensions/scenegraph/nodes/ContentNode.ts
+++ b/src/extensions/scenegraph/nodes/ContentNode.ts
@@ -179,6 +179,7 @@ export class ContentNode extends Node {
         if (child instanceof ContentNode) {
             success = true;
             if (!this.children.includes(child)) {
+                this.detachFromCurrentParent(child);
                 appendedIndex = this.children.length;
                 this.children.push(child);
                 child.setNodeParent(this);

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -1564,6 +1564,18 @@ export class Node extends RoSGNode implements BrsValue {
     }
 
     /**
+     * Detaches a child from its current parent before attaching it elsewhere.
+     * Roku nodes have exactly one parent: appendChild/insertChild/replaceChild reparent implicitly.
+     * @param child Child about to be attached to this node.
+     */
+    protected detachFromCurrentParent(child: Node) {
+        const oldParent = child.getNodeParent();
+        if (oldParent instanceof RoSGNode && oldParent !== this) {
+            oldParent.removeChildByReference(child);
+        }
+    }
+
+    /**
      * Removes a contiguous range of children starting at the provided index.
      * @param index Start index.
      * @param count Number of children to remove.
@@ -1594,6 +1606,7 @@ export class Node extends RoSGNode implements BrsValue {
             if (this.children.includes(child)) {
                 return true;
             }
+            this.detachFromCurrentParent(child);
             const insertionIndex = this.children.length;
             this.children.push(child);
             child.setNodeParent(this);
@@ -1630,6 +1643,7 @@ export class Node extends RoSGNode implements BrsValue {
         if (oldChild instanceof Node) {
             oldChild.removeParent();
         }
+        this.detachFromCurrentParent(newChild);
         newChild.setNodeParent(this);
         this.children.splice(index, 1, newChild);
         this.makeDirty();
@@ -1668,6 +1682,7 @@ export class Node extends RoSGNode implements BrsValue {
             this.recordChildChange("insert", index, index);
             return true;
         }
+        this.detachFromCurrentParent(child);
         child.setNodeParent(this);
         this.children.splice(index, 0, child);
         this.makeDirty();

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -615,6 +615,35 @@ describe("cli", () => {
         expect(stderr).toContain('Attempt to add duplicate field "sharedField" to RokuML component "XmlChildComp"');
     }, 10000);
 
+    it("Reparents a node when it is attached to a different parent", async () => {
+        let command = ["node", brsCliPath, "-r reparent-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        // On Roku a node has exactly one parent: appendChild/insertChild/replaceChild detach the
+        // node from its previous parent. Before the fix the old parent kept the node in its
+        // children array, so the render traversal drew the subtree twice — once inside the new
+        // (translated) container and once at the node's raw position under the old parent.
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "=== Reparent Repro ===",
+            "root child count =  1",
+            "inner child count =  1",
+            "moved parent is inner = true",
+            "a child count =  0",
+            "b child count =  1",
+            "c parent is b = true",
+            "b child count after insert =  0",
+            "c parent is d = true",
+            "d child count after replace =  0",
+            "c parent is e = true",
+            "=== Reparent Repro Complete ===",
+            "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+    }, 10000);
+
     it("Loads Library statements declared in component scripts into the component scope", async () => {
         let command = ["node", brsCliPath, "-r component-library-app", "source/main.brs", "-c 0"].join(" ");
 

--- a/test/cli/resources/reparent-app/components/ReparentComp.xml
+++ b/test/cli/resources/reparent-app/components/ReparentComp.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Moves an XML-declared child into a translated inner container during init(),
+    relying on appendChild's implicit reparent (a node has exactly one parent on Roku).
+    Before the fix the moved node stayed attached to BOTH parents and rendered twice:
+    once inside the translated container and once at its raw XML position.
+-->
+<component name="ReparentComp" extends="Group">
+    <script type="text/brightscript">
+        <![CDATA[
+        sub init()
+            m.top.findNode("innerGroup").appendChild(m.top.findNode("movedGroup"))
+        end sub
+        ]]>
+    </script>
+    <children>
+        <Group id="movedGroup" translation="[100, 0]" />
+        <Group id="innerGroup" translation="[0, 200]" />
+    </children>
+</component>

--- a/test/cli/resources/reparent-app/manifest
+++ b/test/cli/resources/reparent-app/manifest
@@ -1,0 +1,4 @@
+title=Reparent Test
+major_version=1
+minor_version=0
+build_version=0

--- a/test/cli/resources/reparent-app/source/main.brs
+++ b/test/cli/resources/reparent-app/source/main.brs
@@ -1,0 +1,36 @@
+sub Main()
+    print "=== Reparent Repro ==="
+
+    ' A component that moves an XML-declared child into an inner container in init():
+    ' after the move the root must no longer hold the node (single-parent invariant),
+    ' otherwise the render traversal draws the subtree twice.
+    node = CreateObject("roSGNode", "ReparentComp")
+    moved = node.findNode("movedGroup")
+    inner = node.findNode("innerGroup")
+    print "root child count = "; node.getChildCount()
+    print "inner child count = "; inner.getChildCount()
+    print "moved parent is inner = "; moved.getParent().isSameNode(inner)
+
+    ' Plain appendChild between two parents must also reparent.
+    a = CreateObject("roSGNode", "Group")
+    b = CreateObject("roSGNode", "Group")
+    c = CreateObject("roSGNode", "Group")
+    a.appendChild(c)
+    b.appendChild(c)
+    print "a child count = "; a.getChildCount()
+    print "b child count = "; b.getChildCount()
+    print "c parent is b = "; c.getParent().isSameNode(b)
+
+    ' insertChild and replaceChild follow the same single-parent rule.
+    d = CreateObject("roSGNode", "Group")
+    d.insertChild(c, 0)
+    print "b child count after insert = "; b.getChildCount()
+    print "c parent is d = "; c.getParent().isSameNode(d)
+    e = CreateObject("roSGNode", "Group")
+    e.appendChild(CreateObject("roSGNode", "Group"))
+    e.replaceChild(c, 0)
+    print "d child count after replace = "; d.getChildCount()
+    print "c parent is e = "; c.getParent().isSameNode(e)
+
+    print "=== Reparent Repro Complete ==="
+end sub

--- a/test/extensions/scenegraph/Reparent.test.js
+++ b/test/extensions/scenegraph/Reparent.test.js
@@ -1,0 +1,93 @@
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { Node, ContentNode } = scenegraph;
+const { BrsInvalid } = core;
+
+describe("attaching a node that already has a parent reparents it (single-parent invariant)", () => {
+    test("appendChildToParent detaches the child from its previous parent", () => {
+        // Mirrors moving an XML-declared child into another container via appendChild in init():
+        // on Roku a node has exactly one parent, so the old parent must not keep (and render) it.
+        const oldParent = new Node([], "Group");
+        const newParent = new Node([], "Group");
+        const child = new Node([], "Group");
+
+        oldParent.appendChildToParent(child);
+        expect(oldParent.getNodeChildren()).toContain(child);
+
+        newParent.appendChildToParent(child);
+        expect(oldParent.getNodeChildren()).not.toContain(child);
+        expect(oldParent.getNodeChildren()).toHaveLength(0);
+        expect(newParent.getNodeChildren()).toEqual([child]);
+        expect(child.getNodeParent()).toBe(newParent);
+    });
+
+    test("insertChildAtIndex detaches the child from its previous parent", () => {
+        const oldParent = new Node([], "Group");
+        const newParent = new Node([], "Group");
+        const sibling = new Node([], "Group");
+        const child = new Node([], "Group");
+
+        oldParent.appendChildToParent(child);
+        newParent.appendChildToParent(sibling);
+
+        newParent.insertChildAtIndex(child, 0);
+        expect(oldParent.getNodeChildren()).toHaveLength(0);
+        expect(newParent.getNodeChildren()).toEqual([child, sibling]);
+        expect(child.getNodeParent()).toBe(newParent);
+    });
+
+    test("replaceChildAtIndex detaches the new child from its previous parent", () => {
+        const oldParent = new Node([], "Group");
+        const newParent = new Node([], "Group");
+        const placeholder = new Node([], "Group");
+        const child = new Node([], "Group");
+
+        oldParent.appendChildToParent(child);
+        newParent.appendChildToParent(placeholder);
+
+        newParent.replaceChildAtIndex(child, 0);
+        expect(oldParent.getNodeChildren()).toHaveLength(0);
+        expect(newParent.getNodeChildren()).toEqual([child]);
+        expect(child.getNodeParent()).toBe(newParent);
+        expect(placeholder.getNodeParent()).toBe(BrsInvalid.Instance);
+    });
+
+    test("same-parent append stays a no-op and keeps child order", () => {
+        const parent = new Node([], "Group");
+        const first = new Node([], "Group");
+        const second = new Node([], "Group");
+
+        parent.appendChildToParent(first);
+        parent.appendChildToParent(second);
+        parent.appendChildToParent(first);
+        expect(parent.getNodeChildren()).toEqual([first, second]);
+        expect(first.getNodeParent()).toBe(parent);
+    });
+
+    test("same-parent insert still reorders without duplication", () => {
+        const parent = new Node([], "Group");
+        const first = new Node([], "Group");
+        const second = new Node([], "Group");
+
+        parent.appendChildToParent(first);
+        parent.appendChildToParent(second);
+        parent.insertChildAtIndex(second, 0);
+        expect(parent.getNodeChildren()).toEqual([second, first]);
+        expect(second.getNodeParent()).toBe(parent);
+    });
+
+    test("ContentNode append detaches from the previous ContentNode parent", () => {
+        const oldParent = new ContentNode();
+        const newParent = new ContentNode();
+        const child = new ContentNode();
+
+        oldParent.appendChildToParent(child);
+        expect(oldParent.getNodeChildren()).toContain(child);
+
+        newParent.appendChildToParent(child);
+        expect(oldParent.getNodeChildren()).not.toContain(child);
+        expect(newParent.getNodeChildren()).toEqual([child]);
+        expect(child.getNodeParent()).toBe(newParent);
+    });
+});


### PR DESCRIPTION
## Problem

On Roku a SceneGraph node has exactly one parent: `appendChild`, `insertChild`, and `replaceChild` implicitly reparent the node, detaching it from its previous parent. The engine did not do this — it overwrote the child's parent pointer but left the node in the old parent's `children` array. Because the render traversal iterates each parent's `children` array, the subtree was drawn **twice**: once under the new (translated) container and once at its raw position under the old parent.

This surfaced in components that move an XML-declared child into another container in `init()` (a common pattern): the detail screen rendered its content duplicated, with the stray copy aligned to the top of the screen at the child's untranslated position.

## Fix

A small `detachFromCurrentParent` helper in `Node.ts` removes a child from its current parent before it is attached elsewhere — the same detach-then-attach pattern the `reparent()` callable already used. It is called from the three attachment paths (`appendChildToParent`, `insertChildAtIndex`, `replaceChildAtIndex`) and the `ContentNode.appendChildToParent` override.

Unchanged:
- The focus-chain repair in `setNodeParent` still runs after every attach.
- Same-parent append stays a no-op; same-parent insert still reorders.
- `NodeFactory` `setNodeParent` sites remain guarded by their existing parentless checks.

## Tests

- `test/extensions/scenegraph/Reparent.test.js` — cross-parent append/insert/replace detach the node from the old parent, same-parent append/insert keep their existing semantics, plus a `ContentNode` variant.
- `test/cli/resources/reparent-app` + a CLI regression case reproducing the move-XML-child-in-`init()` pattern and asserting the old parent no longer holds the node.

Full suite green (155 suites, 2071 tests); lint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)