### PR TITLE
feat(rsg): add missing `secondaryTitle` field to `ContentNode`

### DIFF
--- a/src/extensions/scenegraph/nodes/ContentNode.ts
+++ b/src/extensions/scenegraph/nodes/ContentNode.ts
@@ -114,6 +114,7 @@ export class ContentNode extends Node {
         { name: "textOverlayUL", type: "string", hidden: true },
         { name: "textOverlayUR", type: "string", hidden: true },
         { name: "title", type: "string", hidden: true },
+        { name: "secondaryTitle", type: "string", hidden: true }, // Introduced in OS 11.5
         { name: "titleSeason", type: "string", hidden: true },
         { name: "trackIDAudio", type: "string", hidden: true },
         { name: "trackIDSubtitle", type: "string", hidden: true },


### PR DESCRIPTION
The field `secondaryTitle` was introduced in Roku OS 11.5 and was missing in `ContentNode`