### PR TITLE
fix(brs): update RoAssociativeArray behavior for handling keys vs interface methods

### DIFF
--- a/src/core/brsTypes/components/RoAssociativeArray.ts
+++ b/src/core/brsTypes/components/RoAssociativeArray.ts
@@ -143,18 +143,12 @@ export class RoAssociativeArray extends BrsComponent implements BrsValue, BrsIte
             throw new Error("Associative array indexes must be strings");
         }
 
-        // TODO: this works for now, in that a property with the same name as a method essentially
-        // overwrites the method. The only reason this doesn't work is that getting a method from an
-        // associative array and _not_ calling it returns `invalid`, but calling it returns the
-        // function itself. I'm not entirely sure why yet, but it's gotta have something to do with
-        // how methods are implemented within RBI.
-        //
-        // Are they stored separately from elements, like they are here? Or does
-        // `Interpreter#visitCall` need to check for `invalid` in its callable, then try to find a
-        // method with the desired name separately? That last bit would work but it's pretty gross.
-        // That'd allow roArrays to have methods with the methods not accessible via `arr["count"]`.
-        // Same with RoAssociativeArrays I guess.
-        return this.findElement(index.value, isCaseSensitive) || this.getMethod(index.value) || BrsInvalid.Instance;
+        // A member read only sees stored elements — on Roku `aa.items` is invalid when no such
+        // key exists, even though Items() is an interface method (apps rely on that to probe
+        // parsed JSON: `if invalid <> data.items`). Interface methods are resolvable only at a
+        // call site: the interpreter's DottedGet/IndexedGet visitors fall back to getMethod()
+        // when this get() yields invalid for a call's callee.
+        return this.findElement(index.value, isCaseSensitive) ?? BrsInvalid.Instance;
     }
 
     set(index: BrsType, value: BrsType, isCaseSensitive = false) {

--- a/src/core/interpreter/index.ts
+++ b/src/core/interpreter/index.ts
@@ -1361,6 +1361,19 @@ export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType>
                         return method;
                     }
                 }
+                // An AA member read never yields an interface method on Roku (`aa.items` with no
+                // such key is invalid); the method resolves only at a call site (`aa.items()`),
+                // where a stored element still shadows it (the classic `aa.count` gotcha).
+                if (
+                    target instanceof BrsInvalid &&
+                    this._activeCallee === expression &&
+                    source instanceof RoAssociativeArray
+                ) {
+                    const method = source.getMethod(expression.name.text);
+                    if (method) {
+                        return method;
+                    }
+                }
                 return target;
             } catch (err: any) {
                 this.addError(new BrsError(err.message, expression.name.location));

--- a/test/e2e/BrsComponents.test.js
+++ b/test/e2e/BrsComponents.test.js
@@ -74,6 +74,12 @@ describe("end to end brightscript functions", () => {
             "AA keys size:  1",
             "values() count:  3",
             "values() in key order: Los Angeles, Chicago, New York",
+            "missing items reads invalid: true",
+            "missing keys reads invalid: true",
+            "items() still callable:  2",
+            "key bracket call still works: passed",
+            "methods in bracket returns invalid: invalid",
+            "methods in bracket raise error: Function Call Operator ( ) attempted on non-function.",
         ]);
     });
 

--- a/test/e2e/resources/components/roAssociativeArray.brs
+++ b/test/e2e/resources/components/roAssociativeArray.brs
@@ -40,4 +40,18 @@ sub main()
     conventions = {"2027": "Chicago", "2026": "Los Angeles", "2028": "New York"}
     print "values() count: " conventions.values().count()        ' => 3
     print "values() in key order: " conventions.values().join(", ") ' => Los Angeles, Chicago, New York
+
+    ' A member read of a missing key returns invalid even when an interface method shares the
+    ' name (apps probe parsed JSON with `invalid <> data.items`); only a call site resolves it.
+    data = {"foo": 1, "testme": function() : return "passed" : end function}
+    print "missing items reads invalid: " invalid = data.items   ' => true
+    print "missing keys reads invalid: " invalid = data.keys     ' => true
+    print "items() still callable: " data.items().count()        ' => 1
+    print "key bracket call still works: " data["testme"]()      ' => passed
+    print "methods in bracket returns invalid: " data["count"]   ' => invalid
+    try
+        print "methods in bracket raise error: " data["count"]() ' => error
+    catch e
+        print "methods in bracket raise error: " e.message
+    end try
 end sub


### PR DESCRIPTION
The `roAssociativeArray` implementation was not handling properly the access to interface methods versus keys with the same name. A member read only sees stored elements — on Roku `aa.items` is invalid when no such key exists, even though Items() is an interface method (apps rely on that to probe parsed JSON: `if invalid <> data.items`). Interface methods are resolvable only at a call site: the interpreter's DottedGet visitors fall back to getMethod() when this get() yields invalid for a call's callee.