### PR TITLE
fix(brs): properly handle boxed String in RoArray, RoAudioPlayer and RoVideoPlayer

### DIFF
--- a/src/core/brsTypes/components/RoArray.ts
+++ b/src/core/brsTypes/components/RoArray.ts
@@ -292,7 +292,7 @@ export class RoArray extends BrsComponent implements BrsValue, BrsArray {
         impl: (interpreter: Interpreter, separator: BrsString) => {
             if (
                 this.elements.some(function (element) {
-                    return !(element instanceof BrsString);
+                    return !isBrsString(element);
                 })
             ) {
                 if (BrsDevice.isDevMode) {

--- a/src/core/brsTypes/components/RoArray.ts
+++ b/src/core/brsTypes/components/RoArray.ts
@@ -289,14 +289,16 @@ export class RoArray extends BrsComponent implements BrsValue, BrsArray {
             args: [new StdlibArgument("separator", ValueKind.String)],
             returns: ValueKind.String,
         },
-        impl: (_: Interpreter, separator: BrsString) => {
+        impl: (interpreter: Interpreter, separator: BrsString) => {
             if (
                 this.elements.some(function (element) {
                     return !(element instanceof BrsString);
                 })
             ) {
                 if (BrsDevice.isDevMode) {
-                    BrsDevice.stderr.write("warning,roArray.Join: Array contains non-string value(s).");
+                    BrsDevice.stderr.write(
+                        `warning,roArray.Join: Array contains non-string value(s). ${interpreter.formatLocation()}`
+                    );
                 }
                 return new BrsString("");
             }
@@ -310,7 +312,7 @@ export class RoArray extends BrsComponent implements BrsValue, BrsArray {
             args: [new StdlibArgument("flags", ValueKind.String, new BrsString(""))],
             returns: ValueKind.Void,
         },
-        impl: (_: Interpreter, flags: BrsString) => {
+        impl: (interpreter: Interpreter, flags: BrsString) => {
             if (flags.toString().match(/([^ir])/g) == null) {
                 const caseInsensitive = flags.toString().includes("i");
                 const originalArrayCopy = [...this.elements];
@@ -321,7 +323,9 @@ export class RoArray extends BrsComponent implements BrsValue, BrsArray {
                     this.elements.reverse();
                 }
             } else if (BrsDevice.isDevMode) {
-                BrsDevice.stderr.write("warning,roArray.Sort: Flags contains invalid option(s).");
+                BrsDevice.stderr.write(
+                    `warning,roArray.Sort: Flags contains invalid option(s). ${interpreter.formatLocation()}`
+                );
             }
             return BrsInvalid.Instance;
         },
@@ -335,7 +339,7 @@ export class RoArray extends BrsComponent implements BrsValue, BrsArray {
             ],
             returns: ValueKind.Void,
         },
-        impl: (_: Interpreter, fieldName: BrsString, flags: BrsString) => {
+        impl: (interpreter: Interpreter, fieldName: BrsString, flags: BrsString) => {
             if (flags.toString().match(/([^ir])/g) == null) {
                 const originalArrayCopy = [...this.elements];
                 this.elements.sort((a, b) => {
@@ -351,7 +355,9 @@ export class RoArray extends BrsComponent implements BrsValue, BrsArray {
                     this.elements.reverse();
                 }
             } else if (BrsDevice.isDevMode) {
-                BrsDevice.stderr.write("warning,roArray.SortBy: Flags contains invalid option(s).");
+                BrsDevice.stderr.write(
+                    `warning,roArray.SortBy: Flags contains invalid option(s). ${interpreter.formatLocation()}`
+                );
             }
             return BrsInvalid.Instance;
         },

--- a/src/core/brsTypes/components/RoAudioPlayer.ts
+++ b/src/core/brsTypes/components/RoAudioPlayer.ts
@@ -1,6 +1,6 @@
 import { BrsValue, ValueKind, BrsInvalid, BrsBoolean, BrsString } from "../BrsType";
 import { BrsComponent } from "./BrsComponent";
-import { BrsType, RoMessagePort, RoAssociativeArray, RoArray, RoAudioPlayerEvent, BrsEvent } from "..";
+import { BrsType, RoMessagePort, RoAssociativeArray, RoArray, RoAudioPlayerEvent, BrsEvent, isBrsString } from "..";
 import { Callable, StdlibArgument } from "../Callable";
 import { Interpreter } from "../../interpreter";
 import { Int32 } from "../Int32";
@@ -82,11 +82,12 @@ export class RoAudioPlayer extends BrsComponent implements BrsValue, BrsHttpAgen
         const content = new Array<string>();
         for (const value of this.contentList) {
             let url = value.get(new BrsString("url"));
-            if (url instanceof BrsString) {
-                if (url.value.startsWith("http")) {
-                    content.push(BrsDevice.getCORSProxy(url.value));
+            if (isBrsString(url)) {
+                const urlValue = url.getValue();
+                if (urlValue.startsWith("http")) {
+                    content.push(BrsDevice.getCORSProxy(urlValue));
                 } else {
-                    content.push(url.value);
+                    content.push(urlValue);
                 }
             }
         }

--- a/src/core/brsTypes/components/RoVideoPlayer.ts
+++ b/src/core/brsTypes/components/RoVideoPlayer.ts
@@ -9,6 +9,7 @@ import {
     BrsEvent,
     RoVideoPlayerEvent,
     toAssociativeArray,
+    isBrsString,
 } from "..";
 import { Callable, StdlibArgument } from "../Callable";
 import { Interpreter } from "../../interpreter";
@@ -105,20 +106,20 @@ export class RoVideoPlayer extends BrsComponent implements BrsValue, BrsHttpAgen
         for (const aa of this.contentList) {
             const item = { url: "", streamFormat: "", audioTrack: -1 };
             let url = aa.get(new BrsString("url"));
-            if (url instanceof BrsString) {
-                item.url = this.getFullUrl(url.value);
+            if (isBrsString(url)) {
+                item.url = this.getFullUrl(url.getValue());
             } else {
                 const stream = aa.get(new BrsString("stream"));
                 if (stream instanceof RoAssociativeArray) {
                     url = stream.get(new BrsString("url"));
-                    if (url instanceof BrsString) {
-                        item.url = this.getFullUrl(url.value);
+                    if (isBrsString(url)) {
+                        item.url = this.getFullUrl(url.getValue());
                     }
                 }
             }
             let streamFormat = aa.get(new BrsString("streamFormat"));
-            if (streamFormat instanceof BrsString) {
-                item.streamFormat = streamFormat.value.toLowerCase();
+            if (isBrsString(streamFormat)) {
+                item.streamFormat = streamFormat.getValue().toLowerCase();
             }
             contents.push(item);
         }

--- a/test/brsTypes/components/RoArray.test.js
+++ b/test/brsTypes/components/RoArray.test.js
@@ -1,6 +1,6 @@
 const brs = require("../../../packages/node/bin/brs.node");
 const { Interpreter } = brs;
-const { RoArray, RoAssociativeArray, BrsBoolean, BrsString, Int32, BrsInvalid, Float } = brs.types;
+const { RoArray, RoAssociativeArray, RoString, BrsBoolean, BrsString, Int32, BrsInvalid, Float } = brs.types;
 const { createMockStreams } = require("../../e2e/E2ETests");
 
 describe("RoArray", () => {
@@ -294,6 +294,25 @@ describe("RoArray", () => {
                 let join = src.getMethod("join");
                 expect(join).toBeTruthy();
                 expect(join.call(interpreter, new BrsString(","))).toEqual(new BrsString(""));
+            });
+
+            it("joins boxed string elements (roString)", () => {
+                let a = new RoString(new BrsString("a"));
+                let b = new BrsString("b");
+                let c = new RoString(new BrsString("c"));
+                let src = new RoArray([a, b, c]);
+
+                let join = src.getMethod("join");
+                expect(join).toBeTruthy();
+                expect(join.call(interpreter, new BrsString(","))).toEqual(new BrsString("a,b,c"));
+            });
+
+            it("joins an array of only boxed strings", () => {
+                let src = new RoArray([new RoString(new BrsString("x")), new RoString(new BrsString("y"))]);
+
+                let join = src.getMethod("join");
+                expect(join).toBeTruthy();
+                expect(join.call(interpreter, new BrsString("-"))).toEqual(new BrsString("x-y"));
             });
         });
 

--- a/test/brsTypes/components/RoAudioPlayer.test.js
+++ b/test/brsTypes/components/RoAudioPlayer.test.js
@@ -1,0 +1,88 @@
+const brs = require("../../../packages/node/bin/brs.node");
+const { Interpreter } = brs;
+const { RoAudioPlayer, RoAssociativeArray, RoArray, RoString, BrsString, Int32 } = brs.types;
+
+/** Builds a ContentMetaData-like associative array from the given members. */
+function contentItem(members) {
+    return new RoAssociativeArray(
+        Object.entries(members).map(([name, value]) => ({ name: new BrsString(name), value }))
+    );
+}
+
+describe("RoAudioPlayer", () => {
+    let interpreter;
+    let originalPostMessage;
+    let messages;
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+        messages = [];
+        originalPostMessage = global.postMessage;
+        global.postMessage = jest.fn((message) => messages.push(message));
+    });
+
+    afterEach(() => {
+        global.postMessage = originalPostMessage;
+    });
+
+    /** Returns the last posted audio playlist, or undefined if none was posted. */
+    function lastPlaylist() {
+        for (let i = messages.length - 1; i >= 0; i--) {
+            if (messages[i] && messages[i].audioPlaylist) {
+                return messages[i].audioPlaylist;
+            }
+        }
+        return undefined;
+    }
+
+    describe("stringification", () => {
+        it("lists stringified value", () => {
+            let player = new RoAudioPlayer();
+            expect(player.toString()).toEqual("<Component: roAudioPlayer>");
+        });
+    });
+
+    describe("setContentList", () => {
+        it("builds the playlist from plain string urls", () => {
+            let player = new RoAudioPlayer();
+            let setContentList = player.getMethod("setContentList");
+            expect(setContentList).toBeTruthy();
+
+            setContentList.call(
+                interpreter,
+                new RoArray([contentItem({ url: new BrsString("http://example.com/song.mp3") })])
+            );
+
+            expect(lastPlaylist()).toEqual(["http://example.com/song.mp3"]);
+        });
+
+        it("builds the playlist from boxed string urls (roString)", () => {
+            let player = new RoAudioPlayer();
+            let setContentList = player.getMethod("setContentList");
+            expect(setContentList).toBeTruthy();
+
+            setContentList.call(
+                interpreter,
+                new RoArray([
+                    contentItem({ url: new RoString(new BrsString("http://example.com/song.mp3")) }),
+                    contentItem({ url: new RoString(new BrsString("local.mp3")) }),
+                ])
+            );
+
+            expect(lastPlaylist()).toEqual(["http://example.com/song.mp3", "local.mp3"]);
+        });
+
+        it("skips items whose url is not a string", () => {
+            let player = new RoAudioPlayer();
+            let setContentList = player.getMethod("setContentList");
+            expect(setContentList).toBeTruthy();
+
+            setContentList.call(
+                interpreter,
+                new RoArray([contentItem({ url: new Int32(1) }), contentItem({ url: new BrsString("keep.mp3") })])
+            );
+
+            expect(lastPlaylist()).toEqual(["keep.mp3"]);
+        });
+    });
+});

--- a/test/brsTypes/components/RoVideoPlayer.test.js
+++ b/test/brsTypes/components/RoVideoPlayer.test.js
@@ -1,0 +1,86 @@
+const brs = require("../../../packages/node/bin/brs.node");
+const { RoVideoPlayer, RoAssociativeArray, RoString, BrsString, Int32 } = brs.types;
+
+/** Builds a ContentMetaData-like associative array from the given members. */
+function contentItem(members) {
+    return new RoAssociativeArray(
+        Object.entries(members).map(([name, value]) => ({ name: new BrsString(name), value }))
+    );
+}
+
+describe("RoVideoPlayer", () => {
+    describe("stringification", () => {
+        it("lists stringified value", () => {
+            let player = new RoVideoPlayer();
+            expect(player.toString()).toEqual("<Component: roVideoPlayer>");
+        });
+    });
+
+    describe("getContent", () => {
+        it("reads the url from a plain string", () => {
+            let player = new RoVideoPlayer();
+            player.contentList = [
+                contentItem({
+                    url: new BrsString("http://example.com/video.mp4"),
+                    streamFormat: new BrsString("mp4"),
+                }),
+            ];
+
+            expect(player.getContent()).toEqual([
+                { url: "http://example.com/video.mp4", streamFormat: "mp4", audioTrack: -1 },
+            ]);
+        });
+
+        it("reads the url from a boxed string (roString)", () => {
+            let player = new RoVideoPlayer();
+            player.contentList = [
+                contentItem({
+                    url: new RoString(new BrsString("http://example.com/video.mp4")),
+                    streamFormat: new RoString(new BrsString("MP4")),
+                }),
+            ];
+
+            expect(player.getContent()).toEqual([
+                { url: "http://example.com/video.mp4", streamFormat: "mp4", audioTrack: -1 },
+            ]);
+        });
+
+        it("reads the url from a boxed string inside a stream object", () => {
+            let player = new RoVideoPlayer();
+            player.contentList = [
+                contentItem({
+                    stream: contentItem({ url: new RoString(new BrsString("http://example.com/stream.m3u8")) }),
+                    streamFormat: new BrsString("hls"),
+                }),
+            ];
+
+            expect(player.getContent()).toEqual([
+                { url: "http://example.com/stream.m3u8", streamFormat: "hls", audioTrack: -1 },
+            ]);
+        });
+
+        it("lowercases a boxed streamFormat", () => {
+            let player = new RoVideoPlayer();
+            player.contentList = [
+                contentItem({
+                    url: new BrsString("video.mp4"),
+                    streamFormat: new RoString(new BrsString("MP4")),
+                }),
+            ];
+
+            expect(player.getContent()[0].streamFormat).toEqual("mp4");
+        });
+
+        it("ignores non-string url values", () => {
+            let player = new RoVideoPlayer();
+            player.contentList = [
+                contentItem({
+                    url: new Int32(42),
+                    streamFormat: new BrsString("mp4"),
+                }),
+            ];
+
+            expect(player.getContent()).toEqual([{ url: "", streamFormat: "mp4", audioTrack: -1 }]);
+        });
+    });
+});

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -915,6 +915,30 @@ describe("cli", () => {
         ]);
     }, 10000);
 
+    it("includes the source location in roArray warnings (dev mode)", async () => {
+        let command = ["node", brsCliPath, "roArrayWarnings.brs", "-c 0"].join(" ");
+
+        let { stdout, stderr } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+            env: { ...process.env, NODE_ENV: "development" },
+        });
+
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "join result: []",
+            "done",
+            "------ Finished 'roArrayWarnings.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+        expect(stderr).toContain(
+            "roArray.Join: Array contains non-string value(s). pkg:/source/roArrayWarnings.brs(4)"
+        );
+        expect(stderr).toContain("roArray.Sort: Flags contains invalid option(s). pkg:/source/roArrayWarnings.brs(8)");
+        expect(stderr).toContain(
+            "roArray.SortBy: Flags contains invalid option(s). pkg:/source/roArrayWarnings.brs(12)"
+        );
+    }, 10000);
+
     describe("SceneGraph .bpk encryption", () => {
         const password = "abcdefghij0123456789abcdefghij01"; // 32 chars (AES-256 key)
         const expected = [

--- a/test/cli/resources/roArrayWarnings.brs
+++ b/test/cli/resources/roArrayWarnings.brs
@@ -1,0 +1,15 @@
+sub Main()
+    ' Join on an array with a non-string element warns with the source location.
+    mixed = ["a", 1, "c"]
+    print "join result: [" mixed.join(",") "]"
+
+    ' Sort with invalid flags warns with the source location.
+    letters = ["b", "a", "c"]
+    letters.sort("x")
+
+    ' SortBy with invalid flags warns with the source location.
+    items = [{ name: "b" }, { name: "a" }]
+    items.sortBy("name", "x")
+
+    print "done"
+end sub


### PR DESCRIPTION
### Two related fixes to BrightScript component behavior:

1. Boxed String (roString) handling — RoArray.join, RoAudioPlayer, and RoVideoPlayer only recognized intrinsic BrsString values (via instanceof BrsString), silently ignoring boxed
strings (roString). They now use the isBrsString() helper (which matches both BrsString and RoString) and read the value through getValue().
2. Source location in roArray warnings — the dev-mode warnings emitted by roArray.Join, roArray.Sort, and roArray.SortBy now append interpreter.formatLocation(), so the message
points at the offending line (e.g. pkg:/source/main.brs(4)) instead of being location-less.

### Details

- RoArray.join — the non-string guard used !(element instanceof BrsString), so an array of boxed strings joined to "". Now uses !isBrsString(element), so boxed strings join
correctly.
- RoAudioPlayer.getContent — resolves each item's url with isBrsString + getValue(), so playlists built from boxed-string urls are populated instead of dropped.
- RoVideoPlayer.getContent — same treatment for url (top-level and nested inside a stream object) and streamFormat.
- Warnings — Join / Sort / SortBy warnings interpolate interpreter.formatLocation(). These only fire in developer mode (BrsDevice.isDevMode).
