### PR TITLE
fix(brs): handle empty POST body in roURLTransfer postFromStringAsync method

### DIFF
--- a/src/core/brsTypes/components/RoURLTransfer.ts
+++ b/src/core/brsTypes/components/RoURLTransfer.ts
@@ -227,7 +227,11 @@ export class RoURLTransfer extends BrsComponent implements BrsValue, BrsHttpAgen
 
     postFromStringAsync(): BrsType {
         const request = this.postBody.shift();
-        if (!request) {
+        // An empty string is a valid POST body (e.g. token requests that carry auth in headers
+        // only), so guard on an empty queue (undefined) rather than falsiness — otherwise the
+        // async request is silently dropped, no roUrlEvent is posted, and the caller's
+        // waitMessage() blocks until timeout.
+        if (request === undefined) {
             return BrsInvalid.Instance;
         }
         return this.postFromStringEvent(request);

--- a/test/brsTypes/components/RoURLTransfer.test.js
+++ b/test/brsTypes/components/RoURLTransfer.test.js
@@ -1,0 +1,66 @@
+const brs = require("../../../packages/node/bin/brs.node");
+const { Interpreter } = brs;
+const { BrsString, BrsInvalid, RoURLTransfer, RoMessagePort, RoURLEvent } = brs.types;
+
+describe("RoURLTransfer", () => {
+    let interpreter;
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+    });
+
+    describe("AsyncPostFromString", () => {
+        // A POST with an empty body is valid (e.g. token requests that carry auth in headers
+        // only). The async path must still fire the request and post an roUrlEvent — regressed
+        // when the queue guard treated the empty-string body as "no work" and dropped it, so the
+        // caller's wait() blocked until timeout.
+        it("fires the request for an empty body and posts an roUrlEvent", () => {
+            const transfer = new RoURLTransfer();
+            const port = new RoMessagePort();
+            transfer.getMethod("setMessagePort").call(interpreter, port);
+
+            // Stub the network layer so no real request is made; capture the body it receives.
+            const sentBodies = [];
+            transfer.postFromStringEvent = (body) => {
+                sentBodies.push(body);
+                return new RoURLEvent(1, "", "ok", 200, "", "");
+            };
+
+            const asyncPost = transfer.getMethod("asyncPostFromString");
+            expect(asyncPost.call(interpreter, new BrsString("")).toBoolean()).toBe(true);
+
+            // The queued callback is what wait()/getMessage drains — it must yield the event.
+            const event = port.getMethod("getMessage").call(interpreter);
+            expect(event).toBeInstanceOf(RoURLEvent);
+            expect(sentBodies).toEqual([""]);
+        });
+
+        it("fires the request for a non-empty body", () => {
+            const transfer = new RoURLTransfer();
+            const port = new RoMessagePort();
+            transfer.getMethod("setMessagePort").call(interpreter, port);
+
+            const sentBodies = [];
+            transfer.postFromStringEvent = (body) => {
+                sentBodies.push(body);
+                return new RoURLEvent(1, "", "ok", 200, "", "");
+            };
+
+            const asyncPost = transfer.getMethod("asyncPostFromString");
+            asyncPost.call(interpreter, new BrsString('{"refreshToken":"abc"}'));
+
+            const event = port.getMethod("getMessage").call(interpreter);
+            expect(event).toBeInstanceOf(RoURLEvent);
+            expect(sentBodies).toEqual(['{"refreshToken":"abc"}']);
+        });
+
+        it("yields invalid when the callback fires with an empty queue", () => {
+            const transfer = new RoURLTransfer();
+            // No body queued: draining must be a no-op (invalid), not a spurious request.
+            transfer.postFromStringEvent = () => {
+                throw new Error("should not be called with an empty queue");
+            };
+            expect(transfer.postFromStringAsync()).toBe(BrsInvalid.Instance);
+        });
+    });
+});


### PR DESCRIPTION
The `roURLTransfer` component was not supporting an empty string as a valid `POST` body (e.g. token requests that carry auth in headers only), so guard on an empty queue (undefined) rather than falsiness, otherwise the async request is silently dropped, no `roUrlEvent` is posted, and the caller's waitMessage() blocks until timeout.