### PR TITLE
fix(rsg): let single-row MarkupGrid vertical keys bubble and honor horizFocusAnimationStyle fixedFocus

### DIFF
--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -30,21 +30,20 @@ export enum FocusStyle {
     FixedFocus = "fixedFocus",
 }
 
-const ValidHorizStyles = new Set(
-    [FocusStyle.FixedFocusWrap, FocusStyle.FloatingFocus].map((style) => style.toLowerCase())
-);
-
 /**
- * Resolves a raw `vertFocusAnimationStyle` string to a canonical {@link FocusStyle}, or `undefined`
- * when the value is not recognized. Matching is case-insensitive.
+ * Resolves a raw focus-animation-style string (either axis: `vertFocusAnimationStyle` or
+ * `horizFocusAnimationStyle`) to a canonical {@link FocusStyle}, or `undefined` when the value is
+ * not recognized. Matching is case-insensitive.
  *
  * The abbreviated value `"fixed"` is accepted as an alias for `fixedFocus`: real apps set
  * `vertFocusAnimationStyle="fixed"` to mean non-wrapping fixed focus, and a device honors that
  * intent rather than keeping the field's previous (possibly `fixedFocusWrap`) value. Without this,
  * a grid whose default is `fixedFocusWrap` (MarkupGrid/PosterGrid) would keep wrapping and never let
- * an Up press at the top row bubble to a parent that moves focus elsewhere.
+ * an Up press at the top row bubble to a parent that moves focus elsewhere. `fixedFocus` is likewise
+ * honored for the horizontal axis even though the reference's option table omits it — a real device
+ * accepts it and pins the focused column at the grid's left edge.
  */
-export function resolveVertFocusStyle(raw: string | undefined): FocusStyle | undefined {
+export function resolveFocusStyle(raw: string | undefined): FocusStyle | undefined {
     const value = (raw ?? "").toLowerCase();
     for (const style of Object.values(FocusStyle)) {
         if (style.toLowerCase() === value) {
@@ -143,6 +142,7 @@ export class ArrayGrid extends Group {
     protected hasNinePatch: boolean;
     protected focusField: string;
     protected vertFocusAnimationStyleName: string = FocusStyle.FloatingFocus.toLowerCase();
+    protected horizFocusAnimationStyleName: string = FocusStyle.FloatingFocus.toLowerCase();
     public itemFocusCallback?: (index: number) => void;
 
     constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.ArrayGrid) {
@@ -177,6 +177,7 @@ export class ArrayGrid extends Group {
         this.setValueSilent("wrapDividerBitmapUri", new BrsString(this.dividerUri));
         this.setValueSilent("sectionDividerBitmapUri", new BrsString(this.dividerUri));
         this.applyVertFocusStyle();
+        this.applyHorizFocusStyle();
         this.lastPressHandled = "";
         this.hasNinePatch = false;
         this.focusField = "listHasFocus";
@@ -193,7 +194,7 @@ export class ArrayGrid extends Group {
         } else if (["jumptoitem", "animatetoitem"].includes(fieldName) && isNumberComp(value)) {
             this.setFocusedItem(jsValueOf(value));
         } else if (fieldName === "vertfocusanimationstyle" && isBrsString(value)) {
-            const style = resolveVertFocusStyle(value.toString());
+            const style = resolveFocusStyle(value.toString());
             if (style) {
                 this.vertFocusAnimationStyleName = style.toLowerCase();
                 this.wrap = style === FocusStyle.FixedFocusWrap;
@@ -201,13 +202,14 @@ export class ArrayGrid extends Group {
                 // Invalid vertFocusAnimationStyle
                 return;
             }
-        } else if (
-            fieldName === "horizfocusanimationstyle" &&
-            isBrsString(value) &&
-            !ValidHorizStyles.has(value.toString().toLowerCase())
-        ) {
-            // Invalid horizFocusAnimationStyle
-            return;
+        } else if (fieldName === "horizfocusanimationstyle" && isBrsString(value)) {
+            const style = resolveFocusStyle(value.toString());
+            if (style) {
+                this.horizFocusAnimationStyleName = style.toLowerCase();
+            } else {
+                // Invalid horizFocusAnimationStyle: keep the field's current value (device behavior)
+                return;
+            }
         }
         super.setValue(index, value, alwaysNotify, kind);
         // Refresh cached row/column counts from the (possibly coerced) field value, so a
@@ -308,6 +310,7 @@ export class ArrayGrid extends Group {
             this.updateItemFocus(this.focusIndex, false, nodeFocus);
             this.focusIndex = newFocus;
             this.focusLayoutDirty = true;
+            this.updateHorizScroll(newFocus);
             this.updateItemFocus(this.focusIndex, true, nodeFocus);
             if (inFocusChain) {
                 super.setValue("itemUnfocused", new Int32(focusedIndex));
@@ -387,6 +390,15 @@ export class ArrayGrid extends Group {
         }
         this.lastPressHandled = handled && key !== "OK" ? key : "";
         return handled;
+    }
+
+    /**
+     * Hook invoked by setFocusedItem after the focus cursor moves, so grid types that keep a
+     * horizontal column-scroll window (MarkupGrid) can update it for every focus path — key
+     * navigation, jumpToItem/animateToItem, and focus-gain. No-op for other node types.
+     */
+    protected updateHorizScroll(_index: number) {
+        // Overridden by MarkupGrid to maintain its horizontal column-scroll window.
     }
 
     protected handleUpDown(_key: string) {
@@ -737,9 +749,21 @@ export class ArrayGrid extends Group {
      */
     protected applyVertFocusStyle() {
         const style =
-            resolveVertFocusStyle(this.getValueJS("vertFocusAnimationStyle") as string) ?? FocusStyle.FloatingFocus;
+            resolveFocusStyle(this.getValueJS("vertFocusAnimationStyle") as string) ?? FocusStyle.FloatingFocus;
         this.vertFocusAnimationStyleName = style.toLowerCase();
         this.wrap = style === FocusStyle.FixedFocusWrap;
+    }
+
+    /**
+     * Derives the cached `horizFocusAnimationStyleName` from the current `horizFocusAnimationStyle`
+     * field, resolving aliases (e.g. `"fixed"` → `fixedFocus`) and falling back to `floatingFocus`
+     * for unrecognized values. Called from the constructors so the cached state stays consistent
+     * with whatever value XML/initialized fields stored on the node.
+     */
+    protected applyHorizFocusStyle() {
+        const style =
+            resolveFocusStyle(this.getValueJS("horizFocusAnimationStyle") as string) ?? FocusStyle.FloatingFocus;
+        this.horizFocusAnimationStyleName = style.toLowerCase();
     }
 
     protected getRenderRowIndex(rowPosition: number) {

--- a/src/extensions/scenegraph/nodes/MarkupGrid.ts
+++ b/src/extensions/scenegraph/nodes/MarkupGrid.ts
@@ -4,7 +4,6 @@ import { AAMember, Interpreter, BrsDevice, BrsString, Int32, IfDraw2D, Rect, Rec
 import { ArrayGrid, FocusStyle } from "./ArrayGrid";
 import { ContentNode } from "./ContentNode";
 import { customNodeExists } from "../factory/NodeFactory";
-import { jsValueOf } from "../factory/Serializer";
 
 export class MarkupGrid extends ArrayGrid {
     readonly defaultFields: FieldModel[] = [
@@ -18,6 +17,9 @@ export class MarkupGrid extends ArrayGrid {
     protected readonly marginX: number;
     protected readonly marginY: number;
     protected readonly gap: number;
+    // Leftmost rendered column — a single shared horizontal window: a grid scrolls all its rows
+    // together on a device (unlike RowList, which keeps a per-row scroll offset).
+    protected scrollCol = 0;
     private itemComponentErrorLogged = false;
 
     constructor(initializedFields: AAMember[] = [], readonly name: string = SGNodeType.MarkupGrid) {
@@ -38,6 +40,7 @@ export class MarkupGrid extends ArrayGrid {
         this.setValueSilent("focusBitmapUri", new BrsString(this.focusUri));
         this.setValueSilent("wrapDividerBitmapUri", new BrsString(this.dividerUri));
         this.applyVertFocusStyle();
+        this.applyHorizFocusStyle();
         this.numRows = this.getValueJS("numRows") as number;
         this.numCols = this.getValueJS("numColumns") as number;
         this.hasNinePatch = true;
@@ -82,7 +85,10 @@ export class MarkupGrid extends ArrayGrid {
                 }
             }
         }
-        if (nextIndex >= 0 && nextIndex < this.content.length) {
+        // A wrap on a single content row resolves to the focused index itself: the move is a
+        // no-op and must NOT report handled, so the key bubbles to an ancestor's onKeyEvent
+        // (e.g. a screen moving focus from a one-row related-items grid back to a menu above).
+        if (nextIndex >= 0 && nextIndex < this.content.length && nextIndex !== this.focusIndex) {
             const itemIndex = this.metadata[nextIndex]?.index ?? nextIndex;
             this.setValue("animateToItem", new Int32(itemIndex));
             handled = true;
@@ -95,22 +101,70 @@ export class MarkupGrid extends ArrayGrid {
         return this.handleUpDown(key);
     }
 
-    protected handleLeftRight(key: string) {
-        let handled = false;
-        const offset = key === "left" ? -1 : 1;
-        const nextIndex = this.focusIndex + offset;
-        if (nextIndex >= 0 && nextIndex < this.content.length && this.itemComps?.[nextIndex]) {
-            const numCols = jsValueOf(this.getValue("numColumns")) as number;
-            const currentRow = Math.floor(this.focusIndex / numCols);
-            const nextRow = Math.floor(nextIndex / numCols);
-            const item = this.itemComps[nextIndex];
-            if (currentRow === nextRow && item.nodeSubtype !== "Group") {
-                const itemIndex = this.metadata[nextIndex]?.index ?? nextIndex;
-                this.setValue("animateToItem", new Int32(itemIndex));
-                handled = true;
-            }
+    /** Columns that fit fully on screen; falls back to numCols when the pitch is degenerate. */
+    private maxVisibleColumns(): number {
+        const itemSize = this.getValueJS("itemSize") as number[];
+        const spacing = this.getValueJS("itemSpacing") as number[];
+        const pitch = (itemSize?.[0] ?? 0) + (spacing?.[0] ?? 0);
+        if (pitch <= 0) {
+            return Math.max(1, this.numCols);
         }
-        return handled;
+        // Like RowList's floating-focus math, the viewport is the scene width. Limitation: a grid
+        // translated right of x=0 (or with itemClippingRect) can overestimate by up to a column.
+        return Math.max(1, Math.floor(this.sceneRect.width / pitch));
+    }
+
+    protected updateHorizScroll(index: number) {
+        const numCols = Math.max(1, this.numCols || 1);
+        const col = index % numCols;
+        if (this.horizFocusAnimationStyleName === FocusStyle.FixedFocus.toLowerCase()) {
+            // fixedFocus: the focused column is pinned at the grid's left edge.
+            this.scrollCol = col;
+            return;
+        }
+        // floatingFocus, and fixedFocusWrap — horizontal wrapping is not implemented yet (the
+        // documented pair is fixedFocusWrap + focusColumn); it floats like a row with too few
+        // items would on a device: minimal scroll keeping the focused column fully visible.
+        const maxVisible = this.maxVisibleColumns();
+        const maxScroll = Math.max(0, numCols - maxVisible);
+        if (col < this.scrollCol) {
+            this.scrollCol = col;
+        } else if (col >= this.scrollCol + maxVisible) {
+            this.scrollCol = col - maxVisible + 1;
+        }
+        this.scrollCol = Math.max(0, Math.min(this.scrollCol, maxScroll));
+    }
+
+    protected resetFocusForNewContent(freshContent: boolean) {
+        if (freshContent) {
+            // Covers the unfocused path where ArrayGrid resets the cursor silently without
+            // routing through setFocusedItem/updateHorizScroll.
+            this.scrollCol = 0;
+        }
+        super.resetFocusForNewContent(freshContent);
+    }
+
+    protected handleLeftRight(key: string) {
+        const offset = key === "left" ? -1 : 1;
+        const numCols = Math.max(1, this.numCols || 1);
+        const nextIndex = this.focusIndex + offset;
+        if (nextIndex < 0 || nextIndex >= this.content.length) {
+            // Off either end: bubble to an ancestor's onKeyEvent (no horizontal wrap on device).
+            return false;
+        }
+        if (Math.floor(nextIndex / numCols) !== Math.floor(this.focusIndex / numCols)) {
+            // Left/right never changes rows.
+            return false;
+        }
+        // Placeholder cells pad a section's ragged last row (ArrayGrid.processSection). Check the
+        // content model instead of requiring this.itemComps[nextIndex] to exist — the old rendered-
+        // component check also blocked navigation to any column not yet scrolled on screen.
+        if (this.content[nextIndex]?.name === "_placeholder_") {
+            return false;
+        }
+        const itemIndex = this.metadata[nextIndex]?.index ?? nextIndex;
+        this.setValue("animateToItem", new Int32(itemIndex));
+        return true;
     }
 
     protected renderContent(
@@ -167,7 +221,10 @@ export class MarkupGrid extends ArrayGrid {
                 sectionIndex++;
                 itemRect.y += divHeight + spacing[1];
             }
-            for (let c = 0; c < this.numCols; c++) {
+            // Start at the horizontal scroll window's left column (clamped in case numColumns
+            // shrank at runtime) so the focused/visible columns lay out from the grid's left edge.
+            const startCol = Math.min(this.scrollCol, Math.max(0, this.numCols - 1));
+            for (let c = startCol; c < this.numCols; c++) {
                 itemRect.width = columnWidths[c] ?? itemSize[0];
                 const index = rowIndex + c;
                 if (index >= this.content.length) {

--- a/src/extensions/scenegraph/nodes/MarkupList.ts
+++ b/src/extensions/scenegraph/nodes/MarkupList.ts
@@ -76,7 +76,9 @@ export class MarkupList extends ArrayGrid {
         if (this.wrap) {
             nextIndex = this.getIndex(offset);
         }
-        if (nextIndex >= 0 && nextIndex < this.content.length) {
+        // A wrap on a single-item list resolves to the focused index itself: the move is a no-op
+        // and must NOT report handled, so the key bubbles to an ancestor's onKeyEvent.
+        if (nextIndex >= 0 && nextIndex < this.content.length && nextIndex !== this.focusIndex) {
             const itemIndex = this.metadata[nextIndex]?.index ?? nextIndex;
             this.setValue("animateToItem", new Int32(itemIndex));
             handled = true;

--- a/test/extensions/scenegraph/MarkupGridHorizNav.test.js
+++ b/test/extensions/scenegraph/MarkupGridHorizNav.test.js
@@ -1,0 +1,191 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsDevice, BrsString, Int32, RoArray, Float } = core;
+
+/** Builds a root ContentNode with `count` flat item children. */
+function buildContent(count) {
+    const root = SGNodeFactory.createNode("ContentNode");
+    for (let i = 0; i < count; i++) {
+        const item = SGNodeFactory.createNode("ContentNode");
+        item.setValue("title", new BrsString(`item ${i}`));
+        root.appendChildToParent(item);
+    }
+    return root;
+}
+
+/**
+ * A focused single-row horizontal strip: numRows=1, numColumns = item count (the related-items
+ * row recipe). itemSize [252,360] + spacing [16,16] on the headless 1280-wide scene gives
+ * floor(1280 / 268) = 4 fully visible columns for the floating-focus math.
+ */
+function focusedStrip(style, count = 20) {
+    const grid = SGNodeFactory.createNode("MarkupGrid");
+    grid.setValue("numRows", new Int32(1));
+    grid.setValue("numColumns", new Int32(count));
+    grid.setValue("itemSize", new RoArray([new Float(252), new Float(360)]));
+    grid.setValue("itemSpacing", new RoArray([new Float(16), new Float(16)]));
+    if (style) {
+        grid.setValue("horizFocusAnimationStyle", new BrsString(style));
+    }
+    grid.setValue("content", buildContent(count));
+    grid.setNodeFocus(true);
+    return grid;
+}
+
+describe("MarkupGrid horizFocusAnimationStyle handling", () => {
+    beforeAll(() => {
+        // The grid resolves fonts/focus bitmap from the common: volume; mount it once.
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    describe("field acceptance", () => {
+        test("fixedFocus is accepted (a device honors it despite the doc's option table)", () => {
+            const grid = focusedStrip("fixedFocus");
+            expect(grid.getValueJS("horizFocusAnimationStyle")).toBe("fixedFocus");
+        });
+
+        test('the shorthand "fixed" resolves to fixedFocus, like the vertical alias', () => {
+            const grid = focusedStrip("fixed");
+            expect(grid.getValueJS("horizFocusAnimationStyle")).toBe("fixed");
+            // Behaves as fixedFocus: the scroll window pins the focused column at the left edge.
+            grid.handleKey("right", true);
+            expect(grid.scrollCol).toBe(1);
+        });
+
+        test("an unrecognized value is ignored, keeping the previous (floating) style", () => {
+            const grid = focusedStrip("banana");
+            expect(grid.getValueJS("horizFocusAnimationStyle")).toBe("floatingFocus");
+        });
+    });
+
+    describe("fixedFocus: focused column pinned at the left edge, content scrolls", () => {
+        test("right presses advance itemFocused with scrollCol following exactly", () => {
+            const grid = focusedStrip("fixedFocus");
+            for (let i = 1; i <= 6; i++) {
+                expect(grid.handleKey("right", true)).toBe(true);
+                expect(grid.getValueJS("itemFocused")).toBe(i);
+                expect(grid.scrollCol).toBe(i);
+            }
+        });
+
+        test("no wrap: right at the last item and left at the first are unhandled (bubble)", () => {
+            const grid = focusedStrip("fixedFocus", 5);
+            expect(grid.handleKey("left", true)).toBe(false);
+            for (let i = 0; i < 4; i++) {
+                expect(grid.handleKey("right", true)).toBe(true);
+            }
+            expect(grid.getValueJS("itemFocused")).toBe(4);
+            expect(grid.handleKey("right", true)).toBe(false);
+            // Walk back to the start; scrollCol tracks the focused column the whole way.
+            for (let i = 3; i >= 0; i--) {
+                expect(grid.handleKey("left", true)).toBe(true);
+                expect(grid.scrollCol).toBe(i);
+            }
+            expect(grid.handleKey("left", true)).toBe(false);
+        });
+
+        test("jumpToItem scrolls the window to the target column", () => {
+            const grid = focusedStrip("fixedFocus");
+            grid.setValue("jumpToItem", new Int32(10));
+            expect(grid.getValueJS("itemFocused")).toBe(10);
+            expect(grid.scrollCol).toBe(10);
+        });
+    });
+
+    describe("floatingFocus (default): focus floats within the visible window, then scrolls", () => {
+        test("scrollCol stays 0 while focus is inside the window, then follows", () => {
+            const grid = focusedStrip();
+            // 4 columns fit (1280 / 268); focus floats through columns 0..3 without scrolling.
+            for (let i = 1; i <= 3; i++) {
+                expect(grid.handleKey("right", true)).toBe(true);
+                expect(grid.scrollCol).toBe(0);
+            }
+            // Moving to column 4 scrolls the window by one, and so on.
+            expect(grid.handleKey("right", true)).toBe(true);
+            expect(grid.scrollCol).toBe(1);
+            expect(grid.handleKey("right", true)).toBe(true);
+            expect(grid.scrollCol).toBe(2);
+            // Scrolling left only once focus moves before the window's left column.
+            expect(grid.handleKey("left", true)).toBe(true);
+            expect(grid.scrollCol).toBe(2);
+            expect(grid.handleKey("left", true)).toBe(true);
+            expect(grid.handleKey("left", true)).toBe(true);
+            expect(grid.scrollCol).toBe(2);
+            expect(grid.handleKey("left", true)).toBe(true);
+            expect(grid.scrollCol).toBe(1);
+        });
+
+        test("jumpToItem scrolls minimally to make the target visible", () => {
+            const grid = focusedStrip();
+            grid.setValue("jumpToItem", new Int32(10));
+            // Window of 4: item 10 becomes the rightmost visible column (10 - 4 + 1).
+            expect(grid.scrollCol).toBe(7);
+        });
+
+        test("no wrap: ends bubble", () => {
+            const grid = focusedStrip(undefined, 3);
+            expect(grid.handleKey("left", true)).toBe(false);
+            expect(grid.handleKey("right", true)).toBe(true);
+            expect(grid.handleKey("right", true)).toBe(true);
+            expect(grid.handleKey("right", true)).toBe(false);
+        });
+    });
+
+    describe("fixedFocusWrap: horizontal wrapping not implemented, floats without wrap", () => {
+        test("right at the last item is unhandled (bubbles) instead of wrapping", () => {
+            const grid = focusedStrip("fixedFocusWrap", 3);
+            expect(grid.handleKey("right", true)).toBe(true);
+            expect(grid.handleKey("right", true)).toBe(true);
+            expect(grid.handleKey("right", true)).toBe(false);
+            expect(grid.handleKey("left", true)).toBe(true);
+        });
+    });
+
+    describe("multi-row grids and placeholders", () => {
+        test("right at a row boundary stays in the row (unhandled)", () => {
+            const grid = SGNodeFactory.createNode("MarkupGrid");
+            grid.setValue("numColumns", new Int32(4));
+            grid.setValue("content", buildContent(12));
+            grid.setNodeFocus(true);
+            for (let i = 0; i < 3; i++) {
+                expect(grid.handleKey("right", true)).toBe(true);
+            }
+            expect(grid.getValueJS("itemFocused")).toBe(3);
+            // Item 4 exists but is on the next row — left/right never changes rows.
+            expect(grid.handleKey("right", true)).toBe(false);
+        });
+
+        test("navigation into a section's padding placeholder is unhandled", () => {
+            // A sectioned content tree with a ragged last row: ArrayGrid.processSection pads the
+            // row with _placeholder_ nodes, which must not receive focus.
+            const root = SGNodeFactory.createNode("ContentNode");
+            const section = SGNodeFactory.createNode("ContentNode");
+            section.setValue("ContentType", new BrsString("section"));
+            section.setValue("title", new BrsString("Section"));
+            for (let i = 0; i < 3; i++) {
+                const item = SGNodeFactory.createNode("ContentNode");
+                item.setValue("title", new BrsString(`item ${i}`));
+                section.appendChildToParent(item);
+            }
+            root.appendChildToParent(section);
+
+            const grid = SGNodeFactory.createNode("MarkupGrid");
+            grid.setValue("numColumns", new Int32(4));
+            grid.setValue("content", root);
+            grid.setNodeFocus(true);
+            expect(grid.handleKey("right", true)).toBe(true);
+            expect(grid.handleKey("right", true)).toBe(true);
+            // Item 3 is the placeholder padding the 4-column row.
+            expect(grid.handleKey("right", true)).toBe(false);
+        });
+    });
+});

--- a/test/extensions/scenegraph/MarkupGridWrap.test.js
+++ b/test/extensions/scenegraph/MarkupGridWrap.test.js
@@ -77,3 +77,49 @@ describe("MarkupGrid vertFocusAnimationStyle handling (wrap vs. escape at the to
         expect(grid.handleKey("up", true)).toBe(true);
     });
 });
+
+describe("single-row grid: vertical keys bubble instead of wrapping onto themselves", () => {
+    beforeAll(() => {
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    /** A focused single-row strip (numRows=1, numColumns = content count) — the "related items
+     * row" recipe: under the default fixedFocusWrap a vertical wrap resolves to the focused item
+     * itself, which must NOT be reported handled or the key never reaches the screen's onKeyEvent. */
+    function singleRowGrid(count = 8) {
+        const grid = SGNodeFactory.createNode("MarkupGrid");
+        grid.setValue("numRows", new Int32(1));
+        grid.setValue("numColumns", new Int32(count));
+        grid.setValue("content", buildContent(count));
+        grid.setNodeFocus(true);
+        return grid;
+    }
+
+    test("MarkupGrid with one row: up/down presses and releases are unhandled (bubble)", () => {
+        const grid = singleRowGrid();
+        expect(grid.handleKey("up", true)).toBe(false);
+        expect(grid.handleKey("up", false)).toBe(false);
+        expect(grid.handleKey("down", true)).toBe(false);
+        expect(grid.handleKey("down", false)).toBe(false);
+        // rewind/fastforward page vertically; a single-row grid can't move either.
+        expect(grid.handleKey("rewind", true)).toBe(false);
+        expect(grid.handleKey("fastforward", true)).toBe(false);
+        // Horizontal navigation still works (proves the grid is live, just not consuming vertical).
+        expect(grid.handleKey("right", true)).toBe(true);
+        expect(grid.getValueJS("itemFocused")).toBe(1);
+    });
+
+    test("MarkupList with a single item: up/down are unhandled (bubble)", () => {
+        const list = SGNodeFactory.createNode("MarkupList");
+        list.setValue("content", buildContent(1));
+        list.setNodeFocus(true);
+        expect(list.handleKey("up", true)).toBe(false);
+        expect(list.handleKey("down", true)).toBe(false);
+        expect(list.handleKey("rewind", true)).toBe(false);
+    });
+});


### PR DESCRIPTION
## Problem

A common detail-screen recipe — a `MarkupGrid` with `numRows="1"` and `numColumns` set to the content count (a horizontal related-items strip below a button menu) — misbehaved in two ways vs. a real device:

1. **Up/Down were swallowed.** `MarkupGrid.handleUpDown` reported the key handled even when the default `fixedFocusWrap` vertical wrap resolved back to the focused item itself (the only row). The key never bubbled to an ancestor's `onKeyEvent`, so a screen that moves focus from the strip back to the menu above never received it. `MarkupList` had the same missing guard (a one-item list swallowed up/down too).
2. **Horizontal focus always floated.** `horizFocusAnimationStyle` was declared but inert: `ArrayGrid.setValue` rejected `fixedFocus` for it (a real device honors it, plus the `"fixed"` shorthand) and nothing read the field. There was no horizontal scroll at all, and `handleLeftRight` required the target item component to already be rendered — items past the screen edge were unreachable.

## Fix

- **Bubbling guard** (`MarkupGrid.handleUpDown`, `MarkupList.handleUpDown`): a move that resolves to the focused index is not handled, matching the guard RowList/ZoomRowList/PosterGrid already have. Also fixes rewind/fastforward paging on a single-row grid.
- **Shared style resolver**: `resolveVertFocusStyle` → `resolveFocusStyle` (body unchanged); the `horizFocusAnimationStyle` branch now accepts `fixedFocus`/`fixed`, caching the canonical name like the vertical axis does. Invalid values still keep the previous field value.
- **Horizontal scroll window** (`MarkupGrid.scrollCol` — one window shared by all rows, matching device grids that scroll rows together):
  - `fixedFocus`: focused column pinned at the grid's left edge, content scrolls; no wrap, ends bubble.
  - `floatingFocus` (default): focus floats within the fully-visible columns, then scrolls minimally (same viewport math as RowList); no wrap, ends bubble.
  - `fixedFocusWrap`: keeps floating behavior (horizontal wrapping still unimplemented, TODO).
  - `renderContent` starts the column loop at the window's left column, clamped for runtime `numColumns` shrinks.
- **`handleLeftRight` rewrite**: navigates from the content model (section-padding `_placeholder_` cells still skipped, row boundaries still respected) instead of requiring a rendered item component.
- **Single update path**: `jumpToItem`/`animateToItem`/key nav/focus-gain all update the window through a new `updateHorizScroll` hook in `ArrayGrid.setFocusedItem` — a no-op for every other node type (RowList has its own `setFocusedItem` and is untouched).

## Tests

- New `test/extensions/scenegraph/MarkupGridHorizNav.test.js`: field acceptance (`fixedFocus`/`fixed`/invalid), pinned-left scrolling and end bubbling for `fixedFocus`, floating-window scrolling and `jumpToItem` minimal scroll, `fixedFocusWrap` non-wrap, row-boundary and placeholder guards.
- Extended `test/extensions/scenegraph/MarkupGridWrap.test.js`: single-row grid up/down/rewind/fastforward presses and releases bubble; one-item MarkupList bubbles.
- Full suite green (168 suites, 2179 tests, all snapshots); verified end-to-end against a production SceneGraph app in brs-desktop (up returns to the menu; right/left scrolls with the focus pinned left, all items reachable, no wrap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)