### PR TITLE
fix(rsg): ButtonBar sample — RowList fit check, LayoutGroup re-alignment, single-row grid key propagation

### DIFF
--- a/src/extensions/scenegraph/nodes/LayoutGroup.ts
+++ b/src/extensions/scenegraph/nodes/LayoutGroup.ts
@@ -1,4 +1,4 @@
-import { AAMember, Interpreter, BrsBoolean, BrsType, Float, RoArray, IfDraw2D } from "brs-engine";
+import { AAMember, Interpreter, BrsBoolean, BrsType, Float, RoArray, IfDraw2D, Rect } from "brs-engine";
 import { FieldKind, FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";
 import { jsValueOf } from "../factory/Serializer";
@@ -35,6 +35,11 @@ export class LayoutGroup extends Group {
     private layoutDirty = true;
     private metricsUsedThisPass?: WeakMap<Node, LayoutMetrics>;
     private readonly childSizes = new WeakMap<Node, NodeSize>();
+    // Translation applyLayout last assigned to each child. The LayoutGroup owns its children's
+    // managed-axis positions, so if a child's translation drifts from this (e.g. an app writes a
+    // child's translation directly after layout, as SGDEX ButtonBar does to its label), re-layout
+    // must run to re-impose the aligned position — a translation change alone does not dirty layout.
+    private readonly assignedTranslations = new WeakMap<Node, number[]>();
     private lastSpacingSignature = "";
     private lastChildCount = 0;
     private readonly epsilon = 0.25;
@@ -97,6 +102,23 @@ export class LayoutGroup extends Group {
         if (layoutChildren.length !== this.lastChildCount) {
             this.lastChildCount = layoutChildren.length;
             this.layoutDirty = true;
+        }
+
+        // Re-layout if any child's translation drifted from what applyLayout last assigned it — an
+        // external write to a managed child's translation would otherwise persist, since a translation
+        // change does not dirty layout on its own.
+        if (!this.layoutDirty) {
+            for (const child of layoutChildren) {
+                const assigned = this.assignedTranslations.get(child);
+                if (!assigned) {
+                    continue;
+                }
+                const current = this.getChildTranslation(child);
+                if (!this.nearlyEqual(assigned[0], current[0]) || !this.nearlyEqual(assigned[1], current[1])) {
+                    this.layoutDirty = true;
+                    break;
+                }
+            }
         }
 
         const addAfter = this.shouldAddSpacingAfterChild();
@@ -185,6 +207,7 @@ export class LayoutGroup extends Group {
             }
 
             this.setChildTranslation(child, translation);
+            this.assignedTranslations.set(child, translation.slice());
 
             currentOffset = positionOffset + metrics.primary;
             if (addSpacingAfterChild && i < childCount - 1) {
@@ -256,12 +279,28 @@ export class LayoutGroup extends Group {
         direction: LayoutDirection,
         metricsMap?: WeakMap<Node, LayoutMetrics>
     ): LayoutMetrics {
-        const rect = this.chooseActiveRect(child);
+        const { rect, cached } = this.chooseActiveRect(child);
+        let originX = rect.x;
+        let originY = rect.y;
+        // A cached rect's origin reflects the translation applyLayout assigned last time (the child
+        // rendered there), NOT the child's current translation. If the app has since moved the child,
+        // shift the measured origin by that drift so applyLayout positions from the CURRENT translation
+        // plus the child's intrinsic offset — otherwise the delta-based positioning below leaves the
+        // child at the app's translation on the managed axes (e.g. a ButtonBar label stuck low). The
+        // fallback rect already uses the current translation, so it needs no shift.
+        if (cached) {
+            const assigned = this.assignedTranslations.get(child);
+            if (assigned) {
+                const current = this.getChildTranslation(child);
+                originX += current[0] - assigned[0];
+                originY += current[1] - assigned[1];
+            }
+        }
         const metrics: LayoutMetrics = {
             primary: direction === "horiz" ? rect.width : rect.height,
             cross: direction === "horiz" ? rect.height : rect.width,
-            crossStart: direction === "horiz" ? rect.y : rect.x,
-            primaryStart: direction === "horiz" ? rect.x : rect.y,
+            crossStart: direction === "horiz" ? originY : originX,
+            primaryStart: direction === "horiz" ? originX : originY,
         };
 
         if (metricsMap) {
@@ -271,7 +310,7 @@ export class LayoutGroup extends Group {
         return metrics;
     }
 
-    private chooseActiveRect(child: Group) {
+    private chooseActiveRect(child: Group): { rect: Rect; cached: boolean } {
         const candidates = [child.rectToParent, child.rectToScene, child.rectLocal];
         for (const rect of candidates) {
             if (
@@ -282,7 +321,7 @@ export class LayoutGroup extends Group {
                 rect.width > 0 &&
                 rect.height > 0
             ) {
-                return rect;
+                return { rect, cached: true };
             }
         }
 
@@ -290,12 +329,13 @@ export class LayoutGroup extends Group {
         const dims = child.getDimensions();
         const cached = this.childSizes.get(child);
 
-        return {
+        const rect = {
             x: translation[0],
             y: translation[1],
             width: typeof dims.width === "number" && dims.width > 0 ? dims.width : cached?.width ?? 0,
             height: typeof dims.height === "number" && dims.height > 0 ? dims.height : cached?.height ?? 0,
         };
+        return { rect, cached: false };
     }
 
     private calculateTotalPrimary(metricsList: LayoutMetrics[], spacings: number[], addAfter: boolean) {

--- a/src/extensions/scenegraph/nodes/RowList.ts
+++ b/src/extensions/scenegraph/nodes/RowList.ts
@@ -189,10 +189,8 @@ export class RowList extends ArrayGrid {
 
         const spacing = this.getRowItemSpacing(rowIndex); // Use the actual row's spacing
         const rowItemWidth = this.getRowItemWidth(rowIndex);
-        const cols = this.content[rowIndex]?.getNodeChildren();
-        const numCols = cols?.length ?? 0;
-        const totalRowWidth = numCols * rowItemWidth + (numCols - 1) * spacing[0];
-        const allItemsFitOnScreen = totalRowWidth <= this.sceneRect.width;
+        const cols = this.getContentChildren(this.content[rowIndex]);
+        const allItemsFitOnScreen = this.allItemsFitOnScreen(rowIndex, cols);
 
         // Adjust scroll offset based on animation style
         if (allItemsFitOnScreen && rowFocusStyle !== RowFocusStyle.Fixed) {
@@ -358,8 +356,8 @@ export class RowList extends ArrayGrid {
     protected handleLeftRight(key: string) {
         const offset = key === "left" ? -1 : 1;
         const currentRow = this.focusIndex;
-        const cols = this.content[currentRow]?.getNodeChildren();
-        const numCols = cols?.length ?? 0;
+        const cols = this.getContentChildren(this.content[currentRow]);
+        const numCols = cols.length;
 
         if (numCols <= 1) {
             return false;
@@ -368,7 +366,7 @@ export class RowList extends ArrayGrid {
         this.rowScrollOffset[currentRow] ??= 0;
 
         const rowItemWidth = this.getRowItemWidth(currentRow);
-        const allItemsFitOnScreen = this.checkIfAllItemsFitOnScreen(numCols, rowItemWidth);
+        const allItemsFitOnScreen = this.allItemsFitOnScreen(currentRow, cols);
         const rowFocusStyle = (this.getValueJS("rowFocusAnimationStyle") as string).toLowerCase();
 
         if (allItemsFitOnScreen && rowFocusStyle !== RowFocusStyle.Fixed) {
@@ -479,11 +477,30 @@ export class RowList extends ArrayGrid {
         return this.resolveVector(this.getValueJS("rowItemSpacing"), rowIndex, fallback);
     }
 
-    private checkIfAllItemsFitOnScreen(numCols: number, rowItemWidth: number): boolean {
-        // Use the focused row's spacing (this.focusIndex is the absolute row index)
-        const spacing = this.getRowItemSpacing(this.focusIndex);
-        const totalRowWidth = numCols * rowItemWidth + (numCols - 1) * spacing[0];
-        return totalRowWidth <= this.sceneRect.width;
+    /**
+     * Total laid-out width of a row's items plus inter-item spacing. For variable-width rows this sums
+     * each item's actual width (`getItemWidth`, which resolves the item's `[res]ItemWidth`) instead of
+     * `numCols * rowItemSize.x` — an app can set `rowItemSize.x` to the whole row/bar width (e.g. SGDEX
+     * ButtonBar) while the individual buttons are far narrower, so the uniform estimate hugely
+     * overshoots and makes the list think its items don't fit. Reduces to the uniform formula for
+     * non-variable rows.
+     */
+    private getTotalRowWidth(rowIndex: number, cols: ContentNode[]): number {
+        const numCols = cols.length;
+        if (numCols === 0) {
+            return 0;
+        }
+        const spacing = this.getRowItemSpacing(rowIndex);
+        const rowItemWidth = this.getRowItemWidth(rowIndex);
+        let total = (numCols - 1) * spacing[0];
+        for (let c = 0; c < numCols; c++) {
+            total += this.getItemWidth(rowIndex, c, cols, rowItemWidth);
+        }
+        return total;
+    }
+
+    private allItemsFitOnScreen(rowIndex: number, cols: ContentNode[]): boolean {
+        return this.getTotalRowWidth(rowIndex, cols) <= this.sceneRect.width;
     }
 
     private handleAllItemsFit(currentRow: number, numCols: number, offset: number): boolean {
@@ -745,7 +762,7 @@ export class RowList extends ArrayGrid {
                 height: this.sceneRect.height,
             });
         }
-        this.renderRowContent(rowIndex, cols, numCols, context.rowItemWidth, spacing, context.itemRect, context);
+        this.renderRowContent(rowIndex, cols, context.rowItemWidth, spacing, context.itemRect, context);
         if (clip) {
             context.draw2D?.popClip();
         }
@@ -777,14 +794,12 @@ export class RowList extends ArrayGrid {
     private renderRowContent(
         rowIndex: number,
         cols: ContentNode[],
-        numCols: number,
         rowItemWidth: number,
         spacing: number[],
         itemRect: Rect,
         context: RowListRenderContext
     ): void {
-        const totalRowWidth = numCols * rowItemWidth + (numCols - 1) * spacing[0];
-        const allItemsFitOnScreen = totalRowWidth <= this.sceneRect.width;
+        const allItemsFitOnScreen = this.allItemsFitOnScreen(rowIndex, cols);
         const rowFocusStyle = (this.getValueJS("rowFocusAnimationStyle") as string).toLowerCase();
 
         this.rowScrollOffset[rowIndex] ??= 0;
@@ -943,14 +958,8 @@ export class RowList extends ArrayGrid {
         const content = cols[colIndex];
         const nodeFocus = sgRoot.focused === this;
 
-        // Check if all items in this row fit on screen by checking if last item fits
-        const numCols = cols.length;
-        const rowItemWidth = itemRect.width;
-        const spacing = this.getRowItemSpacing(rowIndex);
-        const lastItemX =
-            itemRect.x - colIndex * (rowItemWidth + spacing[0]) + (numCols - 1) * (rowItemWidth + spacing[0]);
-        const lastItemRightEdge = lastItemX + rowItemWidth;
-        const allItemsFitOnScreen = lastItemRightEdge <= this.sceneRect.width;
+        // Sum the row's actual (possibly variable) item widths to decide whether it all fits.
+        const allItemsFitOnScreen = this.allItemsFitOnScreen(rowIndex, cols);
 
         // Determine focus behavior based on animation style and screen fit
         let focused = false;
@@ -1028,7 +1037,7 @@ export class RowList extends ArrayGrid {
             return;
         }
         const showShortRows = (this.getValueJS("showRowCounterForShortRows") as boolean) ?? true;
-        if (!showShortRows && this.checkIfAllItemsFitOnScreen(numCols, context.rowItemWidth)) {
+        if (!showShortRows && this.allItemsFitOnScreen(rowIndex, this.getContentChildren(this.content[rowIndex]))) {
             return;
         }
         const font = this.getValue("rowLabelFont") as Font;

--- a/src/extensions/scenegraph/nodes/ZoomRowList.ts
+++ b/src/extensions/scenegraph/nodes/ZoomRowList.ts
@@ -233,7 +233,12 @@ export class ZoomRowList extends ArrayGrid {
             }
             next = (next + this.content.length) % this.content.length;
         }
-        if (next >= 0 && next < this.content.length) {
+        // Only consume the key when the focus actually moves to a different row. With a single row
+        // (or any wrap that lands back on the current row) the focus does not change, so the key must
+        // stay unhandled and propagate up the node tree — matching a real device, where up/down on a
+        // single-row grid moves focus to a sibling above/below (e.g. a ButtonBar). RowList guards the
+        // same way.
+        if (next >= 0 && next < this.content.length && next !== this.focusIndex) {
             super.setValue("scrollingStatus", BrsBoolean.True);
             this.focusIndex = next;
             this.rowFocus[next] ??= 0;

--- a/test/extensions/scenegraph/LayoutGroup.test.js
+++ b/test/extensions/scenegraph/LayoutGroup.test.js
@@ -1,0 +1,75 @@
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsString, Float, RoArray } = core;
+
+/** Minimal interpreter accepted by renderNode → renderChildren when draw2D is absent. */
+const fakeInterpreter = {};
+
+function vector(values) {
+    return new RoArray(values.map((v) => new Float(v)));
+}
+
+/**
+ * Regression: a LayoutGroup owns its children's managed-axis positions. On Roku, if an app writes a
+ * child's translation directly (SGDEX ButtonBar does this to its label via setTitleLabelStyle after
+ * the group has already been laid out), the group re-imposes the aligned position on the next
+ * render. A translation change alone does not dirty the layout, and the group's delta-based
+ * positioning measures from the child's stale (previously rendered) rect — so without a fix the
+ * label sticks at the app's translation and its centered text sits low (bottom-aligned).
+ */
+describe("LayoutGroup re-imposes child alignment after an external translation change", () => {
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    test("a child moved by the app is realigned to the group's managed position on re-render", () => {
+        // Horizontal group, vertAlignment center → the child's cross axis (y) is managed: its box is
+        // centered on the group origin (y = -height/2).
+        const layout = SGNodeFactory.createNode("LayoutGroup");
+        layout.setValue("layoutDirection", new BrsString("horiz"));
+        layout.setValue("vertAlignment", new BrsString("center"));
+
+        const child = SGNodeFactory.createNode("Rectangle");
+        child.setValue("width", new Float(100));
+        child.setValue("height", new Float(40));
+        layout.appendChildToParent(child);
+
+        // First layout: single child at the left (primary x = 0), cross-centered (y = -20).
+        layout.renderNode(fakeInterpreter, [0, 0], 0, 1);
+        expect(child.getValueJS("translation")[0]).toBeCloseTo(0);
+        expect(child.getValueJS("translation")[1]).toBeCloseTo(-20);
+
+        // App moves the child directly (as ButtonBar's item component does to its label).
+        child.setValue("translation", vector([0, 100]));
+
+        // Re-render: the group detects the drift and re-imposes the aligned position (y back to -20),
+        // rather than leaving the child where the app put it.
+        layout.renderNode(fakeInterpreter, [0, 0], 0, 1);
+        expect(child.getValueJS("translation")[0]).toBeCloseTo(0);
+        expect(child.getValueJS("translation")[1]).toBeCloseTo(-20);
+    });
+
+    test("a custom cross-axis alignment leaves an app-set child translation untouched", () => {
+        // vertAlignment custom → the cross axis is NOT managed, so the app's y is preserved; only the
+        // primary (x) axis is stacked by the group.
+        const layout = SGNodeFactory.createNode("LayoutGroup");
+        layout.setValue("layoutDirection", new BrsString("horiz"));
+        layout.setValue("vertAlignment", new BrsString("custom"));
+
+        const child = SGNodeFactory.createNode("Rectangle");
+        child.setValue("width", new Float(100));
+        child.setValue("height", new Float(40));
+        layout.appendChildToParent(child);
+
+        layout.renderNode(fakeInterpreter, [0, 0], 0, 1);
+
+        child.setValue("translation", vector([0, 100]));
+        layout.renderNode(fakeInterpreter, [0, 0], 0, 1);
+
+        // Primary axis stays stacked at 0; the custom cross axis keeps the app's value.
+        expect(child.getValueJS("translation")[0]).toBeCloseTo(0);
+        expect(child.getValueJS("translation")[1]).toBeCloseTo(100);
+    });
+});

--- a/test/extensions/scenegraph/VariableWidthItems.test.js
+++ b/test/extensions/scenegraph/VariableWidthItems.test.js
@@ -69,6 +69,47 @@ describe("RowList variableWidthItems", () => {
         expect(items[2].rectToScene.x).toBe(320); // 110 + 200 + 10
     });
 
+    test("floats focus and stops at the edges when variable-width items fit, despite an oversized rowItemSize", () => {
+        // Regression (SGDEX ButtonBar): the app sets rowItemSize.x to the WHOLE bar width while each
+        // button is far narrower via HDItemWidth, and uses fixedFocusWrap. The "do all items fit?"
+        // check used numCols * rowItemSize.x (3 * 980 = 2940 > 1280) and wrongly concluded the row
+        // overflowed, pinning focus at column 0 and scrolling/wrapping the row. Summing the real
+        // per-item widths (100+200+150 + spacing = 470 < 1280) makes focus float per button and clamp
+        // at the first/last button with no wrap.
+        const list = SGNodeFactory.createNode("RowList");
+        list.setValue("numRows", new Float(1));
+        list.setValue("itemSize", new RoArray([new Float(1280), new Float(55)]));
+        list.setValue("rowHeights", new RoArray([new Float(55)]));
+        // Oversized uniform width: the whole bar, not a single button.
+        list.setValue("rowItemSize", new RoArray([new RoArray([new Float(980), new Float(55)])]));
+        list.setValue("rowItemSpacing", new RoArray([new RoArray([new Float(10), new Float(0)])]));
+        list.setValue("variableWidthItems", new RoArray([BrsBoolean.True]));
+        list.setValue("rowFocusAnimationStyle", new BrsString("fixedFocusWrap"));
+        list.setValue("content", buildRow([100, 200, 150]));
+        list.setNodeFocus(true);
+
+        expect(list.rowFocus[0]).toBe(0);
+
+        // Right floats focus button-to-button (the column advances; it is not pinned at 0).
+        expect(list.handleKey("right", true)).toBe(true);
+        expect(list.rowFocus[0]).toBe(1);
+        expect(list.getValueJS("rowItemFocused")).toEqual([0, 1]);
+        expect(list.handleKey("right", true)).toBe(true);
+        expect(list.rowFocus[0]).toBe(2);
+
+        // At the last button Right STOPS (no wrap back to 0) and reports the key as unhandled.
+        expect(list.handleKey("right", true)).toBe(false);
+        expect(list.rowFocus[0]).toBe(2);
+
+        // Left floats back and STOPS at the first button (no wrap to the last).
+        expect(list.handleKey("left", true)).toBe(true);
+        expect(list.rowFocus[0]).toBe(1);
+        expect(list.handleKey("left", true)).toBe(true);
+        expect(list.rowFocus[0]).toBe(0);
+        expect(list.handleKey("left", true)).toBe(false);
+        expect(list.rowFocus[0]).toBe(0);
+    });
+
     test("falls back to the row's rowItemSize width for an item without [res]ItemWidth", () => {
         const root = SGNodeFactory.createNode("ContentNode");
         const row = SGNodeFactory.createNode("ContentNode");

--- a/test/extensions/scenegraph/ZoomRowList.test.js
+++ b/test/extensions/scenegraph/ZoomRowList.test.js
@@ -3,8 +3,23 @@ const path = require("path");
 const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
 const core = require("../../../packages/node/bin/brs.node.js");
 
-const { SGNodeFactory } = scenegraph;
-const { BrsDevice } = core;
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsDevice, BrsString, BrsBoolean } = core;
+
+/** Builds root → rows → items so a ZoomRowList has the given row/column shape. */
+function buildContent(rows) {
+    const root = SGNodeFactory.createNode("ContentNode");
+    for (const row of rows) {
+        const rowNode = SGNodeFactory.createNode("ContentNode");
+        for (const title of row) {
+            const item = SGNodeFactory.createNode("ContentNode");
+            item.setValue("title", new BrsString(title));
+            rowNode.appendChildToParent(item);
+        }
+        root.appendChildToParent(rowNode);
+    }
+    return root;
+}
 
 /**
  * ZoomRowList zoom sizing: the focused row uses `rowZoomHeight` and must render LARGER than the
@@ -24,5 +39,56 @@ describe("ZoomRowList zoom defaults", () => {
         // A bare node defaults to HD resolution (Group falls back to "HD").
         const node = SGNodeFactory.createNode("ZoomRowList");
         expect(node.defaultRowZoomHeight).toBeGreaterThan(node.defaultRowHeight);
+    });
+});
+
+/**
+ * Key propagation: on a real device up/down only consume the key when focus actually moves to
+ * another row. A single-row grid (the SGDEX GridView shape — one row per content type) has nowhere
+ * to move vertically, so up/down must stay unhandled and bubble up the node tree to a sibling above
+ * (e.g. a ButtonBar). The default wrap=true used to wrap the single row onto itself and report the
+ * key as handled, swallowing it.
+ */
+describe("ZoomRowList up/down propagation", () => {
+    beforeAll(() => {
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    test("a single-row grid does NOT consume up/down (lets the key bubble), even with wrap=true", () => {
+        const list = SGNodeFactory.createNode("ZoomRowList");
+        list.setValue("itemComponentName", new BrsString("X"));
+        list.setValue("content", buildContent([["A", "B", "C"]])); // one row
+        list.setNodeFocus(true);
+        expect(list.getValueJS("wrap")).toBe(true); // default
+        expect(list.handleKey("up", true)).toBe(false);
+        expect(list.handleKey("down", true)).toBe(false);
+        expect(list.focusIndex).toBe(0);
+    });
+
+    test("a multi-row grid still wraps (wrap=true) and moves (wrap=false) on up/down", () => {
+        const wrapped = SGNodeFactory.createNode("ZoomRowList");
+        wrapped.setValue("itemComponentName", new BrsString("X"));
+        wrapped.setValue("content", buildContent([["A"], ["B"], ["C"]]));
+        wrapped.setNodeFocus(true);
+        // wrap=true: up from row 0 wraps to the last row and is handled.
+        expect(wrapped.handleKey("up", true)).toBe(true);
+        expect(wrapped.focusIndex).toBe(2);
+        sgRoot.setFocused();
+
+        const clamped = SGNodeFactory.createNode("ZoomRowList");
+        clamped.setValue("itemComponentName", new BrsString("X"));
+        clamped.setValue("wrap", BrsBoolean.False);
+        clamped.setValue("content", buildContent([["A"], ["B"], ["C"]]));
+        clamped.setNodeFocus(true);
+        // wrap=false: up from row 0 has nowhere to go → bubbles; down moves to row 1.
+        expect(clamped.handleKey("up", true)).toBe(false);
+        expect(clamped.focusIndex).toBe(0);
+        expect(clamped.handleKey("down", true)).toBe(true);
+        expect(clamped.focusIndex).toBe(1);
     });
 });


### PR DESCRIPTION
## Summary

Three SceneGraph fixes surfaced by the SGDEX ButtonBar sample (a `Group → LayoutGroup → RowList` bar over a `GridView`/`ZoomRowList`):

### 1. RowList — focus scrolled instead of floating
Every "do all items fit on screen?" check estimated a row's width as `numCols * rowItemSize.x` (the **uniform** per-item width). When an app sets `rowItemSize.x` to the whole bar width while items are far narrower via `variableWidthItems` (`[res]ItemWidth`), that overshoots and the row is treated as overflowing → `fixedFocusWrap` pins focus at the first item and scrolls. Fixed by summing each item's actual width (`getTotalRowWidth`/`allItemsFitOnScreen`, reusing `getItemWidth`) across all five fit checks. Focus now floats and **stops** at the edges. Uniform rows unaffected.

### 2. LayoutGroup — label drifted to the bottom
The group centered a child correctly on the first layout but never re-imposed the aligned position when the app wrote the child's translation directly afterwards: a translation change didn't dirty the layout, and `applyLayout` positioned children by a **delta from their stale rect**. Fixed by detecting translation drift from the last assigned position (re-run layout) and shifting the measured origin by that drift so positioning uses the child's **current** translation plus its intrinsic offset. A `custom`-alignment axis is preserved.

### 3. ZoomRowList — single-row grid swallowed up/down
`handleUpDown` reported the key as handled whenever the target row was in range, but with `wrap=true` (the default) a **single-row** grid wraps the lone row onto itself — focus never moves, yet the key was consumed. A grid with one row per content section (the SGDEX GridView shape) therefore trapped up/down and never let focus return to a sibling above it (the ButtonBar). Fixed by only consuming the key when the focus truly changes rows (`next !== focusIndex`), matching RowList and a real device's key propagation. Multi-row wrap/clamp behavior unchanged.

## Testing
- `LayoutGroup.test.js` (new): re-imposes alignment after an external child move; `custom` axis preserved.
- `VariableWidthItems.test.js`: oversized `rowItemSize` + `variableWidthItems` + `fixedFocusWrap` — Left/Right float and clamp at the edges without wrapping.
- `ZoomRowList.test.js`: single-row grid lets up/down bubble (even with default `wrap=true`); multi-row still wraps (`wrap=true`) and moves/clamps (`wrap=false`).
- Full scenegraph suite (402) + SG-rendering CLI regressions pass; lint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)