### PR TITLE
fix(rsg): change `ContentNode.subtitleTracks` type from `assocarray` to `array`

### DIFF
--- a/src/extensions/scenegraph/nodes/ContentNode.ts
+++ b/src/extensions/scenegraph/nodes/ContentNode.ts
@@ -102,7 +102,7 @@ export class ContentNode extends Node {
         { name: "streamUrls", type: "stringarray", hidden: true },
         { name: "subtitleColor", type: "string", hidden: true },
         { name: "subtitleConfig", type: "assocarray", hidden: true },
-        { name: "subtitleTracks", type: "assocarray", hidden: true },
+        { name: "subtitleTracks", type: "array", hidden: true },
         { name: "subtitleUrl", type: "string", hidden: true },
         { name: "switchingStrategy", type: "string", hidden: true },
         { name: "targetRect", type: "assocarray", hidden: true },


### PR DESCRIPTION
Adjusting the type of `subtitleTracks` according to the [Content Metadata documentation](https://developer.roku.com/dev/docs/content-metadata). The field must be an Array of AssociateArrays, not an AssociateArray.