### PR TITLE
fix(scenegraph): reset key buffer on roSGScreen close to prevent stale key leaking into next screen

### DIFF
--- a/src/core/device/BrsDevice.ts
+++ b/src/core/device/BrsDevice.ts
@@ -478,6 +478,19 @@ export class BrsDevice {
     }
 
     /**
+     * Discards any buffered-but-undelivered key events and resets the press/release
+     * debounce state. Call this when a screen closes, so a key event still in flight
+     * for that screen (e.g. the release half of a press/release pair) is not later
+     * delivered to a different screen that becomes active next, as would never happen
+     * on a real device where key events are scoped to the currently displayed screen.
+     */
+    static resetKeysBuffer() {
+        this.keysBuffer.length = 0;
+        this.lastKey = -1;
+        this.lastMod = -1;
+    }
+
+    /**
      * Updates the control keys buffer from shared array and returns the next key.
      * Handles single key event mode and remote button press/release logic.
      * @returns Next key event to be handled or undefined if queue is empty

--- a/src/extensions/scenegraph/components/RoSGScreen.ts
+++ b/src/extensions/scenegraph/components/RoSGScreen.ts
@@ -327,6 +327,7 @@ export class RoSGScreen extends BrsComponent implements BrsValue, BrsDraw2D {
             returns: ValueKind.Void,
         },
         impl: (_: Interpreter) => {
+            BrsDevice.resetKeysBuffer();
             this.port?.pushMessage(new RoSGScreenEvent(BrsBoolean.True));
             return Uninitialized.Instance;
         },


### PR DESCRIPTION
## Summary

Fixes a hybrid-app bug where switching from a `roSGScreen` to a plain `roScreen` (and back) via the Back button doesn't behave like a real device: pressing Back once bounces straight back to the SceneGraph screen instead of staying on the newly shown `roScreen` part.

**Root cause:** `BrsDevice.keysBuffer`/`lastKey`/`lastMod` are global static state, shared by every screen's message port (`RoScreen.getNewEvents` and `RoSGScreen.handleNextKey` both call `BrsDevice.updateKeysBuffer()`). Roku splits a physical button press into two discrete events (press, then release). When a `Scene`'s `onKeyEvent` consumes a Back **press** (`handled = true`) and the app immediately closes the `roSGScreen` and creates a new `roScreen`, the matching **release** half of that press/release pair can still be sitting in the buffer. The newly created `roScreen`'s message port then dequeues that stale release as if it were a brand new event. Since Roku's own button-code convention doesn't distinguish press (`0-99`) from release (`100-199`) by *name* — only by code range — app code that checks `isButton("back")` without also checking press/release (a very common pattern, mirroring how Roku documents button codes) reads the leaked release as a new Back activation and reacts to it immediately.

This never reproduces on a real device, where key events are scoped to whichever screen is currently active — there's no shared global buffer to leak from.

## Fix

- `BrsDevice.resetKeysBuffer()` (`src/core/device/BrsDevice.ts`) discards any buffered key events and resets the press/release debounce state (`lastKey`/`lastMod`).
- Called from `RoSGScreen.close()` (`src/extensions/scenegraph/components/RoSGScreen.ts`), so no key event still in flight for the closing screen's focus chain can leak into whatever screen becomes active next.

This is deliberately minimal — it doesn't introduce a general "active screen" concept, it just ensures a screen transition can't carry over an already-half-consumed key transaction.

## Test plan

- [x] `npm run lint` / `npm run prettier:write` clean
- [x] Full `test/extensions/scenegraph` + `test/cli` suites pass (547 passed)
- [x] Verified against a real Roku device, `brs-cli --ecp`, and `brs-desktop`, using [markwpearce/roku-hybrid-example](https://github.com/markwpearce/roku-hybrid-example) — a small hybrid `roSGScreen`/`roScreen` app that reproduces the issue:
  - Before the fix: pressing Back once in the SceneGraph part immediately bounced back to SceneGraph instead of showing the ball game.
  - After the fix: Back correctly switches to and stays on the ball game (`roScreen`) part, and a second Back press correctly returns to the SceneGraph part — matching real-device behavior in both `brs-cli` and `brs-desktop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)