### PR TITLE
fix(rsg): PanelSet full-screen preview position, focus handling, and back-navigation panel retention

### DIFF
--- a/src/extensions/scenegraph/nodes/MarkupList.ts
+++ b/src/extensions/scenegraph/nodes/MarkupList.ts
@@ -163,4 +163,17 @@ export class MarkupList extends ArrayGrid {
         // 9-patch's own 19px content margins, so the focus frame hugs the row instead of overflowing.
         return { left: this.marginX, right: this.marginX, top: this.marginY, bottom: this.marginY };
     }
+
+    /**
+     * Like MarkupGrid, a real device reports a MarkupList's bounding rect as exactly the laid-out
+     * item extent (rows of itemSize plus spacing) with NO focus-bitmap outset. The outset would
+     * also be unstable: renderFocus re-derives hasNinePatch from whichever bitmap was drawn last,
+     * so a list whose focus bitmap is a 9-patch but whose footprint is a plain image would grow
+     * when focused and shrink when not — visibly shifting siblings a LayoutGroup places below it.
+     * The marginX/marginY outset still drives the drawn focus frame (focusMargins), just not the
+     * reported rects.
+     */
+    protected rectMargins(): { x: number; y: number } {
+        return { x: 0, y: 0 };
+    }
 }

--- a/src/extensions/scenegraph/nodes/PanelSet.ts
+++ b/src/extensions/scenegraph/nodes/PanelSet.ts
@@ -136,12 +136,28 @@ export class PanelSet extends Group {
         this.focusIndex--;
         super.setValue("isGoingBack", BrsBoolean.True);
         if (this.panels.length > 2) {
-            const removedPanel = this.panels.pop();
-            if (removedPanel?.getValueJS("isFullScreen") === true) {
+            if (currentPanel === this.panels.at(-1) && currentPanel.getValueJS("isFullScreen") === true) {
+                // A displayed full-screen panel occupies both positions: going back slides it
+                // fully offscreen (removed), restoring the pair — and focus — that preceded it.
+                this.panels.pop();
                 this.focusIndex = Math.max(0, this.panels.length - 2);
+                this.removeChildByReference(currentPanel);
+                super.setValue("numPanels", new Float(this.panels.length));
+            } else {
+                // Only panels that slide fully off the right edge are auto-removed (Roku
+                // contract). After the slide the visible pair is [focusIndex, focusIndex + 1];
+                // going back from the LAST panel removes nothing — it stays as the right panel,
+                // reachable again with a right press.
+                let removed = false;
+                while (this.panels.length > 2 && this.panels.length - 1 > this.focusIndex + 1) {
+                    const removedPanel = this.panels.pop()!;
+                    this.removeChildByReference(removedPanel);
+                    removed = true;
+                }
+                if (removed) {
+                    super.setValue("numPanels", new Float(this.panels.length));
+                }
             }
-            this.removeChildByReference(removedPanel!);
-            super.setValue("numPanels", new Float(this.panels.length));
         }
         currentPanel.setNodeFocus(false);
         this.setNodeFocus(true);

--- a/src/extensions/scenegraph/nodes/PanelSet.ts
+++ b/src/extensions/scenegraph/nodes/PanelSet.ts
@@ -2,6 +2,7 @@ import { AAMember, BrsBoolean, BrsString, BrsType, Float, IfDraw2D, Interpreter,
 import { FieldKind, FieldModel } from "../SGTypes";
 import { GridPanel, Panel, Poster, SGNodeType } from ".";
 import { Group } from "./Group";
+import { Node } from "./Node";
 import { sgRoot } from "../SGRoot";
 
 const DefaultPanelGapHD = 30;
@@ -29,6 +30,7 @@ export class PanelSet extends Group {
     private focusIndex: number = 0;
     private wasFocused: boolean = false;
     private handleSelect: boolean = true;
+    private appendingPreview: boolean = false;
     public focusedPanelCallback?: (panel: Panel) => void;
 
     constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.PanelSet) {
@@ -179,10 +181,12 @@ export class PanelSet extends Group {
                 // PanelSet itself receiving focus — apps commonly focus a contained Panel directly.
                 this.wireNextPanel(child);
             }
-            if (child.getValueJS("isFullScreen") === true) {
-                this.focusIndex = this.panels.length - 1;
-            } else {
-                this.focusIndex = Math.max(0, this.panels.length - 2);
+            if (!this.appendingPreview) {
+                if (child.getValueJS("isFullScreen") === true) {
+                    this.focusIndex = this.panels.length - 1;
+                } else {
+                    this.focusIndex = Math.max(0, this.panels.length - 2);
+                }
             }
             super.setValue("numPanels", new Float(this.panels.length));
             this.refreshFocus();
@@ -200,7 +204,12 @@ export class PanelSet extends Group {
             panel.setTranslationX(panel.getValueJS("leftPosition") as number);
             if (visiblePanels.length > 1) {
                 const panel2 = visiblePanels[1];
-                if (panel2.getValueJS("isFullScreen") === true) {
+                // A full-screen panel occupies both positions only once it is the displayed
+                // (focused) panel; while it is still an unfocused nextPanel preview it sits on
+                // the right like any other panel, per the Roku Panel.isFullScreen contract.
+                const panel2TakesOver =
+                    panel2.getValueJS("isFullScreen") === true && this.panels[this.focusIndex] === panel2;
+                if (panel2TakesOver) {
                     const panel2PosX = panel2.getValueJS("leftPosition") as number;
                     panel2.setTranslationX(panel2PosX);
                 } else {
@@ -236,7 +245,14 @@ export class PanelSet extends Group {
     private wireNextPanel(panel: GridPanel) {
         panel.nextPanelCallback = (nextPanel: Panel) => {
             if (this.panels.length === 1) {
-                this.appendChildToParent(nextPanel);
+                // Appending a nextPanel preview must not move focus off the menu panel —
+                // even a full-screen preview (which takes over only via direct appendChild).
+                this.appendingPreview = true;
+                try {
+                    this.appendChildToParent(nextPanel);
+                } finally {
+                    this.appendingPreview = false;
+                }
                 return;
             }
             const removed = this.panels.splice(-1, 1, nextPanel);
@@ -282,12 +298,31 @@ export class PanelSet extends Group {
                     focusedPanel.setValue("leftOrientation", BrsBoolean.from(leftIndex === this.focusIndex));
                     this.focusedPanelCallback(focusedPanel);
                 }
-                focusedPanel.setNodeFocus(true);
+                // Don't steal focus when it already lives inside the focused panel — e.g. the
+                // app's focusedChild observer forwarded focus to a list nested in the panel, and
+                // that list's itemFocused observer appended the next detail panel (re-entering
+                // here). Re-focusing the panel would pull focus off the inner list, and the app's
+                // observer cannot repair it mid-dispatch (Field re-entrancy guard).
+                if (!this.isFocusWithin(focusedPanel, currentFocus)) {
+                    focusedPanel.setNodeFocus(true);
+                }
             }
             this.wasFocused = true;
         } else if (this.wasFocused) {
             this.wasFocused = false;
             this.isDirty = true;
         }
+    }
+
+    /** Whether `focused` is the panel itself or a node inside the panel's subtree. */
+    private isFocusWithin(panel: Panel, focused: unknown): boolean {
+        let node: unknown = focused;
+        while (node instanceof Node) {
+            if (node === panel) {
+                return true;
+            }
+            node = node.getNodeParent();
+        }
+        return false;
     }
 }

--- a/test/extensions/scenegraph/ListMeasureStability.test.js
+++ b/test/extensions/scenegraph/ListMeasureStability.test.js
@@ -1,0 +1,55 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { MarkupList } = scenegraph;
+const { BrsDevice, Int32, Float, RoArray } = core;
+
+/**
+ * Regression: a MarkupList's reported bounding rect must be exactly the laid-out item extent
+ * (rows of itemSize plus spacing), with NO focus-bitmap outset, and must not depend on the
+ * list's focus state. renderFocus re-derives hasNinePatch from whichever bitmap was drawn last
+ * (focus vs. footprint), so a list with a 9-patch focus bitmap but a plain-image footprint
+ * (e.g. a transparent placeholder) reported a rect that grew by the margin outset while focused
+ * and shrank when focus left — a LayoutGroup stacking siblings below the list (a label/button
+ * section) visibly jumped as focus moved between the list and the section below it.
+ */
+describe("MarkupList measured extent is focus-independent", () => {
+    beforeAll(() => {
+        // MarkupList font-typed defaults need the common: fonts; mount once.
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    function vector(values) {
+        return new RoArray(values.map((v) => new Float(v)));
+    }
+
+    /** Calls the protected updateRect with a fresh rect and returns the computed size. */
+    function measure(list, numRows, itemSize) {
+        const rect = { x: 0, y: 0, width: 0, height: 0 };
+        list.updateRect(rect, numRows, itemSize);
+        return rect;
+    }
+
+    test("the extent has no focus-bitmap outset regardless of hasNinePatch", () => {
+        // Mirrors a settings ratings menu: 6 rows of 560x80 with 8px between rows.
+        const list = new MarkupList();
+        list.setValue("numRows", new Int32(12));
+        list.setValue("itemSpacing", vector([0, 8]));
+        const itemSize = [560, 80];
+        const expected = { width: 560, height: 6 * 80 + 5 * 8 };
+
+        // Focused state: the 9-patch focus bitmap was drawn last (hasNinePatch = true).
+        list.hasNinePatch = true;
+        const focusedRect = measure(list, 6, itemSize);
+
+        // Unfocused state: a plain-image footprint was drawn last (hasNinePatch = false).
+        list.hasNinePatch = false;
+        const unfocusedRect = measure(list, 6, itemSize);
+
+        expect(focusedRect).toEqual({ x: 0, y: 0, ...expected });
+        expect(unfocusedRect).toEqual(focusedRect);
+    });
+});

--- a/test/extensions/scenegraph/PanelSetFullScreen.test.js
+++ b/test/extensions/scenegraph/PanelSetFullScreen.test.js
@@ -1,0 +1,121 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsBoolean, BrsDevice, Float, Interpreter } = core;
+
+/**
+ * Regression: a Panel with isFullScreen=true assigned as a menu panel's nextPanel (the
+ * create-next-panel preview flow) was immediately given the full-screen layout — placed at its
+ * own leftPosition (the left side of the PanelSet) with the left menu panel not rendered — so
+ * the preview covered the menu list. Per the Roku Panel.isFullScreen contract, a full-screen
+ * panel "takes up both the left and right positions" only once it is the displayed (focused)
+ * panel; as an unfocused preview it sits on the right like any other panel. The preview append
+ * must also not move focus off the menu panel.
+ */
+describe("PanelSet full-screen panel as a nextPanel preview", () => {
+    let interpreter;
+
+    beforeAll(() => {
+        // ListPanel builds Labels, which resolve fonts from the common: volume; mount it once.
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    function buildPanelSet() {
+        const panelSet = SGNodeFactory.createNode("PanelSet");
+        const menuPanel = SGNodeFactory.createNode("ListPanel");
+        menuPanel.setValue("leftPosition", new Float(0));
+        menuPanel.setValue("width", new Float(437));
+        menuPanel.setValue("leftOnly", BrsBoolean.True);
+        panelSet.appendChildToParent(menuPanel);
+        menuPanel.setNodeFocus(true);
+        const fullPanel = SGNodeFactory.createNode("Panel");
+        fullPanel.setValue("isFullScreen", BrsBoolean.True);
+        // Simulate the app assigning nextPanel during createNextPanelIndex dispatch: the
+        // PanelSet wires this callback on the menu panel at append time.
+        menuPanel.nextPanelCallback(fullPanel);
+        return { panelSet, menuPanel, fullPanel };
+    }
+
+    test("an unfocused full-screen preview renders on the right of the menu panel", () => {
+        const { panelSet, menuPanel, fullPanel } = buildPanelSet();
+
+        panelSet.renderNode(interpreter, [0, 0], 0, 1);
+
+        // 0 (menu leftPosition) + 437 (menu width) + 30 (HD gap) — NOT the panel's own
+        // leftPosition (narrow default 105), and the menu stays where it was.
+        expect(menuPanel.getValueJS("translation")[0]).toBe(0);
+        expect(fullPanel.getValueJS("translation")[0]).toBe(467);
+    });
+
+    test("appending the preview keeps focus on the menu panel", () => {
+        const { menuPanel } = buildPanelSet();
+
+        expect(sgRoot.focused).toBe(menuPanel);
+    });
+
+    test("the full-screen panel takes over both positions once focused", () => {
+        const { panelSet, fullPanel } = buildPanelSet();
+
+        panelSet.handleKey("right", true);
+        panelSet.renderNode(interpreter, [0, 0], 0, 1);
+
+        expect(sgRoot.focused).toBe(fullPanel);
+        // Focused full-screen panel keeps the existing behavior: its own leftPosition.
+        expect(fullPanel.getValueJS("translation")[0]).toBe(105);
+    });
+
+    test("appending a next panel keeps focus inside the already-focused panel", () => {
+        // Mirrors the multi-account settings flow: after moving right onto the (full-screen)
+        // selector panel, the app's focusedChild observer forwards focus to a list nested inside
+        // it (not assigned to the ListPanel's `list` field), and that list's itemFocused observer
+        // appends the third detail panel. refreshFocus used to re-focus the selector panel itself,
+        // stealing focus from the inner list — leaving the panel without a visibly focused list
+        // until a second right press.
+        const { panelSet, fullPanel } = buildPanelSet();
+        const offsetGroup = SGNodeFactory.createNode("Group");
+        const innerList = SGNodeFactory.createNode("MarkupGrid");
+        offsetGroup.appendChildToParent(innerList);
+        fullPanel.appendChildToParent(offsetGroup);
+
+        panelSet.handleKey("right", true);
+        expect(sgRoot.focused).toBe(fullPanel);
+        // The app forwards focus into the nested list...
+        innerList.setNodeFocus(true);
+        // ...and appends the next detail panel; focus must stay on the inner list.
+        const detailPanel = SGNodeFactory.createNode("Panel");
+        panelSet.appendChildToParent(detailPanel);
+        expect(sgRoot.focused).toBe(innerList);
+
+        // A further right press still moves focus to the detail panel.
+        panelSet.handleKey("right", true);
+        expect(sgRoot.focused).toBe(detailPanel);
+    });
+
+    test("a full-screen panel added via direct appendChild still takes over immediately", () => {
+        const panelSet = SGNodeFactory.createNode("PanelSet");
+        const menuPanel = SGNodeFactory.createNode("ListPanel");
+        menuPanel.setValue("leftPosition", new Float(0));
+        panelSet.appendChildToParent(menuPanel);
+        menuPanel.setNodeFocus(true);
+        const fullPanel = SGNodeFactory.createNode("Panel");
+        fullPanel.setValue("isFullScreen", BrsBoolean.True);
+        panelSet.appendChildToParent(fullPanel);
+
+        panelSet.renderNode(interpreter, [0, 0], 0, 1);
+
+        expect(sgRoot.focused).toBe(fullPanel);
+        expect(fullPanel.getValueJS("translation")[0]).toBe(105);
+    });
+});

--- a/test/extensions/scenegraph/PanelSetFullScreen.test.js
+++ b/test/extensions/scenegraph/PanelSetFullScreen.test.js
@@ -103,6 +103,46 @@ describe("PanelSet full-screen panel as a nextPanel preview", () => {
         expect(sgRoot.focused).toBe(detailPanel);
     });
 
+    test("going back from the last panel keeps it as the right panel (left/right round trip)", () => {
+        // With three panels [menu, selector, detail] and focus on the detail panel, pressing left
+        // must NOT remove the detail panel: it did not slide off the right edge — it remains the
+        // right panel of the visible pair, so a following right press reaches it again. goBack
+        // used to pop the trailing panel unconditionally whenever more than two panels existed,
+        // making the detail panel vanish on the first left press.
+        const { panelSet, fullPanel } = buildPanelSet();
+        panelSet.handleKey("right", true);
+        const detailPanel = SGNodeFactory.createNode("Panel");
+        panelSet.appendChildToParent(detailPanel);
+        panelSet.handleKey("right", true);
+        expect(sgRoot.focused).toBe(detailPanel);
+
+        // Left: back to the selector panel; the detail panel must survive as the right panel.
+        panelSet.handleKey("left", true);
+        expect(sgRoot.focused).toBe(fullPanel);
+        expect(detailPanel.getNodeParent()).toBe(panelSet);
+
+        // Right again: the detail panel is still there and regains focus.
+        panelSet.handleKey("right", true);
+        expect(sgRoot.focused).toBe(detailPanel);
+    });
+
+    test("going back to the first panel removes panels that slid off the right edge", () => {
+        // From [menu, selector, detail] focused on the selector, pressing left slides the pair to
+        // [menu, selector]: the detail panel goes past the right edge and is auto-removed (Roku
+        // contract: panels that slide fully offscreen to the right are removed as children).
+        const { panelSet, menuPanel, fullPanel } = buildPanelSet();
+        panelSet.handleKey("right", true);
+        const detailPanel = SGNodeFactory.createNode("Panel");
+        panelSet.appendChildToParent(detailPanel);
+        panelSet.handleKey("right", true);
+
+        panelSet.handleKey("left", true);
+        panelSet.handleKey("left", true);
+        expect(sgRoot.focused).toBe(menuPanel);
+        expect(detailPanel.getNodeParent()).not.toBe(panelSet);
+        expect(fullPanel.getNodeParent()).toBe(panelSet);
+    });
+
     test("a full-screen panel added via direct appendChild still takes over immediately", () => {
         const panelSet = SGNodeFactory.createNode("PanelSet");
         const menuPanel = SGNodeFactory.createNode("ListPanel");


### PR DESCRIPTION
## Summary

Fixes four PanelSet/list issues surfaced by a production app's multi-panel settings flow (a settings menu ListPanel whose `nextPanel` is a full-screen account-selector panel, which in turn appends a third detail panel):

- **Full-screen `nextPanel` preview rendered on the left, over the menu.** `renderChildren` applied the `isFullScreen` layout (panel at its own `leftPosition`, left panel not rendered) unconditionally. Per the Roku `Panel.isFullScreen` contract, a full-screen panel occupies both positions only once it is the displayed (focused) panel — as an unfocused preview it now sits on the right like any other panel.
- **Focus handling around full-screen panels.** The `nextPanel` preview append no longer steals focus from the menu (a direct `appendChild()` of a full-screen panel keeps the immediate take-over per the docs), and `refreshFocus` no longer pulls focus off a node nested *inside* the focused panel — an app that forwards focus to a list inside the panel (via a `focusedChild` observer) keeps it there when the list's `itemFocused` observer appends the next detail panel.
- **`goBack` destroyed the last panel.** With three panels and focus on the last one, pressing left removed it — the user had to go left and right again to recreate it. Per the Roku contract only panels that slide fully off the **right edge** are auto-removed: going back from the last panel now keeps it as the right panel of the visible pair (left/right round trip works); going back from an inner panel still trims the panels that slid offscreen, and a displayed full-screen panel keeps its slide-away-and-remove behavior.
- **`MarkupList` reported a focus-dependent bounding rect.** The reported rect included a `marginX`/`marginY` outset whenever the last-drawn focus bitmap was a 9-patch; with a 9-patch focus bitmap but a plain-image footprint the list grew when focused and shrank when not, so a `LayoutGroup` stacking a label/button section below it visibly jumped as focus moved. Like `MarkupGrid` (and a real device), the reported rect is now exactly the laid-out item extent; the outset still drives the drawn focus frame.

## Test plan

- New regression suites:
  - `test/extensions/scenegraph/PanelSetFullScreen.test.js` — preview position, preview keeps menu focus, take-over when focused, nested-focus preservation on append, left/right round trip from the last panel, offscreen removal when backing to the first panel, direct-append take-over.
  - `test/extensions/scenegraph/ListMeasureStability.test.js` — MarkupList measured extent is focus-independent with no outset.
- Full jest suite passes (166 suites / 2158 tests), lint + prettier clean.
- Verified end-to-end in brs-desktop against a production multi-panel settings flow: preview shows on the right of the menu, the selector list receives focus after sliding left, the spacing below the ratings list is stable, and left/right navigation between the 2nd and 3rd panels works without the 3rd panel disappearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)