### PR TITLE
fix(rsg): keep ButtonGroup from managing custom (non-Button) Group children

### DIFF
--- a/src/extensions/scenegraph/nodes/ButtonGroup.ts
+++ b/src/extensions/scenegraph/nodes/ButtonGroup.ts
@@ -105,7 +105,9 @@ export class ButtonGroup extends LayoutGroup {
     }
 
     appendChildToParent(child: BrsType): boolean {
-        if (child instanceof Group) {
+        // Only Button children are managed by the group; custom Group components keep their
+        // own text/size/position and are laid out by the inherited LayoutGroup behavior.
+        if (child instanceof Button) {
             const buttonText = child.getValue("text");
             const buttons = this.getValue("buttons");
             if (buttons instanceof RoArray && isBrsString(buttonText)) {
@@ -117,6 +119,19 @@ export class ButtonGroup extends LayoutGroup {
         return super.appendChildToParent(child);
     }
 
+    /**
+     * The group manages layout, appearance and focus only for Button children (created from the
+     * `buttons` string array or appended directly). A group holding only custom Group components
+     * behaves as a plain LayoutGroup, as on Roku.
+     */
+    private isManagedMode(): boolean {
+        const buttons = jsValueOf(this.getValue("buttons")) as string[] | undefined;
+        if (buttons?.length) {
+            return true;
+        }
+        return this.children.some((child) => child instanceof Button);
+    }
+
     setNodeFocus(focusOn: boolean): boolean {
         const focus = super.setNodeFocus(focusOn);
         if (focus) {
@@ -126,6 +141,13 @@ export class ButtonGroup extends LayoutGroup {
     }
 
     handleKey(key: string, press: boolean): boolean {
+        // Only consume keys when the group manages Button children and the key focus is on the
+        // group or one of those buttons — otherwise let the key bubble to the app's onKeyEvent.
+        const focused = sgRoot.focused;
+        const focusWithin = focused === this || (focused instanceof Button && focused.getNodeParent() === this);
+        if (!this.isManagedMode() || !focusWithin) {
+            return false;
+        }
         if (!press && this.lastPressHandled === key) {
             this.lastPressHandled = "";
             return true;
@@ -148,6 +170,12 @@ export class ButtonGroup extends LayoutGroup {
     }
 
     renderNode(interpreter: Interpreter, origin: number[], angle: number, opacity: number, draw2D?: IfDraw2D) {
+        if (!this.isManagedMode()) {
+            // No managed Button children: behave as a plain LayoutGroup so the app's
+            // layoutDirection/itemSpacings and child translations are honored.
+            super.renderNode(interpreter, origin, angle, opacity, draw2D);
+            return;
+        }
         if (!this.isVisible()) {
             this.updateRenderTracking(true);
             return;
@@ -182,7 +210,7 @@ export class ButtonGroup extends LayoutGroup {
 
     private refreshButtons() {
         const buttons = jsValueOf(this.getValue("buttons")) as string[];
-        if (!buttons) {
+        if (!buttons?.length) {
             return;
         }
         const buttonsCount = Math.max(buttons.length, this.children.length);
@@ -193,7 +221,11 @@ export class ButtonGroup extends LayoutGroup {
             const buttonText = buttons[i];
             if (buttonText) {
                 let button = this.children[i];
-                if (!(button instanceof Group)) {
+                if (button instanceof Group && !(button instanceof Button)) {
+                    // Custom Group child: not managed — leave its text/size/position alone.
+                    continue;
+                }
+                if (!(button instanceof Button)) {
                     button = this.createButton();
                 }
                 button.setValueSilent("text", new BrsString(buttonText));
@@ -221,7 +253,12 @@ export class ButtonGroup extends LayoutGroup {
                 break;
             }
         }
-        this.children.splice(buttons.length);
+        // Drop only surplus managed Buttons beyond the `buttons` array — never custom children.
+        for (let i = this.children.length - 1; i >= buttons.length; i--) {
+            if (this.children[i] instanceof Button) {
+                this.children.splice(i, 1);
+            }
+        }
     }
 
     private createButton(): Button {
@@ -237,15 +274,29 @@ export class ButtonGroup extends LayoutGroup {
     }
 
     private refreshFocus() {
+        if (!this.isManagedMode()) {
+            return;
+        }
         const focusedNode = sgRoot.focused;
-        if (
-            this.children.length &&
-            focusedNode instanceof RoSGNode &&
-            (focusedNode === this || focusedNode.getNodeParent() === this)
-        ) {
+        if (this.children.length && focusedNode === this) {
+            // Per Roku: when the ButtonGroup itself has focus, key focus goes to one of its buttons.
             const focusedButton = this.children[this.focusIndex];
-            if (focusedNode !== focusedButton && focusedButton instanceof RoSGNode) {
+            if (focusedButton instanceof RoSGNode) {
                 sgRoot.setFocused(focusedButton);
+            }
+            this.wasFocused = true;
+        } else if (
+            focusedNode instanceof Button &&
+            focusedNode.getNodeParent() === this &&
+            this.children.includes(focusedNode)
+        ) {
+            // A managed button was focused directly (e.g. by app code): follow it instead of
+            // stealing focus back to the previously focused index.
+            const index = this.children.indexOf(focusedNode);
+            if (index !== this.focusIndex) {
+                this.focusIndex = index;
+                super.setValue("buttonFocused", new Int32(index));
+                this.isDirty = true;
             }
             this.wasFocused = true;
         } else if (this.wasFocused) {

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -840,6 +840,35 @@ describe("cli", () => {
         ]);
     }, 10000);
 
+    it("ButtonGroup leaves custom (non-Button) children unmanaged", async () => {
+        let command = ["node", brsCliPath, "-r buttongroup-custom-children-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        // Repro of a keyboard screen whose bottom row is a built-in ButtonGroup used purely as a
+        // horizontal layout container for custom Group-based button components, with the screen
+        // moving focus between them via setFocus(). The group must not manage such children: it
+        // used to capture them into `buttons`, re-stack them vertically at x=0 (drawing the right
+        // button over the left), steal focus back to index 0 on every render, and consume OK —
+        // firing buttonSelected for the wrong (hidden) button.
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "=== ButtonGroup Custom Children Repro ===",
+            "left x =  0",
+            "right x =  216",
+            "left text = Left",
+            "right text = Right",
+            "right hasFocus = true",
+            "left hasFocus = true",
+            "right x after focus =  216",
+            "children count =  2",
+            "=== ButtonGroup Custom Children Complete ===",
+            "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+    }, 10000);
+
     it("PanelSet creates the right panel on item focus without hasNextPanel", async () => {
         let command = ["node", brsCliPath, "-r panelset-nextpanel-app", "source/main.brs", "-c 0"].join(" ");
 

--- a/test/cli/resources/buttongroup-custom-children-app/components/MainScene.brs
+++ b/test/cli/resources/buttongroup-custom-children-app/components/MainScene.brs
@@ -1,0 +1,3 @@
+sub init()
+    m.top.backgroundColor = "0x101010FF"
+end sub

--- a/test/cli/resources/buttongroup-custom-children-app/components/MainScene.xml
+++ b/test/cli/resources/buttongroup-custom-children-app/components/MainScene.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="MainScene" extends="Scene">
+    <script type="text/brightscript" uri="pkg:/components/MainScene.brs" />
+    <children>
+        <Rectangle id="background" width="1280" height="720" color="0x101010FF" />
+        <!-- A built-in ButtonGroup used purely as a horizontal layout container for custom
+             Group-based button components (a common app pattern) — the group must not manage
+             them: no repositioning, no focus stealing, no key consumption. -->
+        <ButtonGroup
+            id="buttonRow"
+            layoutDirection="horiz"
+            itemSpacings="[39]"
+            translation="[100, 600]">
+            <PlainButton id="leftButton" text="Left" width="177" />
+            <PlainButton id="rightButton" text="Right" width="500" />
+        </ButtonGroup>
+    </children>
+</component>

--- a/test/cli/resources/buttongroup-custom-children-app/components/PlainButton.brs
+++ b/test/cli/resources/buttongroup-custom-children-app/components/PlainButton.brs
@@ -1,0 +1,22 @@
+sub init()
+    m.bg = m.top.findNode("bg")
+    m.label = m.top.findNode("label")
+    m.top.focusable = true
+end sub
+
+sub onTextChanged()
+    m.label.text = m.top.text
+end sub
+
+sub onWidthChanged()
+    m.bg.width = m.top.width
+    m.label.width = m.top.width
+end sub
+
+function onKeyEvent(key as string, press as boolean) as boolean
+    if press and key = "OK"
+        m.top.selected = true
+        return true
+    end if
+    return false
+end function

--- a/test/cli/resources/buttongroup-custom-children-app/components/PlainButton.xml
+++ b/test/cli/resources/buttongroup-custom-children-app/components/PlainButton.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="PlainButton" extends="Group">
+    <script type="text/brightscript" uri="pkg:/components/PlainButton.brs" />
+    <interface>
+        <field id="text" type="string" onChange="onTextChanged" />
+        <field id="width" type="float" onChange="onWidthChanged" />
+        <field id="selected" type="boolean" alwaysNotify="true" />
+    </interface>
+    <children>
+        <Rectangle id="bg" height="48" color="0x303030FF" />
+        <Label id="label" height="48" horizAlign="center" vertAlign="center" />
+    </children>
+</component>

--- a/test/cli/resources/buttongroup-custom-children-app/manifest
+++ b/test/cli/resources/buttongroup-custom-children-app/manifest
@@ -1,0 +1,4 @@
+title=ButtonGroup Custom Children Test
+major_version=1
+minor_version=0
+build_version=0

--- a/test/cli/resources/buttongroup-custom-children-app/source/main.brs
+++ b/test/cli/resources/buttongroup-custom-children-app/source/main.brs
@@ -1,0 +1,40 @@
+sub Main()
+    print "=== ButtonGroup Custom Children Repro ==="
+
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+
+    scene = screen.CreateScene("MainScene")
+    screen.show()
+    scene.setFocus(true)
+
+    row = scene.findNode("buttonRow")
+    leftButton = scene.findNode("leftButton")
+    rightButton = scene.findNode("rightButton")
+
+    ' Force a layout/measurement pass, then verify the horizontal layout is honored.
+    rect = row.boundingRect()
+    leftTrans = leftButton.translation
+    rightTrans = rightButton.translation
+    print "left x = "; Int(leftTrans[0])
+    print "right x = "; Int(rightTrans[0])
+
+    ' The custom children keep their own text — the group must not overwrite it.
+    print "left text = "; leftButton.text
+    print "right text = "; rightButton.text
+
+    ' Focus the right button directly (as app screens do); the group must not steal it back.
+    rightButton.setFocus(true)
+    rect = row.boundingRect()
+    print "right hasFocus = "; rightButton.hasFocus()
+
+    ' Switch focus to the left button and verify layout stayed stable across focus changes.
+    leftButton.setFocus(true)
+    rect = row.boundingRect()
+    print "left hasFocus = "; leftButton.hasFocus()
+    print "right x after focus = "; Int(rightButton.translation[0])
+    print "children count = "; row.getChildCount()
+
+    print "=== ButtonGroup Custom Children Complete ==="
+end sub

--- a/test/extensions/scenegraph/ButtonGroup.test.js
+++ b/test/extensions/scenegraph/ButtonGroup.test.js
@@ -4,7 +4,7 @@ const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
 const core = require("../../../packages/node/bin/brs.node.js");
 
 const { SGNodeFactory, sgRoot } = scenegraph;
-const { BrsDevice, BrsString, BrsBoolean } = core;
+const { BrsDevice, BrsString, BrsBoolean, Float, RoArray } = core;
 
 /** Minimal interpreter accepted by renderNode → renderChildren (never dereferenced when draw2D is absent). */
 const fakeInterpreter = {};
@@ -41,5 +41,144 @@ describe("ButtonGroup bounding rect", () => {
         expect(rect.height).toBeGreaterThan(0);
         // Centering must not collapse to the far right (the bug placed it at ~960 on a 1920 screen).
         expect((1920 - rect.width) / 2).toBeLessThan(900);
+    });
+});
+
+describe("ButtonGroup with custom (non-Button) Group children", () => {
+    // Apps use a ButtonGroup as a horizontal layout container for their own focusable button
+    // components (Group-based, with a `text` interface field). Roku does not manage such children:
+    // the group must behave as a plain LayoutGroup and never reposition, restyle, focus-steal, or
+    // consume keys on their behalf.
+    beforeAll(() => {
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    function createCustomButton(text, width) {
+        // Label stands in for a custom Group component exposing a `text` field.
+        const child = SGNodeFactory.createNode("Label");
+        child.setValue("text", new BrsString(text));
+        child.setValue("width", new Float(width));
+        child.setValue("height", new Float(48));
+        child.setValue("focusable", BrsBoolean.True);
+        return child;
+    }
+
+    function createHorizontalGroup() {
+        const group = SGNodeFactory.createNode("ButtonGroup");
+        group.setValue("layoutDirection", new BrsString("horiz"));
+        group.setValue("itemSpacings", new RoArray([new Float(39)]));
+        const left = createCustomButton("Back", 177);
+        const right = createCustomButton("Continue", 1149);
+        group.appendChildToParent(left);
+        group.appendChildToParent(right);
+        return { group, left, right };
+    }
+
+    test("does not capture custom children into the buttons array", () => {
+        const { group } = createHorizontalGroup();
+        expect(group.getValueJS("buttons")).toEqual([]);
+    });
+
+    test("lays custom children out horizontally and keeps them stable across focus changes", () => {
+        const { group, left, right } = createHorizontalGroup();
+        group.renderNode(fakeInterpreter, [0, 0], 0, 1);
+
+        expect(left.getValueJS("translation")[0]).toBeCloseTo(0, 0);
+        expect(right.getValueJS("translation")[0]).toBeCloseTo(177 + 39, 0);
+
+        // Focus each child in turn; the layout must not be recomputed to a vertical/origin stack.
+        sgRoot.setFocused(right);
+        group.renderNode(fakeInterpreter, [0, 0], 0, 1);
+        sgRoot.setFocused(left);
+        group.renderNode(fakeInterpreter, [0, 0], 0, 1);
+
+        expect(left.getValueJS("translation")[0]).toBeCloseTo(0, 0);
+        expect(right.getValueJS("translation")[0]).toBeCloseTo(177 + 39, 0);
+        // Custom children keep their own text/size — the group must not overwrite them.
+        expect(left.getValueJS("text")).toBe("Back");
+        expect(right.getValueJS("text")).toBe("Continue");
+    });
+
+    test("does not steal focus from a directly focused custom child", () => {
+        const { group, right } = createHorizontalGroup();
+        group.renderNode(fakeInterpreter, [0, 0], 0, 1);
+
+        sgRoot.setFocused(right);
+        group.renderNode(fakeInterpreter, [0, 0], 0, 1);
+
+        expect(sgRoot.focused).toBe(right);
+    });
+
+    test("lets keys bubble to the app instead of consuming them", () => {
+        const { group, right } = createHorizontalGroup();
+        group.renderNode(fakeInterpreter, [0, 0], 0, 1);
+        sgRoot.setFocused(right);
+
+        expect(group.handleKey("OK", true)).toBe(false);
+        expect(group.handleKey("down", true)).toBe(false);
+        expect(group.handleKey("left", true)).toBe(false);
+        // OK must not fire a spurious selection of button index 0.
+        expect(sgRoot.focused).toBe(right);
+    });
+
+    test("keeps custom children through focus-in/focus-out re-renders", () => {
+        const { group, right } = createHorizontalGroup();
+        group.renderNode(fakeInterpreter, [0, 0], 0, 1);
+
+        sgRoot.setFocused(right);
+        group.renderNode(fakeInterpreter, [0, 0], 0, 1);
+        sgRoot.setFocused();
+        group.renderNode(fakeInterpreter, [0, 0], 0, 1);
+
+        expect(group.getNodeChildren().length).toBe(2);
+    });
+});
+
+describe("ButtonGroup with managed Button children", () => {
+    beforeAll(() => {
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    test("follows a directly focused Button instead of stealing focus back to the previous index", () => {
+        const group = SGNodeFactory.createNode("ButtonGroup");
+        const first = SGNodeFactory.createNode("Button");
+        first.setValue("text", new BrsString("First"));
+        const second = SGNodeFactory.createNode("Button");
+        second.setValue("text", new BrsString("Second"));
+        group.appendChildToParent(first);
+        group.appendChildToParent(second);
+        group.renderNode(fakeInterpreter, [0, 0], 0, 1);
+
+        sgRoot.setFocused(second);
+        group.renderNode(fakeInterpreter, [0, 0], 0, 1);
+
+        expect(sgRoot.focused).toBe(second);
+        expect(group.getValueJS("buttonFocused")).toBe(1);
+        // OK selects the button that actually holds focus, not the stale index 0.
+        expect(group.handleKey("OK", true)).toBe(true);
+        expect(group.getValueJS("buttonSelected")).toBe(1);
+    });
+
+    test("redirects focus to the current button when the group itself is focused", () => {
+        const group = SGNodeFactory.createNode("ButtonGroup");
+        const first = SGNodeFactory.createNode("Button");
+        first.setValue("text", new BrsString("First"));
+        group.appendChildToParent(first);
+        group.renderNode(fakeInterpreter, [0, 0], 0, 1);
+
+        sgRoot.setFocused(group);
+        group.renderNode(fakeInterpreter, [0, 0], 0, 1);
+
+        expect(sgRoot.focused).toBe(first);
     });
 });


### PR DESCRIPTION
## Problem

Apps commonly use a built-in `ButtonGroup` purely as a **horizontal layout container** (`layoutDirection="horiz"` + `itemSpacings`) for their own focusable Group-based button components, moving focus between them manually via `setFocus()` from the screen's `onKeyEvent`. This works on a real Roku, but on brs-engine such screens broke in three ways once focus reached the buttons:

1. **Overlap** — the group's vertical-only `refreshButtons()` re-stacked every child at `x=0`, drawing the right button on top of the left one (the first focus change dirtied the group and clobbered the app's horizontal layout).
2. **Focus stuck** — `refreshFocus()` ran every frame and stole focus back to `children[focusIndex]` (stuck at 0) whenever the app focused a child directly, so left/right could never switch buttons.
3. **Wrong button activated** — `handleKey()` consumed OK and fired `buttonSelected` for index 0, activating the hidden left button (e.g. a Back button whose `selected` observer closes the screen).

## Root cause

`ButtonGroup.appendChildToParent` captured **any** Group child with a `text` field into its managed `buttons` list. Per the Roku spec (`external/dev-doc/.../buttongroup.md`), ButtonGroup manages the layout, appearance, and focus of a vertical list of **Button** nodes only, and takes over key focus only "when the ButtonGroup node has focus" — custom Group children are left alone and the group behaves as its `LayoutGroup` base.

## Fix (`src/extensions/scenegraph/nodes/ButtonGroup.ts`)

Managed vs. unmanaged distinction — only engine `Button` instances (including `StdDlgButton`) are managed:

- `appendChildToParent` captures text into `buttons` only for `Button` children.
- `renderNode` delegates entirely to `LayoutGroup` when there are no managed buttons — honoring `layoutDirection`/`itemSpacings`/alignments and stable child translations, and reporting real layout dimensions in the bounding rect.
- `refreshButtons` early-returns on an empty `buttons` array (kills a latent delete-all-children `splice(0)` hazard), skips non-Button children, and prunes only surplus managed Buttons.
- `refreshFocus` **syncs** `focusIndex`/`buttonFocused` to a directly focused Button instead of stealing focus, and only redirects focus into a button when the group itself is focused (per spec).
- `handleKey` only consumes up/down/OK when focus is on the group or one of its managed Buttons; otherwise keys bubble to the app's `onKeyEvent`, as on device.

`Dialog`/`StandardDialog`/`StdDlgButtonArea` (pure managed mode — Buttons only) are unchanged.

## Tests

- New unit tests in `test/extensions/scenegraph/ButtonGroup.test.js`: no capture of custom children, horizontal layout stability across focus changes, no focus stealing, key bubbling, splice guard, and managed-mode focus sync (`buttonFocused`/`buttonSelected` follow the actually focused Button).
- New CLI resource app `test/cli/resources/buttongroup-custom-children-app` reproducing the keyboard-screen pattern end-to-end.
- Full `test/extensions` (434 tests) and `test/cli/cli.test.js` (46 tests) suites pass, including the StandardDialog and dialog-buttongroup-focus regressions.
- Verified in brs-desktop against a production app exhibiting all three symptoms — buttons stay in place, left/right switches focus, OK activates the focused button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)