### PR TITLE
fix(rsg): Properly handle boxed Strings in PosterGrid, ScrollableText, and ZoomRowList

### DIFF
--- a/src/extensions/scenegraph/nodes/PosterGrid.ts
+++ b/src/extensions/scenegraph/nodes/PosterGrid.ts
@@ -9,6 +9,7 @@ import {
     IfDraw2D,
     Rect,
     RoFont,
+    isBrsString,
 } from "brs-engine";
 import { FieldKind, FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";
@@ -121,7 +122,7 @@ export class PosterGrid extends ArrayGrid {
 
     setValue(index: string, value: BrsType, alwaysNotify?: boolean, kind?: FieldKind) {
         const fieldName = index.toLowerCase();
-        if (fieldName === "vertfocusanimationstyle" && value instanceof BrsString) {
+        if (fieldName === "vertfocusanimationstyle" && isBrsString(value)) {
             const style = value.getValue().toLowerCase();
             if (ValidFocusStyles.has(style)) {
                 this.vertFocusAnimationStyleName = style;

--- a/src/extensions/scenegraph/nodes/ScrollableText.ts
+++ b/src/extensions/scenegraph/nodes/ScrollableText.ts
@@ -10,6 +10,7 @@ import {
     RoBitmap,
     RoFont,
     Rect,
+    isBrsString,
 } from "brs-engine";
 import { FieldKind, FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";
@@ -93,10 +94,10 @@ export class ScrollableText extends Group {
             // Track focus state: focusedChild is set to `this` when focused, BrsInvalid when unfocused
             this.focused = !(value instanceof BrsInvalid) && value !== null && value !== undefined;
         } else if (fieldName === "scrollbartrackbitmapuri") {
-            const uri = value instanceof BrsString ? value.getValue() : "";
+            const uri = isBrsString(value) ? value.getValue() : "";
             this.customTrackBitmap = uri ? this.loadBitmap(uri) : undefined;
         } else if (fieldName === "scrollbarthumbbitmapuri") {
-            const uri = value instanceof BrsString ? value.getValue() : "";
+            const uri = isBrsString(value) ? value.getValue() : "";
             this.customThumbBitmap = uri ? this.loadBitmap(uri) : undefined;
         }
         super.setValue(index, value, alwaysNotify, kind, sync);

--- a/src/extensions/scenegraph/nodes/ScrollableText.ts
+++ b/src/extensions/scenegraph/nodes/ScrollableText.ts
@@ -3,14 +3,13 @@ import {
     Interpreter,
     BrsBoolean,
     BrsInvalid,
-    BrsString,
+    isBrsString,
     BrsType,
     Float,
     IfDraw2D,
     RoBitmap,
     RoFont,
     Rect,
-    isBrsString,
 } from "brs-engine";
 import { FieldKind, FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";

--- a/src/extensions/scenegraph/nodes/ZoomRowList.ts
+++ b/src/extensions/scenegraph/nodes/ZoomRowList.ts
@@ -12,6 +12,7 @@ import {
     IfDraw2D,
     Rect,
     RoFont,
+    isBrsString,
 } from "brs-engine";
 import { sgRoot } from "../SGRoot";
 import { ContentNode } from "./ContentNode";
@@ -161,7 +162,7 @@ export class ZoomRowList extends ArrayGrid {
             if (typeof coords[0] === "number" && typeof coords[1] === "number") {
                 this.setFocusedItem(coords[0], coords[1]);
             }
-        } else if (fieldName === "rowfocusanimationstyle" && value instanceof BrsString) {
+        } else if (fieldName === "rowfocusanimationstyle" && isBrsString(value)) {
             // Horizontal item focus style; validate but do NOT let it drive vertical wrap.
             const style = value.toString().toLowerCase();
             if (!ValidFocusStyles.has(style)) {


### PR DESCRIPTION
The `setValue()` can receive boxed values and some Nodes were not properly handling boxed String values.