### PR TITLE
fix(rsg): parentSubtype() returns Invalid instead of "" at the hierarchy root

### DIFF
--- a/src/extensions/scenegraph/components/RoSGNode.ts
+++ b/src/extensions/scenegraph/components/RoSGNode.ts
@@ -1808,18 +1808,18 @@ export abstract class RoSGNode extends BrsComponent implements BrsValue, ISGNode
         return new Callable("parentSubtype", {
             signature: {
                 args: [new StdlibArgument("nodeType", ValueKind.String)],
-                returns: ValueKind.Object,
+                returns: ValueKind.String,
             },
             impl: (interpreter: Interpreter, nodeType: BrsString) => {
                 const remote = this.rendezvousCall(interpreter, "parentSubtype", [nodeType]);
                 if (remote !== undefined) {
                     return remote;
                 }
+                // Per the Roku docs this always returns a String - callers (e.g. the
+                // rokucommunity/promises library's isPromise()) walk the hierarchy checking
+                // for "" to detect the root, so returning Invalid here crashes them.
                 const parentType = subtypeHierarchy.get(nodeType.getValue().toLowerCase());
-                if (parentType) {
-                    return new BrsString(parentType);
-                }
-                return BrsInvalid.Instance;
+                return new BrsString(parentType ?? "");
             },
         });
     }

--- a/test/extensions/scenegraph/ParentSubtype.test.js
+++ b/test/extensions/scenegraph/ParentSubtype.test.js
@@ -1,0 +1,49 @@
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { Node, Group } = scenegraph;
+const { Interpreter, BrsString } = core;
+
+/**
+ * ifSGNodeDict.parentSubtype(nodeType as String) as String is documented to always return a
+ * String - an empty string when nodeType has no parent in the SceneGraph class hierarchy (e.g.
+ * "Node" itself, the root). rokucommunity/promises' isPromise() walks the hierarchy via this
+ * method and checks `subType = ""` to detect the root; brs-engine returned Invalid instead,
+ * which crashed LCase(Invalid) on the very next loop iteration for any non-Promise node passed
+ * to isPromise() - failing on every @SGNode Rooibos suite that validates isPromise()/isComplete()
+ * against a plain node.
+ */
+describe("ifSGNodeDict.parentSubtype", () => {
+    let interpreter;
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+    });
+
+    test("returns an empty string, not Invalid, for a root type with no parent", () => {
+        const node = new Node([], "Node");
+        const parentSubtype = node.getMethod("parentSubtype");
+
+        const result = parentSubtype.call(interpreter, new BrsString("Node"));
+
+        expect(result).toEqual(new BrsString(""));
+    });
+
+    test("returns the parent subtype for a type with a known parent", () => {
+        const node = new Group([], "Group");
+        const parentSubtype = node.getMethod("parentSubtype");
+
+        const result = parentSubtype.call(interpreter, new BrsString("Group"));
+
+        expect(result).toEqual(new BrsString("Node"));
+    });
+
+    test("returns an empty string for an unrecognized node type name", () => {
+        const node = new Node([], "Node");
+        const parentSubtype = node.getMethod("parentSubtype");
+
+        const result = parentSubtype.call(interpreter, new BrsString("NotARealNodeType"));
+
+        expect(result).toEqual(new BrsString(""));
+    });
+});


### PR DESCRIPTION
## Summary
- `ifSGNodeDict.parentSubtype(nodeType as String) as String` is documented to always return a `String`, using an empty string to mean "`nodeType` has no parent" (the root type `Node` itself, or an unrecognized type name). brs-engine returned `BrsInvalid.Instance` in that case instead (and registered the wrong Callable return kind, `ValueKind.Object` rather than `String`).
- [`rokucommunity/promises`](https://github.com/rokucommunity/promises)' `isPromise()` walks the SceneGraph class hierarchy via this exact method to detect whether a node is (or descends from) a `Promise`:
  ```brightscript
  while true
      subType = promise.parentSubtype(subType)
      if lCase(subType).endsWith("_promise") then return true
      if subType = "" then exit while
  end while
  ```
  With brs-engine returning `Invalid` instead of `""` once the walk reaches the hierarchy root, the *next* loop iteration's `lCase(subType)` throws a Type Mismatch - crashing `isPromise()`/`isComplete()` for any non-`Promise` node. In practice this crashed Rooibos's own `promise validation` / `promise settlement check` tests (and any `@SGNode` Rooibos suite exercising these checks) on brs-desktop/brs-cli, while the identical test passes on a real device.
- Fix: return `new BrsString(parentType ?? "")` and correct the registered return kind to `ValueKind.String`.

## Validating against a real device
Rather than trust the docs alone, I built a small repro (`createObject("roSGNode", "Node").parentSubtype("Node")`, etc.) and ran it on a physical Roku via [`rokubot`](https://www.npmjs.com/package/rokubot):

| Call | Real device | brs-engine (fixed) |
| --- | --- | --- |
| `parentSubtype("Node")` (hierarchy root) | `String`, `""` | `String`, `""` |
| `parentSubtype("Group")` (has a parent) | `String`, `"Node"` | `String`, `"Node"` |
| `parentSubtype("NotARealNodeType")` (unknown) | `String`, `""` | `String`, `""` |

Before the fix, brs-engine returned `Invalid` for the first and third rows.

## Test plan
- [x] Added `test/extensions/scenegraph/ParentSubtype.test.js` covering the hierarchy-root, known-parent, and unrecognized-type-name cases.
- [x] Verified the new test fails on the pre-fix code and passes on the fix (toggled via `git stash`).
- [x] `npm run lint` and `npm run build` (all three packages) pass.
- [x] `npm test` - full suite green (170 suites, 2190 tests).
- [x] Re-ran the real-world Rooibos suite that surfaced this against a rebuilt brs-desktop - `promise validation` and `promise settlement check` now pass (previously crashing).
- [x] Cross-validated against a physical Roku device with a purpose-built repro app (table above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)