### PR TITLE
fix(rsg): restore m context on rebuilt custom nodes and fix quit debugger loop

### DIFF
--- a/src/core/interpreter/index.ts
+++ b/src/core/interpreter/index.ts
@@ -1150,6 +1150,12 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
             this._tryMode = tryMode;
         } catch (err: any) {
             this._tryMode = tryMode;
+            if (this.inExitMode()) {
+                // The debugger's `quit`/EXIT unwinds by re-throwing the original RuntimeError. Let it
+                // propagate past user try/catch so the app terminates instead of the catch block
+                // swallowing the exit and looping forever.
+                throw err;
+            }
             if (!(err instanceof BrsError) || err instanceof Stmt.GotoLabel || err instanceof Stmt.ReturnValue) {
                 throw err;
             }

--- a/src/extensions/scenegraph/factory/NodeFactory.ts
+++ b/src/extensions/scenegraph/factory/NodeFactory.ts
@@ -447,6 +447,14 @@ function createNodeByTypeDef(typeDef: ComponentDefinition, subtype: string): Nod
                 }
                 node.addNodeField(fieldName, fieldValue.type, fieldValue.alwaysNotify === "true", false);
             }
+            // Flat/deserialized nodes skip initializeNode(), so establish the `m` context here
+            // (top/global) that a custom component's script functions expect. Without it, invoking
+            // a public function via callFunc on a cross-thread-restored or cloned node runs with an
+            // empty `m`, so `m.top` is invalid and the call crashes.
+            const mPointer = new RoAssociativeArray([]);
+            mPointer.set(new BrsString("top"), node);
+            mPointer.set(new BrsString("global"), sgRoot.mGlobal);
+            node.m = mPointer;
         }
     }
     return node;

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -615,6 +615,28 @@ describe("cli", () => {
         expect(stderr).toContain('Attempt to add duplicate field "sharedField" to RokuML component "XmlChildComp"');
     }, 10000);
 
+    it("Restores the m context on a rebuilt custom component so callFunc sees m.top/m.global", async () => {
+        let command = ["node", brsCliPath, "-r clone-callfunc-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        // A custom component subclassing a data node is rebuilt through createFlatNode (the same
+        // path a cross-thread Task copy takes; clone() exercises it single-threaded). Before the fix
+        // the rebuilt node had an empty `m`, so invoking a public function via callFunc ran with an
+        // invalid `m.top` and crashed. Both fields must now resolve.
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "=== Clone CallFunc Repro ===",
+            "clone subtype = MyData",
+            "readTop = MyData",
+            "readGlobal = VALID_GLOBAL",
+            "=== Clone CallFunc Repro Complete ===",
+            "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+    }, 10000);
+
     it("Reparents a node when it is attached to a different parent", async () => {
         let command = ["node", brsCliPath, "-r reparent-app", "source/main.brs", "-c 0"].join(" ");
 

--- a/test/cli/resources/clone-callfunc-app/components/MainScene.xml
+++ b/test/cli/resources/clone-callfunc-app/components/MainScene.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="MainScene" extends="Scene">
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+    end sub
+    ]]></script>
+</component>

--- a/test/cli/resources/clone-callfunc-app/components/MyData.xml
+++ b/test/cli/resources/clone-callfunc-app/components/MyData.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="MyData" extends="ContentNode">
+    <interface>
+        <function name="readTop" />
+        <function name="readGlobal" />
+    </interface>
+    <script type="text/brightscript"><![CDATA[
+    function readTop() as string
+        if m.top <> invalid then
+            return m.top.subtype()
+        end if
+        return "INVALID_TOP"
+    end function
+
+    function readGlobal() as string
+        if m.global <> invalid then
+            return "VALID_GLOBAL"
+        end if
+        return "INVALID_GLOBAL"
+    end function
+    ]]></script>
+</component>

--- a/test/cli/resources/clone-callfunc-app/manifest
+++ b/test/cli/resources/clone-callfunc-app/manifest
@@ -1,0 +1,4 @@
+title=Clone CallFunc Repro
+major_version=1
+minor_version=0
+build_version=1

--- a/test/cli/resources/clone-callfunc-app/source/main.brs
+++ b/test/cli/resources/clone-callfunc-app/source/main.brs
@@ -1,0 +1,18 @@
+sub Main()
+    print "=== Clone CallFunc Repro ==="
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+    scene = screen.CreateScene("MainScene")
+    screen.show()
+
+    ' A custom component that subclasses a data node (ContentNode) is reconstructed through
+    ' createFlatNode (the same path a cross-thread Task copy takes). clone() exercises it in a
+    ' single thread. The clone's public function must still see a valid m.top / m.global.
+    original = CreateObject("roSGNode", "MyData")
+    cloned = original.clone(false)
+    print "clone subtype = "; cloned.subtype()
+    print "readTop = "; cloned.callFunc("readTop")
+    print "readGlobal = "; cloned.callFunc("readGlobal")
+    print "=== Clone CallFunc Repro Complete ==="
+end sub

--- a/test/interpreter/TryCatch.test.js
+++ b/test/interpreter/TryCatch.test.js
@@ -1,5 +1,5 @@
 const brs = require("../../packages/node/bin/brs.node");
-const { Interpreter, Lexeme, Expr, Stmt } = brs;
+const { Interpreter, Lexeme, Expr, Stmt, DebugMode } = brs;
 const { Int32, BrsString } = brs.types;
 
 const { createMockStreams, allArgs } = require("../e2e/E2ETests");
@@ -75,5 +75,34 @@ describe("interpreter try-catch blocks", () => {
         expect(catchSpy).toHaveBeenCalledTimes(1);
         const output = allArgs(stdout.write).filter((arg) => arg !== "\n");
         expect(output[0]).toMatch(/Type Mismatch./);
+    });
+
+    it("does not run the catch block when the interpreter is exiting", () => {
+        // After a Micro Debugger `quit`, the interpreter is in EXIT mode and unwinds by re-throwing
+        // the original RuntimeError. A user try/catch must let that error propagate (so the app
+        // terminates) instead of swallowing it and looping forever.
+        const badComparison = new Expr.Binary(
+            new Expr.Literal(new Int32(2)),
+            token(Lexeme.Less),
+            new Expr.Literal(new BrsString("1"))
+        );
+        const catchSpy = jest.spyOn(printError, "accept");
+
+        const statements = [
+            new Stmt.TryCatch(
+                /* try block */ new Stmt.Block([badComparison]),
+                /* catch block */ new Stmt.Block([printError]),
+                /* error binding */ new Expr.Variable(identifier("e")),
+                {
+                    try: token(Lexeme.Try, "try"),
+                    catch: token(Lexeme.Catch, "catch"),
+                    endtry: token(Lexeme.EndTry, "end try"),
+                }
+            ),
+        ];
+
+        interpreter.debugMode = DebugMode.EXIT;
+        expect(() => interpreter.exec(statements)).toThrow();
+        expect(catchSpy).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## Summary

Fixes two independent engine bugs surfaced by the same report: a `'Dot' Operator attempted with invalid BrightScript Component` crash when a component function is invoked on a cross-thread/cloned custom node, and a Micro Debugger `quit` that loops forever instead of exiting.

### Bug 1 — rebuilt custom nodes lose their `m` context

A custom component subclassing a data node (e.g. `ContentNode`) that is created on a **Task thread** and serialized back to the render thread (or cloned) is rebuilt through `Serializer.toSGNode` → `createFlatNode` → `createNodeByTypeDef`. That path builds the node's fields but **never establishes `node.m`**, unlike the full `initializeNode` path which sets `m.top`/`m.global`. Since `componentDef`/`funcNames` are set from the node subtype, `callFunc(...)` finds the public function and runs it — but with an empty `m`, so `m.top` is `invalid` and the call crashes. It only triggers the first time a component function is invoked on a deserialized node.

**Fix:** establish `m` (`top`=node, `global`=`sgRoot.mGlobal`) in `createNodeByTypeDef`, mirroring `initializeNode` without re-running `init()`/children. Also covers `Node.clone`/`deepCopy`, which take the same path.

### Bug 2 — `quit` swallowed by an app-level `try/catch`

After a debugger `quit` the interpreter is in EXIT mode and unwinds by re-throwing the original `RuntimeError`. `visitTryCatch` caught it and ran the catch block **without checking exit mode**, so an app's own `try/catch` swallowed the quit, printed its handler output, and re-crashed forever.

**Fix:** rethrow at the top of the catch when `inExitMode()`, so the EXIT unwind propagates past user `try/catch` and the app terminates cleanly.

## Tests

- `test/cli/resources/clone-callfunc-app` + case in `test/cli/cli.test.js`: a custom `ContentNode`-subtype exposing public functions that read `m.top`/`m.global`; cloned then invoked via `callFunc`. Confirmed to report `INVALID_TOP`/`INVALID_GLOBAL` without the fix and `MyData`/`VALID_GLOBAL` with it. (`clone()` is the single-threaded proxy for the cross-thread path — the CLI has no Task threads.)
- `test/interpreter/TryCatch.test.js`: EXIT-mode case asserting the catch block is skipped and the error propagates.

Full suite: **2116 passed**. `npm run lint` and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)