### PR TITLE
fix(rsg): only the owning, presenting Video node renders the video plane

### DIFF
--- a/src/extensions/scenegraph/nodes/Video.ts
+++ b/src/extensions/scenegraph/nodes/Video.ts
@@ -753,12 +753,25 @@ export class Video extends Group {
         };
         const rotation = angle + this.getRotation();
         opacity = opacity * this.getOpacity();
-        if (this.isDirty) {
+        // The whole engine shares a SINGLE browser <video> element, but an app can hold several
+        // Video node instances (e.g. a startup logo and a preview player). The video plane is a
+        // transparent hole cleared into the graphics buffer that the main thread fills with that one
+        // element's frames — so only the node that currently OWNS the element (`sgRoot.video`) and
+        // is actively presenting a frame (playing/paused) may position it and punch the hole. A
+        // non-owner instance, or the owner once it is finished/stopped/buffering, punches nothing and
+        // disappears cleanly: this prevents a second Video (or the just-finished startup logo) from
+        // resizing the element and leaking its stale last frame as a shrunken picture, and prevents a
+        // frame-less hole from showing through as a black box before the next screen renders.
+        const state = this.getValueJS("state") as string;
+        const presenting = sgRoot.video === this && opacity > 0 && (state === "playing" || state === "paused");
+        if (this.isDirty && presenting) {
             postMessage(`video,rect,${rect.x},${rect.y},${rect.width},${rect.height}`);
         }
         if (draw2D) {
             this.isDirty = false;
-            draw2D.doDrawClearedRect(rect);
+            if (presenting) {
+                draw2D.doDrawClearedRect(rect);
+            }
         }
         if (this.statusChanged) {
             if (this.seekTimeout > 0 && this.seekTimeout < Date.now() && ["rw", "ff"].includes(this.seekMode)) {

--- a/test/extensions/scenegraph/Video.test.js
+++ b/test/extensions/scenegraph/Video.test.js
@@ -195,6 +195,107 @@ describe("Video cross-thread deserialization guard", () => {
     });
 });
 
+describe("Video plane is only rendered by the owning, actively-presenting Video", () => {
+    let originalPostMessage;
+
+    beforeAll(() => {
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    beforeEach(() => {
+        originalPostMessage = global.postMessage;
+        global.postMessage = jest.fn();
+        sgRoot.setVideo();
+    });
+
+    afterEach(() => {
+        global.postMessage = originalPostMessage;
+        sgRoot.setVideo();
+    });
+
+    // The engine shares ONE browser <video> element, but an app can hold several Video node
+    // instances (startup logo + preview player). The video plane is a transparent hole cleared
+    // into the graphics buffer that the main thread fills with that one element's frames — so only
+    // the node that OWNS the element (sgRoot.video) and is actively presenting a frame
+    // (playing/paused) may position it and punch the hole. Otherwise a non-owner (or a
+    // just-finished) Video resizes the element and leaks its stale last frame as a shrunken
+    // picture, or punches a frame-less hole that shows through as a black box.
+    function makeDraw2D() {
+        return {
+            cleared: [],
+            doDrawClearedRect(rect) {
+                this.cleared.push({ ...rect });
+            },
+        };
+    }
+
+    function fullScreenVideo() {
+        const video = SGNodeFactory.createNode("Video");
+        video.setValue("width", new core.Float(1920));
+        video.setValue("height", new core.Float(1080));
+        return video;
+    }
+
+    test("the owning, playing Video clears its rect and posts the geometry", () => {
+        const video = fullScreenVideo();
+        sgRoot.setVideo(video);
+        video.setState(MediaEvent.StartStream, 0); // -> "playing"
+        video.makeDirty();
+        const draw2D = makeDraw2D();
+        global.postMessage.mockClear();
+
+        video.renderNode({}, [0, 0], 0, 1, draw2D);
+
+        expect(draw2D.cleared).toHaveLength(1);
+        expect(draw2D.cleared[0]).toMatchObject({ x: 0, y: 0, width: 1920, height: 1080 });
+        expect(global.postMessage).toHaveBeenCalledWith("video,rect,0,0,1920,1080");
+    });
+
+    test("the owning Video does NOT render a plane once it has finished", () => {
+        const video = fullScreenVideo();
+        sgRoot.setVideo(video);
+        video.setState(MediaEvent.Finished, 0); // -> "finished"
+        video.makeDirty();
+        const draw2D = makeDraw2D();
+        global.postMessage.mockClear();
+
+        video.renderNode({}, [0, 0], 0, 1, draw2D);
+
+        expect(draw2D.cleared).toHaveLength(0);
+        expect(global.postMessage).not.toHaveBeenCalledWith(expect.stringContaining("video,rect"));
+    });
+
+    test("a non-owner Video does NOT render a plane even while playing", () => {
+        const owner = fullScreenVideo();
+        sgRoot.setVideo(owner);
+        // A second instance (e.g. a preview player) that does NOT own the shared element.
+        const other = fullScreenVideo();
+        other.setState(MediaEvent.StartStream, 0);
+        expect(sgRoot.video).toBe(owner);
+        const draw2D = makeDraw2D();
+        global.postMessage.mockClear();
+
+        other.renderNode({}, [0, 0], 0, 1, draw2D);
+
+        expect(draw2D.cleared).toHaveLength(0);
+        expect(global.postMessage).not.toHaveBeenCalledWith(expect.stringContaining("video,rect"));
+    });
+
+    test("the owning, playing Video at accumulated opacity 0 does NOT render a plane", () => {
+        const video = fullScreenVideo();
+        sgRoot.setVideo(video);
+        video.setState(MediaEvent.StartStream, 0);
+        video.makeDirty();
+        const draw2D = makeDraw2D();
+
+        // Ancestor group faded to opacity 0 propagates opacity 0 to the (visible) Video.
+        video.renderNode({}, [0, 0], 0, 0, draw2D);
+
+        expect(draw2D.cleared).toHaveLength(0);
+    });
+});
+
 describe("Video asyncStopSemantics stopping->stopped transition", () => {
     let originalPostMessage;
 


### PR DESCRIPTION
## Problem

The engine shares a **single** browser `<video>` element on the render thread, but a SceneGraph app can hold **several `Video` node instances** (for example a startup logo video and a preview player — which in one code path is the *same* node reparented and resized, in another a separate node).

The "video plane" is a transparent hole cleared into the graphics buffer (`Video.renderNode` → `draw2D.doDrawClearedRect`) that the main thread fills with that one element's frames. Previously **every visible `Video` node** punched that hole and posted its rect, regardless of whether it owned the shared element or whether the element had a live frame.

Symptoms observed on a startup-video → home flow:
- After the intro video finished, a second `Video` instance (or the same node reparented/resized by a preview player) resized the single element and leaked its **stale last frame as a shrunken, quarter-screen picture**.
- Once the element actually stopped, the frame-less hole showed through as a **black box** before the next screen rendered.
- A full-screen splash `Poster` drawn beneath a faded-out (`opacity=0`) startup group was **erased before it could be seen**, because the visible Video on top cleared the whole region.

## Fix

Gate the video plane on **ownership + active presentation**. Only clear the hole and post `video,rect` when:

```ts
sgRoot.video === this && opacity > 0 && (state === "playing" || state === "paused")
```

Any non-owner instance, or the owner once it is finished/stopped/buffering, renders no plane and disappears cleanly. Ownership was already tracked (`sgRoot.setVideo`; a node claims it in the `control` setter on play/prebuffer/resume/replay) — this change honors it in the render path as well.

## Tests

New regression suite in `test/extensions/scenegraph/Video.test.js`:
- owning + playing node clears its rect and posts the geometry
- owning node renders no plane once finished
- non-owner playing node renders no plane
- owning + playing node at accumulated opacity 0 renders no plane

All 18 Video tests pass; `lint` and `prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)