### PR TITLE
fix(rsg): PanelSet sets attached Panel height per Roku spec

### DIFF
--- a/src/extensions/scenegraph/nodes/Panel.ts
+++ b/src/extensions/scenegraph/nodes/Panel.ts
@@ -6,20 +6,21 @@ import { Group } from "./Group";
 /** Valid values for panel sizes in HD */
 export type PanelSizeValue = {
     width: number;
-    height: number;
     leftPos: number;
 };
 export const PanelSizeValues: Map<string, PanelSizeValue> = new Map([
-    ["narrow", { width: 388, height: 605, leftPos: 105 }],
-    ["medium", { width: 520, height: 605, leftPos: 105 }],
-    ["wide", { width: 645, height: 605, leftPos: 112 }],
-    ["full", { width: 940, height: 605, leftPos: 170 }],
+    ["narrow", { width: 388, leftPos: 105 }],
+    ["medium", { width: 520, leftPos: 105 }],
+    ["wide", { width: 645, leftPos: 112 }],
+    ["full", { width: 940, leftPos: 170 }],
 ]);
 
 export class Panel extends Group {
     readonly defaultFields: FieldModel[] = [
         { name: "width", type: "float", value: "388" },
-        { name: "height", type: "float", value: "605" },
+        // Per the Roku spec, height defaults to -1 and is set by the PanelSet at attach
+        // time — the notifying write is what fires app observers registered in init().
+        { name: "height", type: "float", value: "-1" },
         { name: "leftPosition", type: "float", value: "105" },
         { name: "panelSize", type: "string", value: "narrow", alwaysNotify: true },
         { name: "overhangTitle", type: "string", value: "" },
@@ -52,11 +53,10 @@ export class Panel extends Group {
     }
 
     protected setSizeAndPosition(sizeValue: PanelSizeValue) {
+        // panelSize sets only width and leftPosition (Roku spec); height comes from the PanelSet.
         const width = this.resolution === "HD" ? sizeValue.width : sizeValue.width * 1.5;
-        const height = this.resolution === "HD" ? sizeValue.height : sizeValue.height * 1.5;
         const leftPos = this.resolution === "HD" ? sizeValue.leftPos : sizeValue.leftPos * 1.5;
         this.setValue("width", new Float(width));
-        this.setValue("height", new Float(height));
         this.setValue("leftPosition", new Float(leftPos));
     }
 

--- a/src/extensions/scenegraph/nodes/PanelSet.ts
+++ b/src/extensions/scenegraph/nodes/PanelSet.ts
@@ -82,8 +82,23 @@ export class PanelSet extends Group {
                 this.goBack();
             }
             return;
+        } else if (fieldName === "height") {
+            super.setValue(index, value, alwaysNotify, kind);
+            for (const panel of this.panels) {
+                this.adoptPanel(panel);
+            }
+            return;
         }
         super.setValue(index, value, alwaysNotify, kind);
+    }
+
+    /**
+     * Per the Roku spec, the PanelSet sets each attached Panel's `height` field (apps treat
+     * it as read-only and often observe it to size panel-local UI). Must be a notifying
+     * write so observers registered in the component's init() fire.
+     */
+    private adoptPanel(panel: Panel) {
+        panel.setValue("height", this.getValue("height"));
     }
 
     private updateArrowPositions() {
@@ -192,6 +207,7 @@ export class PanelSet extends Group {
         const added = super.appendChildToParent(child);
         if (added && child instanceof Panel) {
             this.panels.push(child);
+            this.adoptPanel(child);
             if (child instanceof GridPanel) {
                 // Wire the create-next-panel callback at append time so it does not depend on the
                 // PanelSet itself receiving focus — apps commonly focus a contained Panel directly.
@@ -274,6 +290,7 @@ export class PanelSet extends Group {
             const removed = this.panels.splice(-1, 1, nextPanel);
             const removedIndex = this.children.indexOf(removed[0]);
             this.replaceChildAtIndex(nextPanel, removedIndex);
+            this.adoptPanel(nextPanel);
         };
         panel.clearNextPanelCallback = () => this.clearTrailingPanel(panel);
     }

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -713,6 +713,33 @@ describe("cli", () => {
             "",
         ]);
     }, 10000);
+
+    it("Sets an attached Panel's height from the PanelSet, firing observers registered in init()", async () => {
+        let command = ["node", brsCliPath, "-r panel-height-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+
+        // Per the Roku spec, Panel.height defaults to -1 and "will be set by the PanelSet";
+        // apps observe their panel's height in init() (before appendChild) to size
+        // panel-local UI. The attach-time write must be a notifying setValue, and a later
+        // PanelSet height change must propagate to attached panels.
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "=== Panel Height Repro ===",
+            "init height = -1",
+            "detached height = -1",
+            "observed height =  1080",
+            "attached height =  1080",
+            "observed height =  720",
+            "resized height =  720",
+            "=== Panel Height Repro Complete ===",
+            "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+    }, 10000);
+
     it("Reports a RowList's newly focused item at the settled focus band, not its pre-scroll position", async () => {
         let command = ["node", brsCliPath, "-r rowlist-subrect-app", "source/main.brs", "-c 0"].join(" ");
 

--- a/test/cli/resources/panel-height-app/components/DetailPanel.xml
+++ b/test/cli/resources/panel-height-app/components/DetailPanel.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Panel-derived component that observes its own height field in init(), mirroring the
+    documented Roku contract: a Panel's height defaults to -1 and is set by the PanelSet
+    when the panel is attached, notifying observers. Apps rely on that notification to
+    size panel-local UI (e.g. centering a loading spinner over the panel area).
+-->
+<component name="DetailPanel" extends="Panel">
+    <script type="text/brightscript">
+    <![CDATA[
+        sub init()
+            print "init height = "; m.top.height
+            m.top.observeFieldScoped("height", "onHeightChange")
+        end sub
+
+        sub onHeightChange()
+            print "observed height = "; m.top.height
+        end sub
+    ]]>
+    </script>
+</component>

--- a/test/cli/resources/panel-height-app/manifest
+++ b/test/cli/resources/panel-height-app/manifest
@@ -1,0 +1,4 @@
+title=Panel Height Test
+major_version=1
+minor_version=0
+build_version=0

--- a/test/cli/resources/panel-height-app/source/main.brs
+++ b/test/cli/resources/panel-height-app/source/main.brs
@@ -1,0 +1,20 @@
+sub Main()
+    print "=== Panel Height Repro ==="
+
+    panelSet = CreateObject("roSGNode", "PanelSet")
+    panelSet.height = 1080
+
+    ' The component observes its own height in init(), before it is attached.
+    panel = CreateObject("roSGNode", "DetailPanel")
+    print "detached height = "; panel.height
+
+    ' Attaching the panel must set its height from the PanelSet (notifying observers).
+    panelSet.appendChild(panel)
+    print "attached height = "; panel.height
+
+    ' A later PanelSet height change propagates to attached panels.
+    panelSet.height = 720
+    print "resized height = "; panel.height
+
+    print "=== Panel Height Repro Complete ==="
+end sub

--- a/test/extensions/scenegraph/PanelHeight.test.js
+++ b/test/extensions/scenegraph/PanelHeight.test.js
@@ -1,0 +1,103 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsDevice, BrsString, Float, RoMessagePort } = core;
+
+/**
+ * Minimal fake interpreter accepted by Node.addObserver for a port observer.
+ * Port observers never enter inSubEnv (they just pushMessage), so the body is
+ * irrelevant — only the shape matters.
+ */
+const fakeInterpreter = { environment: {}, inSubEnv: () => {} };
+
+/**
+ * Regression: per the Roku spec a Panel's height defaults to -1 and "will be set by the
+ * PanelSet" when the panel is attached. The engine used to bake a fixed default height into
+ * the Panel constructor and never write it at attach time, so an app observing its panel's
+ * `height` field (the documented way to size panel-local UI, e.g. centering a loading
+ * spinner over the panel) never got notified — the UI sized itself from height 0, rendering
+ * pinned to the top of the screen.
+ */
+describe("PanelSet sets attached Panel height", () => {
+    beforeAll(() => {
+        // ListPanel builds Labels, which resolve fonts from the common: volume; mount it once.
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    test("a detached Panel reports the documented default height of -1", () => {
+        const panel = SGNodeFactory.createNode("Panel");
+
+        expect(panel.getValueJS("height")).toBe(-1);
+    });
+
+    test("panelSize sets width and leftPosition but not height", () => {
+        const panel = SGNodeFactory.createNode("Panel");
+
+        panel.setValue("panelSize", new BrsString("wide"));
+
+        expect(panel.getValueJS("width")).toBe(645);
+        expect(panel.getValueJS("leftPosition")).toBe(112);
+        expect(panel.getValueJS("height")).toBe(-1);
+    });
+
+    test("appendChild copies the PanelSet height into the panel", () => {
+        const panelSet = SGNodeFactory.createNode("PanelSet");
+        const panel = SGNodeFactory.createNode("Panel");
+
+        panelSet.appendChildToParent(panel);
+
+        expect(panel.getValueJS("height")).toBe(panelSet.getValueJS("height"));
+    });
+
+    test("appendChild fires the panel's height observers", () => {
+        const panelSet = SGNodeFactory.createNode("PanelSet");
+        const panel = SGNodeFactory.createNode("Panel");
+        const port = new RoMessagePort();
+        const received = [];
+        const originalPush = port.pushMessage.bind(port);
+        port.pushMessage = (event) => {
+            received.push(event);
+            originalPush(event);
+        };
+        panel.addObserver(fakeInterpreter, "unscoped", new BrsString("height"), port);
+
+        panelSet.appendChildToParent(panel);
+
+        expect(received.length).toBe(1);
+        expect(received[0].fieldName.getValue()).toBe("height");
+        expect(received[0].fieldValue.getValue()).toBe(panelSet.getValueJS("height"));
+    });
+
+    test("the create-next-panel replace path sets the new panel's height", () => {
+        const panelSet = SGNodeFactory.createNode("PanelSet");
+        const menuPanel = SGNodeFactory.createNode("ListPanel");
+        panelSet.appendChildToParent(menuPanel);
+        menuPanel.setNodeFocus(true);
+        const firstDetail = SGNodeFactory.createNode("Panel");
+        menuPanel.nextPanelCallback(firstDetail);
+        // With two panels attached, the next callback takes the replace branch.
+        const secondDetail = SGNodeFactory.createNode("Panel");
+        menuPanel.nextPanelCallback(secondDetail);
+
+        expect(firstDetail.getValueJS("height")).toBe(panelSet.getValueJS("height"));
+        expect(secondDetail.getValueJS("height")).toBe(panelSet.getValueJS("height"));
+    });
+
+    test("changing the PanelSet height re-applies it to attached panels", () => {
+        const panelSet = SGNodeFactory.createNode("PanelSet");
+        const panel = SGNodeFactory.createNode("Panel");
+        panelSet.appendChildToParent(panel);
+
+        panelSet.setValue("height", new Float(1080));
+
+        expect(panel.getValueJS("height")).toBe(1080);
+    });
+});


### PR DESCRIPTION
## Problem

An app with a PanelSet screen (menu panel on the left, detail panel on the right) showed its detail-panel loading spinner pinned to the top of the screen — briefly visible and distorted in aspect ratio — instead of centered over the panel area as on a real device.

The app observes its panel's `height` field in `init()` and uses the value to center the spinner, setting only the panel `width` itself. That is the documented Roku contract: [`Panel.height`](https://developer.roku.com/docs/references/scenegraph/sliding-panels-nodes/panel.md) defaults to **-1** and *"In most cases, this will be set by the PanelSet and should be treated as a read-only value"*; `panelSize` sets only `width` and `leftPosition`.

The engine deviated in two ways:

1. `Panel` defaulted `height` to 605 (HD) / 907.5 (FHD), written in the **constructor** — before any component `init()` runs, so no observer could ever see the write.
2. `PanelSet` never wrote a child panel's `height` at attach time (neither `appendChild` nor the create-next-panel replace path).

The app's height observer therefore never fired, its spinner sized itself from height 0, and its centering math degenerated to `y = 0, height = 0` — placing the spinner at the panel top (pushed above the visible area by the app's negative group offset). Forwarding the 0 into the spinner Poster's `height` also triggered the bitmap-size fallback for that axis only (bitmap height × 1.5 in FHD) while the explicit width remained — a visibly stretched spinner.

## Fix

- **`Panel.ts`** — `height` now defaults to `-1` per spec; `panelSize` no longer touches height (only `width` + `leftPosition`).
- **`PanelSet.ts`** — new `adoptPanel()` copies the PanelSet's `height` into a panel via a **notifying** `setValue`, called from both attach paths (`appendChildToParent` and the create-next-panel replace branch), and re-applied to all attached panels when the PanelSet's own `height` changes.

`width`/`leftPosition` remain app-controlled, per the doc.

## Tests

- `test/extensions/scenegraph/PanelHeight.test.js` — default -1, `panelSize` behavior, both attach paths, observer notification, and height propagation on PanelSet resize.
- `test/cli/resources/panel-height-app` + case in `cli.test.js` — end-to-end proof that a `height` observer registered in a Panel-derived component's `init()` fires when the panel is attached.
- Full suite green: 167 suites / 2165 tests; lint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)