### PR TITLE
fix(rsg): paint a black plane while a full-screen Video with UI enabled is buffering

### DIFF
--- a/src/extensions/scenegraph/nodes/Video.ts
+++ b/src/extensions/scenegraph/nodes/Video.ts
@@ -758,12 +758,20 @@ export class Video extends Group {
         // transparent hole cleared into the graphics buffer that the main thread fills with that one
         // element's frames — so only the node that currently OWNS the element (`sgRoot.video`) and
         // is actively presenting a frame (playing/paused) may position it and punch the hole. A
-        // non-owner instance, or the owner once it is finished/stopped/buffering, punches nothing and
-        // disappears cleanly: this prevents a second Video (or the just-finished startup logo) from
-        // resizing the element and leaking its stale last frame as a shrunken picture, and prevents a
-        // frame-less hole from showing through as a black box before the next screen renders.
+        // non-owner instance punches nothing and disappears cleanly: this prevents a second Video
+        // (or the just-finished startup logo) from resizing the element and leaking its stale last
+        // frame as a shrunken picture, and prevents a frame-less hole from showing through as a
+        // black box before the next screen renders.
+        //
+        // While the owner is BUFFERING (loading, before the first frame) a full-screen Video shows a
+        // black plane on Roku so the busy spinner appears over black. We must NOT clear a transparent
+        // hole here — the shared element may still hold a stale frame that would leak through — so we
+        // paint a solid black rect instead. Gated on `isFullscreen()` so it never reintroduces a
+        // black box over a windowed/preview Video.
         const state = this.getValueJS("state") as string;
-        const presenting = sgRoot.video === this && opacity > 0 && (state === "playing" || state === "paused");
+        const owner = sgRoot.video === this && opacity > 0;
+        const presenting = owner && (state === "playing" || state === "paused");
+        const buffering = owner && state === "buffering" && this.isFullscreen();
         if (this.isDirty && presenting) {
             postMessage(`video,rect,${rect.x},${rect.y},${rect.width},${rect.height}`);
         }
@@ -771,6 +779,8 @@ export class Video extends Group {
             this.isDirty = false;
             if (presenting) {
                 draw2D.doDrawClearedRect(rect);
+            } else if (buffering) {
+                draw2D.doDrawRotatedRect(rect, 0x000000ff, 0, [0, 0], opacity);
             }
         }
         if (this.statusChanged) {

--- a/src/extensions/scenegraph/nodes/Video.ts
+++ b/src/extensions/scenegraph/nodes/Video.ts
@@ -771,7 +771,7 @@ export class Video extends Group {
         const state = this.getValueJS("state") as string;
         const owner = sgRoot.video === this && opacity > 0;
         const presenting = owner && (state === "playing" || state === "paused");
-        const buffering = owner && state === "buffering" && this.isFullscreen();
+        const buffering = owner && state === "buffering" && this.uiVisible();
         if (this.isDirty && presenting) {
             postMessage(`video,rect,${rect.x},${rect.y},${rect.width},${rect.height}`);
         }

--- a/test/extensions/scenegraph/Video.test.js
+++ b/test/extensions/scenegraph/Video.test.js
@@ -222,12 +222,24 @@ describe("Video plane is only rendered by the owning, actively-presenting Video"
     // just-finished) Video resizes the element and leaks its stale last frame as a shrunken
     // picture, or punches a frame-less hole that shows through as a black box.
     function makeDraw2D() {
-        return {
+        const target = {
             cleared: [],
+            filled: [],
             doDrawClearedRect(rect) {
                 this.cleared.push({ ...rect });
             },
+            doDrawRotatedRect(rect, rgba, rotation, center, opacity) {
+                this.filled.push({ rect: { ...rect }, rgba, rotation, opacity });
+            },
         };
+        // A buffering fullscreen Video renders its (now-visible) spinner child, which reaches for
+        // other IfDraw2D methods (doDrawScaledObject, …). Return a no-op for anything not tracked.
+        return new Proxy(target, {
+            get(obj, prop) {
+                if (prop in obj) return obj[prop];
+                return () => {};
+            },
+        });
     }
 
     function fullScreenVideo() {
@@ -293,6 +305,56 @@ describe("Video plane is only rendered by the owning, actively-presenting Video"
         video.renderNode({}, [0, 0], 0, 0, draw2D);
 
         expect(draw2D.cleared).toHaveLength(0);
+    });
+
+    // While buffering (loading, before the first frame), a full-screen owner shows a solid BLACK
+    // plane so the busy spinner appears over black — Roku's loading screen. It must NOT clear the
+    // transparent hole (the shared <video> element may still hold a stale frame that would leak
+    // through) and must NOT post the rect.
+    test("the owning full-screen Video paints a solid black plane while buffering", () => {
+        const video = fullScreenVideo();
+        sgRoot.setVideo(video);
+        video.setState(MediaEvent.Loading, 0); // -> "buffering"
+        video.makeDirty();
+        const draw2D = makeDraw2D();
+        global.postMessage.mockClear();
+
+        video.renderNode({}, [0, 0], 0, 1, draw2D);
+
+        expect(video.getValueJS("state")).toBe("buffering");
+        expect(draw2D.cleared).toHaveLength(0);
+        expect(draw2D.filled).toHaveLength(1);
+        expect(draw2D.filled[0].rect).toMatchObject({ x: 0, y: 0, width: 1920, height: 1080 });
+        expect(draw2D.filled[0].rgba >>> 0).toBe(0x000000ff);
+        expect(global.postMessage).not.toHaveBeenCalledWith(expect.stringContaining("video,rect"));
+    });
+
+    test("a non-owner buffering Video paints nothing", () => {
+        const owner = fullScreenVideo();
+        sgRoot.setVideo(owner);
+        const other = fullScreenVideo();
+        other.setState(MediaEvent.Loading, 0); // -> "buffering", but not the owner
+        expect(sgRoot.video).toBe(owner);
+        const draw2D = makeDraw2D();
+
+        other.renderNode({}, [0, 0], 0, 1, draw2D);
+
+        expect(draw2D.cleared).toHaveLength(0);
+        expect(draw2D.filled).toHaveLength(0);
+    });
+
+    test("a windowed buffering Video paints no black plane", () => {
+        const video = SGNodeFactory.createNode("Video");
+        video.setValue("width", new core.Float(640));
+        video.setValue("height", new core.Float(360));
+        sgRoot.setVideo(video);
+        video.setState(MediaEvent.Loading, 0); // -> "buffering"
+        const draw2D = makeDraw2D();
+
+        video.renderNode({}, [0, 0], 0, 1, draw2D);
+
+        expect(draw2D.cleared).toHaveLength(0);
+        expect(draw2D.filled).toHaveLength(0);
     });
 });
 


### PR DESCRIPTION
## Problem

Regression introduced by #1047. The video-plane gate only cleared the transparent hole (and posted the `video,rect` geometry) while the owning Video was `playing` or `paused`. During the **buffering** phase — after `control="play"` but before the first frame — nothing was drawn over the plane, so the busy spinner rendered over whatever screen was shown before rather than over black.

Expected: with playback full-screen and UI enabled, the screen goes black and the spinner is visible while loading.

## Root cause

#1047 tightened the gate to `owner && (state === "playing" || state === "paused")` to stop non-owner / finished Video instances from resizing the single shared browser `<video>` element and leaking a stale last frame. That gate is correct, but it also stopped the buffering phase from drawing anything.

We can't simply restore the old transparent-hole clear during buffering: the shared element may still hold a stale frame that would leak through the hole (exactly what #1047 removed).

## Fix

In `Video.renderNode`, add a `buffering = owner && state === "buffering" && this.uiVisible()` branch that paints a **solid opaque black rect** over the plane instead of clearing a transparent hole. This guarantees black without ever exposing the shared element's contents. Gated on `this.uiVisible()` that includes check for `isFullscreen()` so it can't reintroduce a black box over a windowed/preview Video. The spinner (a child) renders on top, since the plane is drawn before `renderChildren`.

## Tests

`test/extensions/scenegraph/Video.test.js`:
- owner full-screen buffering → one full-rect black `doDrawRotatedRect`, no cleared hole, no `video,rect`
- non-owner buffering → paints nothing
- windowed buffering → no black plane

All 21 Video tests pass; lint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)