### PR TITLE
fix: handle boxed numbers in for-loop bounds and if/while conditions

### DIFF
--- a/src/core/interpreter/index.ts
+++ b/src/core/interpreter/index.ts
@@ -1454,7 +1454,10 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
     visitFor(statement: Stmt.For): BrsType {
         // BrightScript for/to loops evaluate the counter initial value, final value, and increment
         // values *only once*, at the top of the for/to loop.
-        let increment = this.evaluate(statement.increment) as Int32 | Float;
+        // Boxed numbers (roInt/roFloat/…) are valid in every numeric slot, matching Roku — e.g. a
+        // SceneGraph field read returns a boxed value, and `for i = node.maxLines to 0 step -1`
+        // must not crash. Unbox them up front so the comparisons below see intrinsic types.
+        let increment = this.unboxIfNumber(this.evaluate(statement.increment)) as Int32 | Float;
         if (increment instanceof Float) {
             increment = new Int32(Math.trunc(increment.getValue()));
         }
@@ -1476,13 +1479,16 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
         let startValue: BrsType;
         if (this.environment.continueFor) {
             this.execute(step);
-            startValue = this.evaluate(new Expr.Variable(counterName)) as Int32 | Float;
+            startValue = this.unboxIfNumber(this.evaluate(new Expr.Variable(counterName))) as Int32 | Float;
             this.environment.continueFor = false;
         } else {
             this.execute(statement.counterDeclaration);
-            startValue = this.evaluate(statement.counterDeclaration.value) as Int32 | Float;
+            startValue = this.unboxIfNumber(this.evaluate(statement.counterDeclaration.value)) as Int32 | Float;
+            // Keep the loop variable intrinsic even when the initial value was boxed, so the body
+            // and the comparisons below always see the same numeric type.
+            this.environment.define(Scope.Function, counterName.text, startValue, counterName.location);
         }
-        const finalValue = this.evaluate(statement.finalValue) as Int32 | Float;
+        const finalValue = this.unboxIfNumber(this.evaluate(statement.finalValue)) as Int32 | Float;
         if (
             (startValue.getValue() > finalValue.getValue() && increment.getValue() > 0) ||
             (startValue.getValue() < finalValue.getValue() && increment.getValue() < 0)
@@ -1493,7 +1499,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
 
         if (increment.getValue() > 0) {
             while (
-                (this.evaluate(new Expr.Variable(counterName)) as Int32 | Float)
+                (this.unboxIfNumber(this.evaluate(new Expr.Variable(counterName))) as Int32 | Float)
                     .greaterThan(finalValue)
                     .not()
                     .toBoolean()
@@ -1517,7 +1523,10 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
             }
         } else {
             while (
-                (this.evaluate(new Expr.Variable(counterName)) as Int32 | Float).lessThan(finalValue).not().toBoolean()
+                (this.unboxIfNumber(this.evaluate(new Expr.Variable(counterName))) as Int32 | Float)
+                    .lessThan(finalValue)
+                    .not()
+                    .toBoolean()
             ) {
                 // execute the block
                 try {
@@ -1606,7 +1615,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
     }
 
     visitWhile(statement: Stmt.While): BrsType {
-        while (this.evaluate(statement.condition).equalTo(BrsBoolean.True).toBoolean()) {
+        while (this.evaluateCondition(statement.condition)) {
             try {
                 this.execute(statement.body);
             } catch (reason) {
@@ -1625,12 +1634,12 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
     }
 
     visitIf(statement: Stmt.If): BrsType {
-        if (this.evaluate(statement.condition).equalTo(BrsBoolean.True).toBoolean()) {
+        if (this.evaluateCondition(statement.condition)) {
             this.execute(statement.thenBranch);
             return BrsInvalid.Instance;
         } else {
             for (const elseIf of statement.elseIfs || []) {
-                if (this.evaluate(elseIf.condition).equalTo(BrsBoolean.True).toBoolean()) {
+                if (this.evaluateCondition(elseIf.condition)) {
                     this.execute(elseIf.thenBranch);
                     return BrsInvalid.Instance;
                 }
@@ -2350,5 +2359,29 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
             return value.lessThan(compare);
         }
         return value < compare;
+    }
+
+    /**
+     * Unboxes boxed numeric components (roInt, roFloat, …) to their intrinsic value;
+     * returns any other value unchanged.
+     * @param value Value to unbox
+     * @returns The intrinsic number, or the original value
+     */
+    private unboxIfNumber(value: BrsType): BrsType {
+        return isBoxedNumber(value) ? value.unbox() : value;
+    }
+
+    /**
+     * Evaluates an `if`/`while` condition expression to a JS boolean. Boxed numbers
+     * (roInt, roFloat, …) are unboxed first so they truth-test like their intrinsic
+     * values, matching Roku (e.g. `if node.someIntField` where the field read returns
+     * a boxed roInt) — their `equalTo` only compares against the same class. roBoolean
+     * needs no unboxing: its `equalTo` already handles intrinsic booleans and numbers.
+     * @param condition The condition expression to evaluate
+     * @returns The truthiness of the condition
+     */
+    private evaluateCondition(condition: Expr.Expression): boolean {
+        const value = this.unboxIfNumber(this.evaluate(condition));
+        return value.equalTo(BrsBoolean.True).toBoolean();
     }
 }

--- a/src/core/interpreter/index.ts
+++ b/src/core/interpreter/index.ts
@@ -1476,7 +1476,7 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                 new Expr.Literal(increment, statement.increment.location)
             )
         );
-        let startValue: BrsType;
+        let startValue: Int32 | Float;
         if (this.environment.continueFor) {
             this.execute(step);
             startValue = this.unboxIfNumber(this.evaluate(new Expr.Variable(counterName))) as Int32 | Float;

--- a/test/e2e/Syntax.test.js
+++ b/test/e2e/Syntax.test.js
@@ -326,6 +326,9 @@ describe("end to end syntax", () => {
             "for loop exit", // exit early
             " 0", // e after loop
             "initial = final", // loop where initial equals final
+            " 2",
+            " 1",
+            " 0", // boxed start/final/step count down
         ]);
     });
 
@@ -511,6 +514,9 @@ describe("end to end syntax", () => {
             "true false",
             "one false",
             "one true",
+            "boxed int true",
+            "boxed zero false",
+            "boxed int while",
         ]);
     });
 

--- a/test/e2e/resources/boxed-boolean.brs
+++ b/test/e2e/resources/boxed-boolean.brs
@@ -14,4 +14,13 @@ sub main()
             print "both false"
         end if
     end if
+    ' boxed numbers truth-test like their intrinsic value in if/while conditions
+    n = box(1)
+    if n then print "boxed int true"
+    z = box(0)
+    if z then print "wrong" else print "boxed zero false"
+    while n
+        print "boxed int while"
+        exit while
+    end while
 end sub

--- a/test/e2e/resources/for-loops.brs
+++ b/test/e2e/resources/for-loops.brs
@@ -62,3 +62,8 @@ for a = 1.9 to 10.2 step -1.1
     print "this should not be printed"
     exit for
 next
+
+'ensure boxed numbers (e.g. values read from SceneGraph node fields) work in every slot
+for f = box(2) to box(0) step box(-1)
+    print f
+end for


### PR DESCRIPTION
## Problem

Boxed numeric components (`roInt`, `roFloat`, …) are valid in every numeric slot on a real Roku — and a SceneGraph node field read returns a boxed value — but the interpreter assumed intrinsic types in two places:

1. **`for` loop crash.** `visitFor` called `lessThan`/`greaterThan` directly on the counter/start/final/step values. A boxed value in any of those slots crashed:

   ```brightscript
   maxNumLines = m.description.maxLines  ' node field read returns a boxed roInt
   for i = maxNumLines to 0 step -1      ' crashes
   ```

   ```
   WARNING: roSGNode.Set (unhandled exception): "...": this.evaluate(...).lessThan is not a function
   ```

   Surfaced by a production SceneGraph app measuring a Label's line count inside a field observer.

2. **`if`/`while` silent wrong branch.** Conditions were truth-tested via `equalTo(BrsBoolean.True)`, but each boxed number's `equalTo` only compares against its own class (`RoInt.equalTo` returns `false` for anything that isn't an `RoInt`). So `if node.someIntField` silently took the wrong branch — no crash, no warning.

## Fix

- `visitFor` unboxes the start, final, and step values up front (new `unboxIfNumber` helper), redefines the counter variable as intrinsic so the loop body sees a plain number, and unboxes the per-iteration counter read (the body can reassign the counter to a boxed value).
- `visitIf`/`visitWhile` now evaluate conditions through a shared `evaluateCondition` helper that unboxes numbers before the truth test. `roBoolean` is intentionally **not** unboxed — its `equalTo` already handles intrinsic booleans and numbers, so boxed booleans always worked.

Everything else was audited and already handles boxed values correctly: binary operators (arithmetic, comparisons, `mod`, `^`, bit shifts, concat), `and`/`or` RHS, unary `-`/`not`, `++`/`--`, `Dim`, indexed get/set with boxed indexes/keys, typed parameters, return-type coercion, type designators, and `throw`.

## Tests

- `test/e2e/resources/for-loops.brs`: boxed start/final/step count-down loop.
- `test/e2e/resources/boxed-boolean.brs`: boxed-int true/zero-false `if` and boxed-int `while` conditions.

Both new cases fail against master and pass with this change. Full suite green (the two ECP `query/r2d2-bitmaps` tests only fail locally when another app is holding port 8060).

🤖 Generated with [Claude Code](https://claude.com/claude-code)