### PR TITLE
fix(rsg): position PanelSet right panel using the left panel's leftPosition

### DIFF
--- a/src/extensions/scenegraph/nodes/PanelSet.ts
+++ b/src/extensions/scenegraph/nodes/PanelSet.ts
@@ -205,8 +205,9 @@ export class PanelSet extends Group {
                     panel2.setTranslationX(panel2PosX);
                 } else {
                     panel.renderNode(interpreter, origin, angle, opacity, draw2D);
+                    // Per Roku spec: right panel origin = left panel leftPosition + left panel width + spacing
                     const panel2PosX =
-                        (panel2.getValueJS("leftPosition") as number) +
+                        (panel.getValueJS("leftPosition") as number) +
                         (panel.getValueJS("width") as number) +
                         (this.resolution === "HD" ? DefaultPanelGapHD : DefaultPanelGapHD * 1.5);
                     panel2.setTranslationX(panel2PosX);

--- a/test/extensions/scenegraph/PanelSetSpacing.test.js
+++ b/test/extensions/scenegraph/PanelSetSpacing.test.js
@@ -1,0 +1,68 @@
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsBoolean, Float, Interpreter } = core;
+
+/**
+ * Regression: PanelSet right-panel spacing. Per the Roku spec, when two panels are onscreen the
+ * right panel's origin is (leftPosition + leftWidth + spacing), where leftPosition and leftWidth
+ * are the LEFT panel's fields (spacing: 30 px HD). The engine used the RIGHT panel's own
+ * leftPosition instead, so an app that sets leftPosition = 0 only on its left menu panel (the
+ * right panel keeping the "narrow" default of 105) rendered the right panel ~105 px (HD) too far
+ * right — a visibly larger gap than a real device.
+ */
+describe("PanelSet positions the right panel from the left panel's fields", () => {
+    let interpreter;
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    function buildPanelSet() {
+        const panelSet = SGNodeFactory.createNode("PanelSet");
+        const leftPanel = SGNodeFactory.createNode("Panel");
+        leftPanel.setValue("leftPosition", new Float(0));
+        leftPanel.setValue("width", new Float(437));
+        leftPanel.setValue("leftOnly", BrsBoolean.True);
+        const rightPanel = SGNodeFactory.createNode("Panel");
+        // rightPanel keeps the Panel defaults: panelSize "narrow" -> leftPosition 105 (HD).
+        panelSet.appendChildToParent(leftPanel);
+        panelSet.appendChildToParent(rightPanel);
+        return { panelSet, leftPanel, rightPanel };
+    }
+
+    test("right panel x = left leftPosition + left width + default gap", () => {
+        const { panelSet, leftPanel, rightPanel } = buildPanelSet();
+
+        panelSet.renderNode(interpreter, [0, 0], 0, 1);
+
+        expect(leftPanel.getValueJS("translation")[0]).toBe(0);
+        // 0 (left leftPosition) + 437 (left width) + 30 (HD gap) — NOT 105 + 437 + 30.
+        expect(rightPanel.getValueJS("translation")[0]).toBe(467);
+    });
+
+    test("the right panel's own leftPosition does not shift it", () => {
+        const { panelSet, rightPanel } = buildPanelSet();
+        rightPanel.setValue("leftPosition", new Float(300));
+
+        panelSet.renderNode(interpreter, [0, 0], 0, 1);
+
+        expect(rightPanel.getValueJS("translation")[0]).toBe(467);
+    });
+
+    test("a lone left panel sits at its own leftPosition", () => {
+        const panelSet = SGNodeFactory.createNode("PanelSet");
+        const leftPanel = SGNodeFactory.createNode("Panel");
+        leftPanel.setValue("leftPosition", new Float(60));
+        panelSet.appendChildToParent(leftPanel);
+
+        panelSet.renderNode(interpreter, [0, 0], 0, 1);
+
+        expect(leftPanel.getValueJS("translation")[0]).toBe(60);
+    });
+});


### PR DESCRIPTION
## Problem

When a `PanelSet` shows two panels, the right panel was rendered with a larger horizontal gap from the left panel than on a real Roku device — visible in apps that use the sliding-panels nodes for a settings-style screen (menu list on the left, content panel on the right).

## Root cause

Per the Roku spec ([panelset.md](https://developer.roku.com/docs/references/scenegraph/sliding-panels-nodes/panelset.md)):

> The PanelSet node positions the right panel so that the panel origin is at (`leftPosition + leftWidth + spacing`), where `leftPosition` and `leftWidth` are the **left panel** `leftPosition` and `width` fields.

`PanelSet.renderChildren` used the **right** panel's own `leftPosition` in that formula. An app that sets `leftPosition = 0` only on its left menu panel (the right panel keeping the `narrow` default of 105 HD / 157.5 FHD) got the right panel ~105px (HD) / ~157px (FHD) too far right.

## Fix

Read `leftPosition` from the left panel, matching the spec. The full-screen-panel branch (which legitimately positions a panel by its own `leftPosition`) is untouched.

## Tests

- New `test/extensions/scenegraph/PanelSetSpacing.test.js`: right panel x = left `leftPosition` + left `width` + default gap; the right panel's own `leftPosition` does not shift it; a lone left panel sits at its own `leftPosition`.
- Existing `panelset-nextpanel-app` / `panelset-clearpanel-app` CLI suites and the full SceneGraph extension suite (410 tests) stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)