### PR TITLE
fix(rsg): honor app-managed visibility/opacity of a dynamic keyboard's textEditBox

### DIFF
--- a/src/extensions/scenegraph/nodes/DynamicKeyboardBase.ts
+++ b/src/extensions/scenegraph/nodes/DynamicKeyboardBase.ts
@@ -27,6 +27,7 @@ export class DynamicKeyboardBase extends Group {
     readonly keyGrid: DynamicKeyGrid;
     private readonly textBoxHeight: number;
     private readonly gap: number;
+    private lastHideTextBox = false; // matches the hideTextBox default / textEditBox visible default
 
     constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.DynamicKeyboardBase) {
         super([], name);
@@ -96,7 +97,12 @@ export class DynamicKeyboardBase extends Group {
     }
 
     private layoutChildren(hideTextBox: boolean) {
-        this.textEditBox.setValueSilent("visible", BrsBoolean.from(!hideTextBox));
+        // Only sync `visible` when hideTextBox changes — an app may hide the box
+        // directly via textEditBox.visible, which must not be overwritten per frame.
+        if (this.lastHideTextBox !== hideTextBox) {
+            this.lastHideTextBox = hideTextBox;
+            this.textEditBox.setValueSilent("visible", BrsBoolean.from(!hideTextBox));
+        }
         this.textEditBox.setTranslation([0, 0]);
         this.keyGrid.setTranslation([0, hideTextBox ? 0 : this.textBoxHeight + this.gap]);
     }
@@ -246,5 +252,18 @@ export class DynamicKeyboardBase extends Group {
         this.textEditBox.setActive(focused);
         this.keyGrid.setFocusActive(focused);
         super.renderNode(interpreter, origin, angle, opacity, draw2D);
+        // Report the node's intrinsic size as its bounding rect (like the legacy Keyboard),
+        // not the children union: an app-hidden textEditBox still reserves its slot on Roku,
+        // so layout containers (e.g. a centered LayoutGroup) must keep measuring that space.
+        // Only hideTextBox collapses it, by moving the key grid to the top of the node.
+        const gridHeight = (this.keyGrid.getValueJS("height") as number) ?? 0;
+        const width = (this.getValueJS("width") as number) ?? 0;
+        const height = gridHeight + (hideTextBox ? 0 : this.textBoxHeight + this.gap);
+        if (width > 0 && height > 0) {
+            const nodeTrans = this.getTranslation();
+            const rect = { x: origin[0] + nodeTrans[0], y: origin[1] + nodeTrans[1], width, height };
+            this.updateBoundingRects(rect, origin, angle + this.getRotation());
+            this.updateParentRects(origin, angle);
+        }
     }
 }

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -816,9 +816,15 @@ export class Node extends RoSGNode implements BrsValue {
         if (colors) {
             const color = colors.get(new BrsString(name));
             if (isBrsString(color)) {
-                const parsed = convertHexColor(color.getValue());
-                if (parsed >= 0) {
-                    return parsed;
+                // convertHexColor returns a signed 32-bit int, so a high-alpha color like
+                // "0xE13100FF" parses negative, and opaque white collides with its -1 invalid
+                // sentinel — validate the hex digits here instead of gating on the parsed sign.
+                const hex = color
+                    .getValue()
+                    .trim()
+                    .replace(/^(#|0x|&h)/i, "");
+                if (/^[0-9a-f]{1,8}$/i.test(hex)) {
+                    return convertHexColor(hex);
                 }
             } else {
                 const value = jsValueOf(color);

--- a/src/extensions/scenegraph/nodes/TextEditBox.ts
+++ b/src/extensions/scenegraph/nodes/TextEditBox.ts
@@ -221,7 +221,7 @@ export class TextEditBox extends Group {
         this.hintLabel.setValueSilent("visible", BrsBoolean.from(showHint));
         this.secureLabel.setValueSilent("visible", BrsBoolean.from(!showHint && secureMode));
 
-        this.renderCursor(rect, now, text, secureMode, secureText, draw2D);
+        this.renderCursor(rect, now, text, secureMode, secureText, combinedOpacity, draw2D);
 
         this.updateBoundingRects(rect, origin, rotation);
         this.renderChildren(interpreter, drawTrans, rotation, combinedOpacity, draw2D);
@@ -251,6 +251,7 @@ export class TextEditBox extends Group {
         text: string,
         secureMode: boolean,
         secureText: string,
+        opacity: number,
         draw2D?: IfDraw2D
     ) {
         const isActive = this.getValueJS("active") as boolean;
@@ -291,8 +292,9 @@ export class TextEditBox extends Group {
                 width: this.cursor.width,
                 height: this.cursor.height,
             };
-            // Draw cursor
-            this.drawImage(this.cursor, cursorRect, 0, 1, draw2D);
+            // Draw cursor at the node's combined opacity — a near-transparent text box (e.g. an
+            // app "hiding" the box via opacity) must not show a fully opaque blinking cursor.
+            this.drawImage(this.cursor, cursorRect, 0, opacity, draw2D);
         }
     }
 }

--- a/test/extensions/scenegraph/DynamicKeyboard.test.js
+++ b/test/extensions/scenegraph/DynamicKeyboard.test.js
@@ -138,6 +138,20 @@ describe("Dynamic voice keyboards", () => {
             expect(kbd.keyGrid.resolvePaletteColor("FocusColor", 0xffffffff)).toBe(0x0a0b0cff);
         });
 
+        test("resolvePaletteColor accepts high-alpha hex strings (signed parse) and opaque white", () => {
+            const kbd = SGNodeFactory.createNode("DynamicKeyboard");
+            // A top-bit color parses negative as a signed 32-bit int; it must still resolve
+            // (the focus indicator tint), not fall back.
+            kbd.setValue("palette", makePalette({ FocusColor: new BrsString("0xE13100FF") }));
+            expect(kbd.keyGrid.resolvePaletteColor("FocusColor", 0x12345678) >>> 0).toBe(0xe13100ff);
+            // Opaque white parses to -1, which must not collide with the invalid sentinel.
+            kbd.setValue("palette", makePalette({ FocusColor: new BrsString("0xFFFFFFFF") }));
+            expect(kbd.keyGrid.resolvePaletteColor("FocusColor", 0x12345678) >>> 0).toBe(0xffffffff);
+            // A non-color string still falls back.
+            kbd.setValue("palette", makePalette({ FocusColor: new BrsString("nonsense") }));
+            expect(kbd.keyGrid.resolvePaletteColor("FocusColor", 0x12345678) >>> 0).toBe(0x12345678);
+        });
+
         test("rendering themes the text box from the resolved palette, with a fallback", () => {
             const draw2D = {
                 doDrawRotatedText() {},
@@ -457,6 +471,80 @@ describe("Dynamic voice keyboards", () => {
                 expect(names.some((n) => n.includes(bg))).toBe(true);
             });
         }
+
+        test("an app-set textEditBox.visible=false survives rendering (layout unchanged)", () => {
+            const kbd = SGNodeFactory.createNode("DynamicCustomKeyboard");
+            sgRoot.setFocused(kbd);
+            const gridY = () => kbd.keyGrid.getTranslation()[1];
+            kbd.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+            const offsetY = gridY();
+            expect(offsetY).toBeGreaterThan(0); // key grid sits below the text box
+            // The app hides the internal text box directly (not via hideTextBox).
+            kbd.textEditBox.setValue("visible", core.BrsBoolean.False);
+            kbd.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+            kbd.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+            expect(kbd.textEditBox.getValueJS("visible")).toBe(false);
+            // `visible` hides without re-layout: the key grid keeps its offset.
+            expect(gridY()).toBe(offsetY);
+        });
+
+        test("bounding rect keeps the hidden text box's slot (intrinsic size, not children union)", () => {
+            const kbd = SGNodeFactory.createNode("DynamicKeyboard");
+            sgRoot.setFocused(kbd);
+            kbd.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+            const fullRect = { ...kbd.rectToParent };
+            expect(fullRect.y).toBe(0);
+            expect(fullRect.height).toBe(kbd.getValueJS("height"));
+            // Hiding the box via `visible` must NOT shrink the reported bounds — on Roku the
+            // node still reserves the text-box slot, so a centering LayoutGroup keeps its place.
+            kbd.textEditBox.setValue("visible", core.BrsBoolean.False);
+            kbd.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+            expect(kbd.rectToParent).toEqual(fullRect);
+            // Only hideTextBox collapses the slot (key grid moves to the top of the node).
+            kbd.setValue("hideTextBox", core.BrsBoolean.True);
+            kbd.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+            expect(kbd.rectToParent.height).toBeLessThan(fullRect.height);
+        });
+
+        test("hideTextBox still hides the text box and moves the key grid up", () => {
+            const kbd = SGNodeFactory.createNode("DynamicKeyboard");
+            sgRoot.setFocused(kbd);
+            kbd.setValue("hideTextBox", core.BrsBoolean.True);
+            kbd.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+            expect(kbd.textEditBox.getValueJS("visible")).toBe(false);
+            expect(kbd.keyGrid.getTranslation()[1]).toBe(0);
+            // Toggling back restores the box and the layout.
+            kbd.setValue("hideTextBox", core.BrsBoolean.False);
+            kbd.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
+            expect(kbd.textEditBox.getValueJS("visible")).toBe(true);
+            expect(kbd.keyGrid.getTranslation()[1]).toBeGreaterThan(0);
+        });
+
+        test("the text-box cursor honors the box's opacity (near-zero opacity hides it)", () => {
+            const kbd = SGNodeFactory.createNode("DynamicCustomKeyboard");
+            // Apps "hide" the box while keeping it functional via a near-zero opacity;
+            // the blinking cursor must fade with it instead of drawing fully opaque.
+            kbd.textEditBox.setValue("opacity", new core.Float(0.00001));
+            kbd.setValue("text", new BrsString("batman"));
+            sgRoot.setFocused(kbd); // focused keyboard -> active text box -> cursor path
+            let cursorOpacity = null;
+            const capture = {
+                doDrawRotatedText() {},
+                doDrawRotatedRect() {},
+                drawNinePatch() {},
+                doDrawRotatedBitmap() {},
+                doDrawScaledObject(x, y, sx, sy, obj, rgba, opacity) {
+                    const n = obj && typeof obj.getImageName === "function" ? obj.getImageName() : "";
+                    if (n.includes("cursor")) cursorOpacity = opacity;
+                },
+            };
+            // Render a few frames to get past cursor blink phases.
+            for (let i = 0; i < 3 && cursorOpacity === null; i++) {
+                kbd.renderNode(fakeInterpreter, [0, 0], 0, 1, capture);
+            }
+            expect(cursorOpacity).not.toBeNull();
+            expect(cursorOpacity).toBeLessThan(0.001);
+        });
 
         test("DynamicCustomKeyboard draws no keyboard background until a KDF is set", () => {
             const names = drawnImageNames(SGNodeFactory.createNode("DynamicCustomKeyboard"));


### PR DESCRIPTION
## Summary

Apps commonly access a `DynamicKeyboardBase` keyboard's internal `VoiceTextEditBox` through the read-only `textEditBox` field and hide it directly (instead of using `hideTextBox`), keeping the box functional for voice input. On a real Roku this works; in the engine three behaviors diverged, all surfaced by a production app's PIN-entry and search screens:

- **`textEditBox.visible` was clobbered every frame** — `DynamicKeyboardBase.layoutChildren` overwrote the child's `visible` from `hideTextBox` on every render, so an app-set `visible = false` never stuck. The sync now runs only when `hideTextBox` actually changes.
- **Hiding the box shrank the keyboard's bounding rect** to the children union (just the key grid), so centering layout containers measured a shorter node and rendered the keyboard too high. The node now reports its intrinsic size (key grid + text-box slot + gap) like the legacy `Keyboard`; on Roku a `visible`-hidden box still reserves its slot, and only `hideTextBox` collapses it.
- **The blinking cursor ignored the box's opacity** — `TextEditBox.renderCursor` drew at a hardcoded opacity of 1, so a box "hidden" via near-zero opacity (a common pattern to keep voice input alive) still showed a fully opaque cursor floating above the keys. The cursor now inherits the node's combined opacity.

Also fixes `Node.resolvePaletteColor` rejecting hex-string palette colors with a high top byte (e.g. `"0xE13100FF"`): `convertHexColor` returns a signed 32-bit int, so such colors parsed negative and were dropped by the `>= 0` guard (opaque white `0xFFFFFFFF` → `-1` also collided with the invalid sentinel), leaving key-grid focus indicators unthemed. The hex digits are now validated directly and the signed result accepted.

## Testing

- Four new regression tests in `test/extensions/scenegraph/DynamicKeyboard.test.js`:
  - app-set `textEditBox.visible = false` survives repeated renders with the key-grid offset unchanged
  - the bounding rect keeps the hidden text box's slot; only `hideTextBox` collapses it
  - the cursor draws at the box's (near-zero) opacity instead of 1
  - high-alpha and opaque-white hex palette strings resolve; invalid strings still fall back
- Full test suite green (2126 passed); lint and prettier clean.
- Verified end-to-end in brs-desktop against a production SceneGraph app: PIN-pad text box hidden with correct keyboard position and themed focus indicator, and no stray cursor on the search keyboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)