### PR TITLE
fix(rsg): return the measured size from a detached Label's boundingRect() mid-render

### DIFF
--- a/src/extensions/scenegraph/nodes/Group.ts
+++ b/src/extensions/scenegraph/nodes/Group.ts
@@ -568,6 +568,22 @@ export class Group extends Node {
         return rect;
     }
 
+    /**
+     * Records a measured size in all three coordinate-space rects, not just rectLocal.
+     * Used by label getMeasured() implementations: a component sizing itself from a detached
+     * label's boundingRect() (parent space) can query before any render pass reaches the label,
+     * and mid-render getBoundingRect's measuring fallback is skipped when rectLocal is already
+     * non-zero — so the measure must land in every space rather than leave a stale zero
+     * rectToParent/rectToScene. Width/height are translation-invariant; the true origins are
+     * recomputed when a render pass reaches the node in renderNode.
+     */
+    protected setMeasuredBoundingRects(width: number, height: number) {
+        const trans = this.getTranslation();
+        this.rectLocal = { x: 0, y: 0, width, height };
+        this.rectToParent = { x: trans[0], y: trans[1], width, height };
+        this.rectToScene = { x: trans[0], y: trans[1], width, height };
+    }
+
     protected updateBoundingRects(drawRect: Rect, origin: number[], rotation: number) {
         const nodeTrans = this.getTranslation();
         this.rectLocal = { x: 0, y: 0, width: drawRect.width, height: drawRect.height };

--- a/src/extensions/scenegraph/nodes/Label.ts
+++ b/src/extensions/scenegraph/nodes/Label.ts
@@ -62,18 +62,10 @@ export class Label extends Group {
             const size = this.getDimensions();
             const rect: Rect = { x: 0, y: 0, ...size };
             this.measured = this.renderLabel(rect, 0, 1);
-            const width = Math.max(this.measured.width, size.width);
-            const height = Math.max(this.measured.height, size.height);
-            // Populate all three coordinate-space rects, not just rectLocal (same rationale as
-            // SimpleLabel.getMeasured): a component centering a detached label from boundingRect()
-            // (parent space) — sized via explicit width/height before text is set — can query this
-            // mid-render, where getBoundingRect's measuring fallback is skipped because rectLocal
-            // is already non-zero; it must see the measured size in every space, not a stale zero.
-            // Width/height are translation-invariant; true origins are recomputed in renderNode.
-            const trans = this.getTranslation();
-            this.rectLocal = { x: 0, y: 0, width, height };
-            this.rectToParent = { x: trans[0], y: trans[1], width, height };
-            this.rectToScene = { x: trans[0], y: trans[1], width, height };
+            this.setMeasuredBoundingRects(
+                Math.max(this.measured.width, size.width),
+                Math.max(this.measured.height, size.height)
+            );
         }
         return this.measured;
     }

--- a/src/extensions/scenegraph/nodes/Label.ts
+++ b/src/extensions/scenegraph/nodes/Label.ts
@@ -62,9 +62,18 @@ export class Label extends Group {
             const size = this.getDimensions();
             const rect: Rect = { x: 0, y: 0, ...size };
             this.measured = this.renderLabel(rect, 0, 1);
-            rect.width = Math.max(this.measured.width, size.width);
-            rect.height = Math.max(this.measured.height, size.height);
-            this.rectLocal = { x: 0, y: 0, width: rect.width, height: rect.height };
+            const width = Math.max(this.measured.width, size.width);
+            const height = Math.max(this.measured.height, size.height);
+            // Populate all three coordinate-space rects, not just rectLocal (same rationale as
+            // SimpleLabel.getMeasured): a component centering a detached label from boundingRect()
+            // (parent space) — sized via explicit width/height before text is set — can query this
+            // mid-render, where getBoundingRect's measuring fallback is skipped because rectLocal
+            // is already non-zero; it must see the measured size in every space, not a stale zero.
+            // Width/height are translation-invariant; true origins are recomputed in renderNode.
+            const trans = this.getTranslation();
+            this.rectLocal = { x: 0, y: 0, width, height };
+            this.rectToParent = { x: trans[0], y: trans[1], width, height };
+            this.rectToScene = { x: trans[0], y: trans[1], width, height };
         }
         return this.measured;
     }

--- a/src/extensions/scenegraph/nodes/MultiStyleLabel.ts
+++ b/src/extensions/scenegraph/nodes/MultiStyleLabel.ts
@@ -138,9 +138,15 @@ export class MultiStyleLabel extends Group {
             const size = this.getDimensions();
             const rect: Rect = { x: 0, y: 0, ...size };
             this.measured = this.renderLabel(rect, 0, 1);
-            rect.width = Math.max(this.measured.width, size.width);
-            rect.height = Math.max(this.measured.height, size.height);
-            this.rectLocal = { x: 0, y: 0, width: rect.width, height: rect.height };
+            const width = Math.max(this.measured.width, size.width);
+            const height = Math.max(this.measured.height, size.height);
+            // Keep all three coordinate-space rects in sync (see Label.getMeasured /
+            // SimpleLabel.getMeasured) so an eager boundingRect() query mid-render does
+            // not return a stale zero rectToParent/rectToScene.
+            const trans = this.getTranslation();
+            this.rectLocal = { x: 0, y: 0, width, height };
+            this.rectToParent = { x: trans[0], y: trans[1], width, height };
+            this.rectToScene = { x: trans[0], y: trans[1], width, height };
         }
         return this.measured;
     }

--- a/src/extensions/scenegraph/nodes/MultiStyleLabel.ts
+++ b/src/extensions/scenegraph/nodes/MultiStyleLabel.ts
@@ -138,15 +138,10 @@ export class MultiStyleLabel extends Group {
             const size = this.getDimensions();
             const rect: Rect = { x: 0, y: 0, ...size };
             this.measured = this.renderLabel(rect, 0, 1);
-            const width = Math.max(this.measured.width, size.width);
-            const height = Math.max(this.measured.height, size.height);
-            // Keep all three coordinate-space rects in sync (see Label.getMeasured /
-            // SimpleLabel.getMeasured) so an eager boundingRect() query mid-render does
-            // not return a stale zero rectToParent/rectToScene.
-            const trans = this.getTranslation();
-            this.rectLocal = { x: 0, y: 0, width, height };
-            this.rectToParent = { x: trans[0], y: trans[1], width, height };
-            this.rectToScene = { x: trans[0], y: trans[1], width, height };
+            this.setMeasuredBoundingRects(
+                Math.max(this.measured.width, size.width),
+                Math.max(this.measured.height, size.height)
+            );
         }
         return this.measured;
     }

--- a/src/extensions/scenegraph/nodes/SimpleLabel.ts
+++ b/src/extensions/scenegraph/nodes/SimpleLabel.ts
@@ -72,19 +72,7 @@ export class SimpleLabel extends Group {
         if (this.measured === undefined) {
             const rect: Rect = { x: 0, y: 0, width: 0, height: 0 };
             this.measured = this.renderLabel(rect, 0, 1);
-            const width = this.measured.width;
-            const height = this.measured.height;
-            // Populate all three coordinate-space rects, not just rectLocal. A component that sizes
-            // itself from a SimpleLabel's `boundingRect()` (parent space) — e.g. a text pill fitting a
-            // 9-patch background to its label — queries this before the render pass reaches the label;
-            // getBoundingRect's measuring fallback is then skipped (rectLocal is already non-zero), so
-            // it must return the measured size in every space, not a stale zero rectToParent/rectToScene.
-            // Width/height are translation-invariant; the true origins are recomputed when the pass
-            // reaches this node in renderNode.
-            const trans = this.getTranslation();
-            this.rectLocal = { x: 0, y: 0, width, height };
-            this.rectToParent = { x: trans[0], y: trans[1], width, height };
-            this.rectToScene = { x: trans[0], y: trans[1], width, height };
+            this.setMeasuredBoundingRects(this.measured.width, this.measured.height);
         }
         return this.measured;
     }

--- a/test/extensions/scenegraph/Label.test.js
+++ b/test/extensions/scenegraph/Label.test.js
@@ -9,6 +9,9 @@ const { BrsDevice, BrsString, BrsBoolean, Float, RoArray } = core;
 /** Minimal interpreter accepted by renderNode → renderChildren (never dereferenced when draw2D is absent). */
 const fakeInterpreter = {};
 
+/** Minimal fake interpreter accepted by getBoundingRect (mirrors SimpleLabel.test.js). */
+const fakeObserverInterpreter = { environment: {}, inSubEnv: () => {} };
+
 /** A float vector for translation-style fields. */
 function vector(values) {
     return new RoArray(values.map((v) => new Float(v)));
@@ -102,5 +105,62 @@ describe("Label node wrap/vertAlign", () => {
 
         const measured = label.getMeasured();
         expect(measured.height).toBeCloseTo(expected, 5);
+    });
+
+    /**
+     * Regression: a detached Label given explicit width/height (text not yet set) must report
+     * that size from boundingRect() even when queried during an active render pass. Apps center
+     * an overlay label over an icon by reading boundingRect() right after setting width/height
+     * and before appendChild; when that code runs inside a render (e.g. an item component
+     * created mid-frame), getBoundingRect skips the layout refresh and its measuring fallback
+     * (rectLocal is already populated by getMeasured), so getMeasured itself must keep
+     * rectToParent/rectToScene in sync with rectLocal rather than leaving them at zero —
+     * otherwise the app's centering math places the label's top-left at the icon's center.
+     */
+    test("detached sized Label reports its explicit size from boundingRect() mid-render", () => {
+        const label = SGNodeFactory.createNode("Label");
+        label.setValue("font", new BrsString("font:SmallestSystemFont"));
+        label.setValue("horizAlign", new BrsString("center"));
+        label.setValue("vertAlign", new BrsString("center"));
+        label.setValue("width", new Float(56));
+        label.setValue("height", new Float(56));
+        // NOT appended to any parent; text not set — exactly the eager-measure scenario.
+
+        sgRoot.rendering = true;
+        try {
+            const rect = label.getBoundingRect("toParent", fakeObserverInterpreter);
+            expect(rect.width).toBe(56);
+            expect(rect.height).toBe(56);
+            const scene = label.getBoundingRect("toScene", fakeObserverInterpreter);
+            expect(scene.width).toBe(56);
+            expect(scene.height).toBe(56);
+        } finally {
+            sgRoot.rendering = false;
+        }
+
+        // Outside a render pass the same query must also return the explicit size.
+        const rect = label.getBoundingRect("toParent", fakeObserverInterpreter);
+        expect(rect.width).toBe(56);
+        expect(rect.height).toBe(56);
+    });
+
+    test("detached sized Label boundingRect() carries its translation into parent space", () => {
+        const label = SGNodeFactory.createNode("Label");
+        label.setValue("font", new BrsString("font:SmallestSystemFont"));
+        label.setValue("translation", vector([10, 20]));
+        label.setValue("width", new Float(56));
+        label.setValue("height", new Float(56));
+
+        sgRoot.rendering = true;
+        try {
+            expect(label.getBoundingRect("toParent", fakeObserverInterpreter)).toEqual({
+                x: 10,
+                y: 20,
+                width: 56,
+                height: 56,
+            });
+        } finally {
+            sgRoot.rendering = false;
+        }
     });
 });

--- a/test/extensions/scenegraph/MultiStyleLabel.test.js
+++ b/test/extensions/scenegraph/MultiStyleLabel.test.js
@@ -9,6 +9,9 @@ const { BrsDevice, BrsString, BrsBoolean, Int32, RoAssociativeArray } = core;
 /** Minimal interpreter accepted by renderNode → renderChildren (never dereferenced when draw2D is absent). */
 const fakeInterpreter = {};
 
+/** Minimal fake interpreter accepted by getBoundingRect (mirrors SimpleLabel.test.js). */
+const fakeObserverInterpreter = { environment: {}, inSubEnv: () => {} };
+
 /**
  * Builds a `drawingStyles` AA: { styleName: { fontUri, fontSize, color } }.
  * Uses the RoAssociativeArray constructor (not .set) so keys keep their original
@@ -203,5 +206,26 @@ describe("MultiStyleLabel node", () => {
         oneLine.setValue("drawingStyles", drawingStyles({ default: { fontUri: "font:MediumSystemFont" } }));
         oneLine.setValue("text", new BrsString("one"));
         expect(measured.height).toBeGreaterThan(oneLine.getMeasured().height);
+    });
+
+    /**
+     * Regression (see Label.test.js): a detached, explicitly sized label queried with
+     * boundingRect() during an active render pass must report its explicit size — getMeasured
+     * keeps rectToParent/rectToScene in sync with rectLocal instead of leaving them at zero.
+     */
+    test("detached sized MultiStyleLabel reports its explicit size from boundingRect() mid-render", () => {
+        const label = SGNodeFactory.createNode("MultiStyleLabel");
+        label.setValue("drawingStyles", drawingStyles({ default: { fontUri: "font:MediumSystemFont" } }));
+        label.setValue("width", new Int32(56));
+        label.setValue("height", new Int32(56));
+
+        sgRoot.rendering = true;
+        try {
+            const rect = label.getBoundingRect("toParent", fakeObserverInterpreter);
+            expect(rect.width).toBe(56);
+            expect(rect.height).toBe(56);
+        } finally {
+            sgRoot.rendering = false;
+        }
     });
 });


### PR DESCRIPTION
## Problem

An app that creates a Label dynamically, sets explicit `width`/`height`, and reads `boundingRect()` **before** appending it to the tree (a common pattern to center an overlay label over an icon) got back `{0,0,0,0}` when that code ran **inside an active render pass** — e.g. in an item component created by a grid mid-frame. The app's centering math (`iconX + (iconW - rect.width) / 2`) then placed the label's top-left at the icon's center, drawing the text at the bottom-right instead of centered. Since such creation code is typically one-shot, the bad translation was never recomputed.

The same code path worked when it ran outside a render pass (observer fired from a regular field write), which made the bug appear only on specific flows — e.g. app startup with pre-populated content vs. content set later at runtime.

## Root cause

`Label.getMeasured` (and `MultiStyleLabel`'s) populated only `rectLocal`, leaving `rectToParent`/`rectToScene` at the constructor-initialized zero rect. Mid-render, `Node.getBoundingRect` skips the full layout refresh (`sgRoot.rendering` guard) and its measuring fallback only fires when `rectLocal` is degenerate — but `rectLocal` was already valid (populated by `getMeasured` when width/height were set), so the stale zero `rectToParent` was returned as-is.

## Fix

Mirror the `SimpleLabel` fix from 25d2928e: `getMeasured` now keeps all three coordinate-space rects in sync, offsetting `rectToParent`/`rectToScene` by the node's translation (width/height are translation-invariant; true origins are recomputed when a real render pass reaches the node). `MonospaceLabel` inherits the fix from `Label`. `Node.getBoundingRect` is untouched — widening its mid-render fallback guard would risk the fragile re-entrant render path.

On a real Roku, a detached Label with explicit width/height reports that size from `boundingRect()`; this matches that behavior.

## Tests

- New regressions in `test/extensions/scenegraph/Label.test.js`: detached sized Label queried mid-render returns its explicit size in parent and scene space (and outside a render pass), plus translation carried into parent space.
- New regression in `test/extensions/scenegraph/MultiStyleLabel.test.js`.
- Full scenegraph suite (43 suites / 442 tests) and full CLI suite (including the `grid-measure-app` re-entrant measurement guard) pass.
- Verified end-to-end in brs-desktop with a production SceneGraph app exhibiting the symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)