### PR TITLE
fix(rsg): resolve "fixed" vertFocusAnimationStyle to non-wrapping fixedFocus

### DIFF
--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -30,10 +30,32 @@ export enum FocusStyle {
     FixedFocus = "fixedFocus",
 }
 
-const ValidVertStyles = new Set(Object.values(FocusStyle).map((style) => style.toLowerCase()));
 const ValidHorizStyles = new Set(
     [FocusStyle.FixedFocusWrap, FocusStyle.FloatingFocus].map((style) => style.toLowerCase())
 );
+
+/**
+ * Resolves a raw `vertFocusAnimationStyle` string to a canonical {@link FocusStyle}, or `undefined`
+ * when the value is not recognized. Matching is case-insensitive.
+ *
+ * The abbreviated value `"fixed"` is accepted as an alias for `fixedFocus`: real apps set
+ * `vertFocusAnimationStyle="fixed"` to mean non-wrapping fixed focus, and a device honors that
+ * intent rather than keeping the field's previous (possibly `fixedFocusWrap`) value. Without this,
+ * a grid whose default is `fixedFocusWrap` (MarkupGrid/PosterGrid) would keep wrapping and never let
+ * an Up press at the top row bubble to a parent that moves focus elsewhere.
+ */
+export function resolveVertFocusStyle(raw: string | undefined): FocusStyle | undefined {
+    const value = (raw ?? "").toLowerCase();
+    for (const style of Object.values(FocusStyle)) {
+        if (style.toLowerCase() === value) {
+            return style;
+        }
+    }
+    if (value === "fixed") {
+        return FocusStyle.FixedFocus;
+    }
+    return undefined;
+}
 
 export declare namespace ArrayGrid {
     type Metadata = {
@@ -120,7 +142,7 @@ export class ArrayGrid extends Group {
     protected lastPressHandled: string;
     protected hasNinePatch: boolean;
     protected focusField: string;
-    protected vertFocusAnimationStyleName: string;
+    protected vertFocusAnimationStyleName: string = FocusStyle.FloatingFocus.toLowerCase();
     public itemFocusCallback?: (index: number) => void;
 
     constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.ArrayGrid) {
@@ -154,9 +176,7 @@ export class ArrayGrid extends Group {
         this.setValueSilent("focusable", BrsBoolean.True);
         this.setValueSilent("wrapDividerBitmapUri", new BrsString(this.dividerUri));
         this.setValueSilent("sectionDividerBitmapUri", new BrsString(this.dividerUri));
-        const style = (this.getValueJS("vertFocusAnimationStyle") as string) ?? FocusStyle.FloatingFocus;
-        this.vertFocusAnimationStyleName = style.toLowerCase();
-        this.wrap = this.vertFocusAnimationStyleName === FocusStyle.FixedFocusWrap.toLowerCase();
+        this.applyVertFocusStyle();
         this.lastPressHandled = "";
         this.hasNinePatch = false;
         this.focusField = "listHasFocus";
@@ -173,10 +193,10 @@ export class ArrayGrid extends Group {
         } else if (["jumptoitem", "animatetoitem"].includes(fieldName) && isNumberComp(value)) {
             this.setFocusedItem(jsValueOf(value));
         } else if (fieldName === "vertfocusanimationstyle" && isBrsString(value)) {
-            const style = value.toString().toLowerCase();
-            if (ValidVertStyles.has(style)) {
-                this.vertFocusAnimationStyleName = style;
-                this.wrap = style === FocusStyle.FixedFocusWrap.toLowerCase();
+            const style = resolveVertFocusStyle(value.toString());
+            if (style) {
+                this.vertFocusAnimationStyleName = style.toLowerCase();
+                this.wrap = style === FocusStyle.FixedFocusWrap;
             } else {
                 // Invalid vertFocusAnimationStyle
                 return;
@@ -675,6 +695,19 @@ export class ArrayGrid extends Group {
             this.vertFocusAnimationStyleName === FocusStyle.FixedFocusWrap.toLowerCase() ||
             this.vertFocusAnimationStyleName === FocusStyle.FixedFocus.toLowerCase()
         );
+    }
+
+    /**
+     * Derives the cached `vertFocusAnimationStyleName` and `wrap` flag from the current
+     * `vertFocusAnimationStyle` field, resolving aliases (e.g. `"fixed"` → `fixedFocus`) and falling
+     * back to `floatingFocus` for unrecognized values. Called from the constructors so the cached
+     * state stays consistent with whatever value XML/initialized fields stored on the node.
+     */
+    protected applyVertFocusStyle() {
+        const style =
+            resolveVertFocusStyle(this.getValueJS("vertFocusAnimationStyle") as string) ?? FocusStyle.FloatingFocus;
+        this.vertFocusAnimationStyleName = style.toLowerCase();
+        this.wrap = style === FocusStyle.FixedFocusWrap;
     }
 
     protected getRenderRowIndex(rowPosition: number) {

--- a/src/extensions/scenegraph/nodes/MarkupGrid.ts
+++ b/src/extensions/scenegraph/nodes/MarkupGrid.ts
@@ -37,8 +37,7 @@ export class MarkupGrid extends ArrayGrid {
         this.gap = 0;
         this.setValueSilent("focusBitmapUri", new BrsString(this.focusUri));
         this.setValueSilent("wrapDividerBitmapUri", new BrsString(this.dividerUri));
-        const style = this.getValueJS("vertFocusAnimationStyle") as string;
-        this.wrap = style.toLowerCase() === FocusStyle.FixedFocusWrap.toLowerCase();
+        this.applyVertFocusStyle();
         this.numRows = this.getValueJS("numRows") as number;
         this.numCols = this.getValueJS("numColumns") as number;
         this.hasNinePatch = true;

--- a/src/extensions/scenegraph/nodes/PosterGrid.ts
+++ b/src/extensions/scenegraph/nodes/PosterGrid.ts
@@ -100,9 +100,7 @@ export class PosterGrid extends ArrayGrid {
         this.registerInitializedFields(initializedFields);
 
         this.setValueSilent("focusBitmapUri", new BrsString(this.focusUri));
-        const style = (this.getValueJS("vertFocusAnimationStyle") as string) ?? FocusStyle.FixedFocusWrap;
-        this.vertFocusAnimationStyleName = style.toLowerCase();
-        this.wrap = this.vertFocusAnimationStyleName === FocusStyle.FixedFocusWrap.toLowerCase();
+        this.applyVertFocusStyle();
         this.numRows = this.getValueJS("numRows") as number;
         this.numCols = this.getValueJS("numColumns") as number;
         this.hasNinePatch = true;

--- a/test/extensions/scenegraph/MarkupGridWrap.test.js
+++ b/test/extensions/scenegraph/MarkupGridWrap.test.js
@@ -1,0 +1,79 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsDevice, BrsString, Int32 } = core;
+
+/** Builds a root ContentNode with `count` flat item children (a MarkupGrid's content shape). */
+function buildContent(count) {
+    const root = SGNodeFactory.createNode("ContentNode");
+    for (let i = 0; i < count; i++) {
+        const item = SGNodeFactory.createNode("ContentNode");
+        item.setValue("title", new BrsString(`item ${i}`));
+        root.appendChildToParent(item);
+    }
+    return root;
+}
+
+/** A focused multi-row grid (4 columns × 3 rows), focus parked on item 0. */
+function focusedGrid(style) {
+    const grid = SGNodeFactory.createNode("MarkupGrid");
+    grid.setValue("numColumns", new Int32(4));
+    if (style) {
+        grid.setValue("vertFocusAnimationStyle", new BrsString(style));
+    }
+    grid.setValue("content", buildContent(12));
+    grid.setNodeFocus(true);
+    return grid;
+}
+
+describe("MarkupGrid vertFocusAnimationStyle handling (wrap vs. escape at the top row)", () => {
+    beforeAll(() => {
+        // The grid resolves fonts/focus bitmap from the common: volume; mount it once.
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    test("default style (fixedFocusWrap) wraps: Up at the first row is consumed", () => {
+        // MarkupGrid's default vertFocusAnimationStyle is fixedFocusWrap (matches a real device and
+        // the Roku SceneGraphTutorial MarkupGrid sample, which wraps with no style set). A full
+        // multi-row grid wraps the column, so Up at the top row moves to the last row and is handled.
+        const grid = focusedGrid();
+        expect(grid.getValueJS("itemFocused")).toBe(0);
+        expect(grid.handleKey("up", true)).toBe(true);
+    });
+
+    test('the shorthand "fixed" resolves to fixedFocus (non-wrapping): Up at the first row bubbles', () => {
+        // Regression: apps set vertFocusAnimationStyle="fixed" (an alias for fixedFocus) to disable
+        // wrapping. Previously the invalid value was rejected, leaving the fixedFocusWrap default, so
+        // the grid kept wrapping and Up never bubbled to the scene to move focus to a sibling (e.g. a
+        // filter bar). Now "fixed" is honored as non-wrapping, so Up at row 0 returns false.
+        const grid = focusedGrid("fixed");
+        expect(grid.handleKey("up", true)).toBe(false);
+        // Down still moves within the grid (proves the grid handles vertical nav, just not off the top).
+        expect(grid.handleKey("down", true)).toBe(true);
+    });
+
+    test("explicit floatingFocus does NOT wrap: Up at the first row bubbles", () => {
+        const grid = focusedGrid("floatingFocus");
+        expect(grid.handleKey("up", true)).toBe(false);
+    });
+
+    test("explicit fixedFocus does NOT wrap: Up at the first row bubbles", () => {
+        const grid = focusedGrid("fixedFocus");
+        expect(grid.handleKey("up", true)).toBe(false);
+    });
+
+    test("an unrecognized value is ignored, keeping the previous (wrapping) style", () => {
+        // A genuinely invalid value (not the "fixed" alias) is ignored, matching a device that keeps
+        // the field's current value — so the default fixedFocusWrap remains and Up still wraps.
+        const grid = focusedGrid("banana");
+        expect(grid.handleKey("up", true)).toBe(true);
+    });
+});


### PR DESCRIPTION
## Problem

`MarkupGrid`/`PosterGrid` correctly default `vertFocusAnimationStyle` to `fixedFocusWrap` (the SceneGraphTutorial MarkupGrid sample wraps with no style set). But when an app sets the shorthand value `"fixed"` — meaning the non-wrapping `fixedFocus` style — `ArrayGrid.setValue` treated it as an invalid enum value and returned early, leaving the `fixedFocusWrap` default in place.

The grid then kept wrapping vertically, so an **Up press at the first row was consumed** (wrapping to the last row) instead of bubbling to a parent `onKeyEvent` that moves focus to a sibling (e.g. a filter/options bar above the grid).

## Fix

- Add `resolveVertFocusStyle()` in `ArrayGrid.ts`: matches the canonical `FocusStyle` values case-insensitively and maps the alias `"fixed"` → `fixedFocus`. Genuinely invalid values still return `undefined` and are ignored, matching a device that keeps the field's prior value.
- `ArrayGrid.setValue` uses the resolver; a shared `applyVertFocusStyle()` helper derives the cached `vertFocusAnimationStyleName` + `wrap` state in the constructors so it stays consistent with whatever XML/initialized fields stored.
- `MarkupGrid`/`PosterGrid` constructors call the helper. **Grid defaults are unchanged** (`fixedFocusWrap`).
- Both the custom-component instance-attribute path (`NodeFactory` `newChild.setValue`) and runtime assignments route through `setValue`, so both are covered. `RowList` inherits `ArrayGrid.setValue` (its own default is `fixedFocus`, already non-wrap); `LabelList` unchanged.

## Tests

New `test/extensions/scenegraph/MarkupGridWrap.test.js` (5 cases):
- default `fixedFocusWrap` wraps → Up at row 0 is handled
- `"fixed"` → non-wrapping `fixedFocus` → Up at row 0 bubbles (Down still handled)
- explicit `floatingFocus` / `fixedFocus` don't wrap
- a genuinely invalid value is ignored and keeps wrapping

Full `test/extensions/scenegraph` suite passes (44 suites, 439 tests). `lint`/`prettier`/`tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)