### PR TITLE
fix(rsg): ZoomRowList vertical-wrap flag and row-title/poster spacing

### DIFF
--- a/src/extensions/scenegraph/nodes/ZoomRowList.ts
+++ b/src/extensions/scenegraph/nodes/ZoomRowList.ts
@@ -37,8 +37,6 @@ interface RowMetrics {
 
 const ValidFocusStyles = new Set(Object.values(FocusStyle).map((style) => style.toLowerCase()));
 
-const RowFocusStyleWrap = FocusStyle.FixedFocusWrap.toLowerCase();
-
 export class ZoomRowList extends ArrayGrid {
     readonly defaultFields: FieldModel[] = [
         { name: "itemComponentName", type: "string", value: "" },
@@ -133,8 +131,9 @@ export class ZoomRowList extends ArrayGrid {
         this.defaultItemZoomYOffset = 0;
         this.hasNinePatch = true;
         this.focusField = "zoomRowListHasFocus";
-        const rowFocusStyle = (this.getValueJS("rowFocusAnimationStyle") as string) ?? FocusStyle.FixedFocusWrap;
-        this.wrap = rowFocusStyle.toLowerCase() === RowFocusStyleWrap;
+        // Vertical (row-to-row) wrapping is controlled by the boolean `wrap` field, NOT by
+        // `rowFocusAnimationStyle` (which governs horizontal item focus within a row).
+        this.wrap = this.isWrapEnabled();
         this.focusIndex = 0;
         this.rowFocus[0] = 0;
         this.nodeWidth = this.sceneRect.width;
@@ -163,11 +162,11 @@ export class ZoomRowList extends ArrayGrid {
                 this.setFocusedItem(coords[0], coords[1]);
             }
         } else if (fieldName === "rowfocusanimationstyle" && value instanceof BrsString) {
+            // Horizontal item focus style; validate but do NOT let it drive vertical wrap.
             const style = value.toString().toLowerCase();
             if (!ValidFocusStyles.has(style)) {
                 return;
             }
-            this.wrap = style === RowFocusStyleWrap;
         } else if (fieldName === "wrap" && value instanceof BrsBoolean) {
             this.wrap = value.toBoolean();
         } else if (fieldName === "rowwidth" && isNumberComp(value)) {
@@ -212,6 +211,15 @@ export class ZoomRowList extends ArrayGrid {
         super.setValue("currFocusRow", new Float(rowIndex));
     }
 
+    /**
+     * Vertical (row-to-row) wrap state. Read live from the `wrap` field so it always reflects the
+     * current value regardless of how the field was populated (setValue, config append, or a silent
+     * factory path that bypasses the overridden setValue). See the Roku ZoomRowList `wrap` field.
+     */
+    private isWrapEnabled(): boolean {
+        return jsValueOf(this.getValue("wrap")) === true;
+    }
+
     protected handleUpDown(key: string) {
         let handled = false;
         let offset = 0;
@@ -227,7 +235,7 @@ export class ZoomRowList extends ArrayGrid {
             return false;
         }
         let next = this.focusIndex + offset;
-        if (this.wrap) {
+        if (this.isWrapEnabled()) {
             if (this.content.length === 0) {
                 return false;
             }
@@ -441,7 +449,12 @@ export class ZoomRowList extends ArrayGrid {
 
         const titleHeight = this.renderRowTitle(rowIndex, rect, this.nodeWidth, opacity, draw2D);
         const counterHeight = this.renderRowCounter(rowIndex, rect, metrics, this.nodeWidth, opacity, draw2D);
-        const rowY = rect.y + Math.max(titleHeight, counterHeight) + metrics.itemYOffset;
+        // `rowItemYOffset` positions the item row relative to the row top, independently of the
+        // title/counter (which draw at their own rowTitleOffset/rowCounterOffset). They are NOT
+        // stacked (Roku spec) — the title occupies the reserved offset band. Only when no offset is
+        // configured do we reserve the measured band so the title and posters do not overlap.
+        const reservedBand = metrics.itemYOffset > 0 ? 0 : Math.max(titleHeight, counterHeight);
+        const rowY = rect.y + metrics.itemYOffset + reservedBand;
 
         const itemRect: Rect = {
             x: rect.x,
@@ -515,7 +528,7 @@ export class ZoomRowList extends ArrayGrid {
     }
 
     private canWrapRows(displayRows: number): boolean {
-        return this.wrap && displayRows > 0 && this.content.length >= displayRows;
+        return this.isWrapEnabled() && displayRows > 0 && this.content.length >= displayRows;
     }
 
     private canWrapItems(numCols: number, metrics: RowMetrics, availableWidth: number) {

--- a/test/extensions/scenegraph/ZoomRowList.test.js
+++ b/test/extensions/scenegraph/ZoomRowList.test.js
@@ -91,4 +91,19 @@ describe("ZoomRowList up/down propagation", () => {
         expect(clamped.handleKey("down", true)).toBe(true);
         expect(clamped.focusIndex).toBe(1);
     });
+
+    // Vertical wrap must be read live from the `wrap` field, not a cached mirror. Some field
+    // population paths (config append, factory setup) set the field without going through the
+    // overridden setValue, so a mirror seeded from the constructor default would stay stale and the
+    // grid would keep wrapping despite wrap=false. Regression for that silent-populate path.
+    test("wrap=false set via a silent path (bypassing setValue) still disables wrapping", () => {
+        const list = SGNodeFactory.createNode("ZoomRowList");
+        list.setValue("itemComponentName", new BrsString("X"));
+        list.setValueSilent("wrap", BrsBoolean.False);
+        list.setValue("content", buildContent([["A"], ["B"], ["C"]]));
+        list.setNodeFocus(true);
+        // up from row 0 has nowhere to go → unhandled (bubbles), focus stays.
+        expect(list.handleKey("up", true)).toBe(false);
+        expect(list.focusIndex).toBe(0);
+    });
 });


### PR DESCRIPTION
## Summary

Two `ZoomRowList` behaviors diverged from a real Roku; both are fixed in `src/extensions/scenegraph/nodes/ZoomRowList.ts`.

### 1. Vertical wrap ignored the `wrap` field
Per the Roku spec, a `ZoomRowList`'s row-to-row (Up/Down) wrapping is controlled by the boolean **`wrap`** field ("If true, the items wrap from bottom to top. If false, the items do not wrap."). The separate `rowFocusAnimationStyle` field governs **horizontal** item focus within a row — a different axis.

The node derived its internal vertical-wrap flag from `rowFocusAnimationStyle` (default `fixedFocusWrap`), so vertical wrap was effectively always on and `wrap=false` was ignored. As a result Up on the first row / Down on the last row wrapped instead of leaving focus put and letting the key bubble up unhandled.

- Vertical wrap is now read **live** from the `wrap` field via `isWrapEnabled()`, so it survives field-population paths that bypass the overridden `setValue`.
- Decoupled from `rowFocusAnimationStyle` (its value validation is retained).

### 2. Gap between the row title/counter line and the posters was too large
Per the spec, `rowItemYOffset` ("vertical position of the Row relative to the top of its ZoomRowItem") and `rowTitleOffset` ("vertical spacing of the top of the Row Title from the top of the row's coordinate system") are **independent** offsets from the same origin, not stacked. The item row was positioned at `rect.y + max(titleHeight, counterHeight) + rowItemYOffset`, roughly doubling the intended gap.

- Items are now positioned solely by the configured `rowItemYOffset`; the title/counter draw at their own offsets.
- A fallback reserves the measured band only when no offset is configured, so title and posters never overlap.

## Testing
- `npm run build:api` and `npm run build:sg` compile cleanly.
- All scenegraph tests pass, including a new regression: *"wrap=false set via a silent path (bypassing setValue) still disables wrapping"*.
- `npm run lint` clean; changed files pass `prettier --check`.
- Live key-nav and the visual title→poster gap should be confirmed in the browser (grid focus/rendering isn't reliably exercisable in the CLI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)