### PR TITLE
fix(rsg): move live focus when a managed ButtonGroup's focusButton changes

### DIFF
--- a/src/extensions/scenegraph/nodes/ButtonGroup.ts
+++ b/src/extensions/scenegraph/nodes/ButtonGroup.ts
@@ -95,6 +95,14 @@ export class ButtonGroup extends LayoutGroup {
             if (typeof newIndex === "number" && newIndex >= 0 && newIndex < buttons.length) {
                 this.focusIndex = newIndex;
                 super.setValue("buttonFocused", value);
+                // When key focus is already within the group, moving `focusButton` (via up/down
+                // navigation in handleKey, or app code) must move the actual focus to the target
+                // button. Otherwise refreshFocus would snap focusIndex back to the still-focused
+                // previous button and navigation would appear stuck.
+                const target = this.children[newIndex];
+                if (this.hasKeyFocus() && target instanceof RoSGNode && sgRoot.focused !== target) {
+                    sgRoot.setFocused(target);
+                }
             }
         }
         super.setValue(index, value, alwaysNotify, kind);
@@ -132,6 +140,12 @@ export class ButtonGroup extends LayoutGroup {
         return this.children.some((child) => child instanceof Button);
     }
 
+    /** True when key focus is on the group itself or on one of its managed Button children. */
+    private hasKeyFocus(): boolean {
+        const focused = sgRoot.focused;
+        return focused === this || (focused instanceof Button && focused.getNodeParent() === this);
+    }
+
     setNodeFocus(focusOn: boolean): boolean {
         const focus = super.setNodeFocus(focusOn);
         if (focus) {
@@ -143,9 +157,7 @@ export class ButtonGroup extends LayoutGroup {
     handleKey(key: string, press: boolean): boolean {
         // Only consume keys when the group manages Button children and the key focus is on the
         // group or one of those buttons — otherwise let the key bubble to the app's onKeyEvent.
-        const focused = sgRoot.focused;
-        const focusWithin = focused === this || (focused instanceof Button && focused.getNodeParent() === this);
-        if (!this.isManagedMode() || !focusWithin) {
+        if (!this.isManagedMode() || !this.hasKeyFocus()) {
             return false;
         }
         if (!press && this.lastPressHandled === key) {

--- a/test/extensions/scenegraph/ButtonGroup.test.js
+++ b/test/extensions/scenegraph/ButtonGroup.test.js
@@ -4,7 +4,7 @@ const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
 const core = require("../../../packages/node/bin/brs.node.js");
 
 const { SGNodeFactory, sgRoot } = scenegraph;
-const { BrsDevice, BrsString, BrsBoolean, Float, RoArray } = core;
+const { BrsDevice, BrsString, BrsBoolean, Float, Int32, RoArray } = core;
 
 /** Minimal interpreter accepted by renderNode → renderChildren (never dereferenced when draw2D is absent). */
 const fakeInterpreter = {};
@@ -180,5 +180,61 @@ describe("ButtonGroup with managed Button children", () => {
         group.renderNode(fakeInterpreter, [0, 0], 0, 1);
 
         expect(sgRoot.focused).toBe(first);
+    });
+
+    test("moves focus between buttons on up/down key navigation", () => {
+        // Regression (#1060): handleKey updated `focusButton`/`buttonFocused` but not the live
+        // focus, and the next render's refreshFocus snapped focusIndex back to the still-focused
+        // button — so a focused ButtonGroup could never move focus between its buttons.
+        const group = SGNodeFactory.createNode("ButtonGroup");
+        group.setValue("buttons", new RoArray([new BrsString("A"), new BrsString("B"), new BrsString("C")]));
+        group.setNodeFocus(true);
+        const children = group.getNodeChildren();
+        const focusedIndex = () => children.indexOf(sgRoot.focused);
+        expect(focusedIndex()).toBe(0);
+
+        group.handleKey("down", true);
+        group.handleKey("down", false);
+        expect(focusedIndex()).toBe(1);
+        // A render pass must not snap focus back to the previous button.
+        group.renderNode(fakeInterpreter, [0, 0], 0, 1);
+        expect(focusedIndex()).toBe(1);
+        expect(group.getValueJS("buttonFocused")).toBe(1);
+
+        group.handleKey("down", true);
+        group.handleKey("down", false);
+        expect(focusedIndex()).toBe(2);
+        // OK selects the button that actually holds focus.
+        group.handleKey("OK", true);
+        expect(group.getValueJS("buttonSelected")).toBe(2);
+
+        group.handleKey("up", true);
+        group.handleKey("up", false);
+        expect(focusedIndex()).toBe(1);
+    });
+
+    test("setting focusButton on a focused group moves the live focus", () => {
+        // App code sets `focusButton` to reposition focus; it must take effect immediately when
+        // the group already holds key focus (used by screens returning to a specific action).
+        const group = SGNodeFactory.createNode("ButtonGroup");
+        group.setValue("buttons", new RoArray([new BrsString("A"), new BrsString("B"), new BrsString("C")]));
+        group.setNodeFocus(true);
+        const children = group.getNodeChildren();
+
+        group.setValue("focusButton", new Int32(2));
+        expect(children.indexOf(sgRoot.focused)).toBe(2);
+        group.renderNode(fakeInterpreter, [0, 0], 0, 1);
+        expect(children.indexOf(sgRoot.focused)).toBe(2);
+    });
+
+    test("setting focusButton before the group is focused does not force focus", () => {
+        // onVisibleChange sets `focusButton = 0` before setFocus(true); it must not pull global
+        // focus onto the group while nothing in it is focused yet.
+        const group = SGNodeFactory.createNode("ButtonGroup");
+        group.setValue("buttons", new RoArray([new BrsString("A"), new BrsString("B")]));
+
+        group.setValue("focusButton", new Int32(0));
+        expect(sgRoot.focused).not.toBe(group);
+        expect(group.getNodeChildren().includes(sgRoot.focused)).toBe(false);
     });
 });


### PR DESCRIPTION
## Summary

Fixes a regression from #1060 that broke **focus navigation** within a managed `ButtonGroup` (buttons created from the `buttons` string array).

`ButtonGroup.handleKey` (up/down) and app code (`node.focusButton = N`) only update `focusIndex` / `buttonFocused` — they never move the live focus (`sgRoot.focused`). Before #1060, `refreshFocus`'s `parent === this` branch moved actual focus to `children[focusIndex]` on the next render, so the index change took effect. #1060 replaced that branch with a "follow the currently-focused button" one, which does the reverse: on each render it snaps `focusIndex` **back** to the still-focused button. As a result a focused `ButtonGroup` could never move focus between its buttons — Down/Up appeared stuck and the group's focus looked absent.

Reproduced at the node level (initial focus still worked; navigation was the broken part):

```
after focus:             focusedIndex = 0
after Down (pre-render):  focusedIndex = 0   buttonFocused = 1   ← focus didn't move
after render:            focusedIndex = 0   buttonFocused = 0   ← reset back
```

## Fix

Make `focusButton` authoritative. In `setValue("focusbutton")`, when key focus is already within the group (new `hasKeyFocus()` helper), also move `sgRoot.setFocused(children[newIndex])`. This covers both up/down key navigation and programmatic `focusButton` changes.

The `hasKeyFocus()` guard preserves the common `focusButton = 0` **before** `setFocus(true)` pattern — it won't pull global focus onto an otherwise-unfocused group. #1060's custom-children handling and the "follow a directly focused Button" behavior are unchanged.

## Testing

- New regression tests in `test/extensions/scenegraph/ButtonGroup.test.js`: up/down navigation moves focus and survives a render pass, `focusButton` on a focused group moves live focus, `focusButton` before focus does not force focus.
- Full ButtonGroup suite (11), all scenegraph extension tests (447), the buttongroup CLI test, `npm run lint`, and prettier all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)