### PR TITLE
fix(network): follow HTTP redirects in the synchronous XHR download path

### DIFF
--- a/src/core/polyfill/XMLHttpRequest.ts
+++ b/src/core/polyfill/XMLHttpRequest.ts
@@ -417,46 +417,56 @@ export class XMLHttpRequest {
             this.dispatchEvent("readystatechange");
 
             // Handler for the response
+            let redirectCount = 0;
             const responseHandler = (resp: any) => {
                 // Set response property to the response we got back
                 // This is so it remains accessible outside this scope
                 this._response = resp;
                 // Check for redirect
-                // @TODO Prevent looped redirects
-                if (
-                    this._response.statusCode === 302 ||
-                    this._response.statusCode === 303 ||
-                    this._response.statusCode === 307
-                ) {
-                    // Change URL to the redirect location
-                    this._settings.url = this._response.headers.location;
-                    const url = Url.parse(this._settings.url);
-                    // Set host variable in case it's used later
-                    host = url.hostname;
-                    // Options for the new request
-                    let newOptions: any = {
-                        hostname: url.hostname,
-                        port: url.port,
-                        path: url.path,
-                        method: this._response.statusCode === 303 ? "GET" : this._settings.method,
-                        headers: this._headers,
-                    };
+                const sc = this._response.statusCode;
+                if (sc === 301 || sc === 302 || sc === 303 || sc === 307 || sc === 308) {
+                    const location = this._response.headers.location;
+                    if (location && redirectCount < 10) {
+                        redirectCount++;
+                        resp.resume();
+                        // Resolve the (possibly relative) location against the current URL
+                        const redirectUrl = new URL(location, this._settings.url);
+                        this._settings.url = redirectUrl.href;
+                        // Set host variable in case it's used later
+                        host = redirectUrl.hostname;
+                        const newSsl = redirectUrl.protocol === "https:";
+                        const newHeaders = { ...this._headers };
+                        newHeaders["Host"] = redirectUrl.host;
+                        const isGet = sc === 303;
+                        if (isGet) {
+                            delete newHeaders["Content-Length"];
+                        }
+                        // Options for the new request
+                        const newOptions: any = {
+                            hostname: redirectUrl.hostname,
+                            port: redirectUrl.port || (newSsl ? 443 : 80),
+                            path: redirectUrl.pathname + redirectUrl.search,
+                            method: isGet ? "GET" : this._settings.method,
+                            headers: newHeaders,
+                        };
 
-                    if (ssl) {
-                        newOptions.pfx = this._opts.pfx;
-                        newOptions.key = this._opts.key;
-                        newOptions.passphrase = this._opts.passphrase;
-                        newOptions.cert = this._opts.cert;
-                        newOptions.ca = this._opts.ca;
-                        newOptions.ciphers = this._opts.ciphers;
-                        newOptions.rejectUnauthorized = this._opts.rejectUnauthorized === false ? false : true;
+                        if (newSsl) {
+                            newOptions.pfx = this._opts.pfx;
+                            newOptions.key = this._opts.key;
+                            newOptions.passphrase = this._opts.passphrase;
+                            newOptions.cert = this._opts.cert;
+                            newOptions.ca = this._opts.ca;
+                            newOptions.ciphers = this._opts.ciphers;
+                            newOptions.rejectUnauthorized = this._opts.rejectUnauthorized === false ? false : true;
+                        }
+
+                        // Issue the new request, switching protocol if the redirect changed it
+                        const redirectRequest = newSsl ? https.request : http.request;
+                        this._request = redirectRequest(newOptions, responseHandler).on("error", errorHandler);
+                        this._request.end();
+                        // @TODO Check if an XHR event needs to be fired here
+                        return;
                     }
-
-                    // Issue the new request
-                    this._request = doRequest(newOptions, responseHandler).on("error", errorHandler);
-                    this._request.end();
-                    // @TODO Check if an XHR event needs to be fired here
-                    return;
                 }
 
                 this.setState(this.HEADERS_RECEIVED);
@@ -519,55 +529,71 @@ export class XMLHttpRequest {
             const contentFile = `.node-xhr-content-${crypto.randomUUID()}`;
             const syncFile = `.node-xhr-sync-${crypto.randomUUID()}`;
             fs.writeFileSync(syncFile, "", "utf8");
-            // The async request the other Node process executes
-            const execString =
-                "const http = require('http'), https = require('https'), fs = require('fs');" +
-                "const doRequest = http" +
-                (ssl ? "s" : "") +
-                ".request;" +
-                "const options = " +
-                JSON.stringify(options) +
-                ";" +
-                "let responseText = '';" +
-                "let responseData = Buffer.alloc(0);" +
-                "let req = doRequest(options, function(response) {" +
-                "response.on('data', function(chunk) {" +
-                "  const data = Buffer.from(chunk);" +
-                "  responseText += data.toString('utf8');" +
-                "  responseData = Buffer.concat([responseData, data]);" +
-                "});" +
-                "response.on('end', function() {" +
-                "fs.writeFileSync('" +
-                contentFile +
-                "', JSON.stringify({err: null, data: {statusCode: response.statusCode, headers: response.headers, text: responseText, data: responseData.toString('base64')}}), 'utf8');" +
-                "fs.unlinkSync('" +
-                syncFile +
-                "');" +
-                "});" +
-                "response.on('error', function(error) {" +
-                "fs.writeFileSync('" +
-                contentFile +
-                "', 'NODE-XMLHTTPREQUEST-ERROR:' + JSON.stringify(error), 'utf8');" +
-                "fs.unlinkSync('" +
-                syncFile +
-                "');" +
-                "});" +
-                "}).on('error', function(error) {" +
-                "fs.writeFileSync('" +
-                contentFile +
-                "', 'NODE-XMLHTTPREQUEST-ERROR:' + JSON.stringify(error), 'utf8');" +
-                "fs.unlinkSync('" +
-                syncFile +
-                "');" +
-                "});" +
-                (data
-                    ? "req.write('" +
-                      JSON.stringify(data)
-                          .slice(1, -1)
-                          .replaceAll("'", String.raw`\'`) +
-                      "');"
-                    : "") +
-                "req.end();";
+            // The request body (if any) embedded as a single-quoted JS string literal.
+            const bodyLiteral = data
+                ? "'" +
+                  JSON.stringify(data)
+                      .slice(1, -1)
+                      .replaceAll("'", String.raw`\'`) +
+                  "'"
+                : "null";
+            // The async request the other Node process executes. It follows HTTP
+            // redirects (301/302/303/307/308) — switching protocol (http<->https),
+            // updating the Host header, and demoting 303 to GET — because this
+            // synchronous path backs download() for images and many CDNs 302-redirect.
+            const execString = `
+                const http = require('http'), https = require('https'), fs = require('fs');
+                const contentFile = ${JSON.stringify(contentFile)};
+                const syncFile = ${JSON.stringify(syncFile)};
+                const initialOptions = ${JSON.stringify(options)};
+                const initialSsl = ${ssl ? "true" : "false"};
+                const initialUrl = ${JSON.stringify(this._settings.url)};
+                const tlsKeys = ['pfx','key','passphrase','cert','ca','ciphers','rejectUnauthorized'];
+                const maxRedirects = 10;
+                let responseText = '';
+                let responseData = Buffer.alloc(0);
+                function finish(payload) { fs.writeFileSync(contentFile, payload, 'utf8'); fs.unlinkSync(syncFile); }
+                function fail(error) { finish('NODE-XMLHTTPREQUEST-ERROR:' + JSON.stringify(error)); }
+                function send(options, ssl, currentUrl, redirectsLeft, body) {
+                    const doRequest = ssl ? https.request : http.request;
+                    const req = doRequest(options, function(response) {
+                        const sc = response.statusCode;
+                        const loc = response.headers.location;
+                        if ((sc === 301 || sc === 302 || sc === 303 || sc === 307 || sc === 308) && loc) {
+                            response.resume();
+                            if (redirectsLeft <= 0) { fail({ message: 'Too many redirects' }); return; }
+                            const u = new URL(loc, currentUrl);
+                            const nextSsl = u.protocol === 'https:';
+                            const headers = Object.assign({}, options.headers);
+                            headers.Host = u.host;
+                            const isGet = sc === 303;
+                            if (isGet) { delete headers['Content-Length']; delete headers['content-length']; }
+                            const nextOptions = {
+                                hostname: u.hostname,
+                                port: u.port || (nextSsl ? 443 : 80),
+                                path: u.pathname + u.search,
+                                method: isGet ? 'GET' : options.method,
+                                headers: headers
+                            };
+                            for (const k of tlsKeys) { if (initialOptions[k] !== undefined) nextOptions[k] = initialOptions[k]; }
+                            send(nextOptions, nextSsl, u.href, redirectsLeft - 1, isGet ? null : body);
+                            return;
+                        }
+                        response.on('data', function(chunk) {
+                            const d = Buffer.from(chunk);
+                            responseText += d.toString('utf8');
+                            responseData = Buffer.concat([responseData, d]);
+                        });
+                        response.on('end', function() {
+                            finish(JSON.stringify({ err: null, data: { statusCode: response.statusCode, headers: response.headers, text: responseText, data: responseData.toString('base64') } }));
+                        });
+                        response.on('error', function(error) { fail(error); });
+                    }).on('error', function(error) { fail(error); });
+                    if (body) { req.write(body); }
+                    req.end();
+                }
+                send(initialOptions, initialSsl, initialUrl, maxRedirects, ${bodyLiteral});
+            `;
             // Start the other Node Process, executing this string
             const syncProc = spawn(process.argv[0], ["-e", execString]);
             while (fs.existsSync(syncFile)) {

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -112,6 +112,72 @@ describe("cli", () => {
         ]);
     }, 10000);
 
+    it("follows HTTP redirects when downloading a texture", async () => {
+        // Regression: the synchronous download() path (roTextureManager -> loadTexture)
+        // must follow HTTP redirects. Many CDNs 302 image URLs; before the fix the sync
+        // XHR child process ignored the redirect and the texture failed to load.
+        const http = require("http");
+        const { createCanvas } = require("canvas");
+
+        // A real PNG node-canvas can decode back into a valid roBitmap.
+        const canvas = createCanvas(4, 4);
+        const ctx = canvas.getContext("2d");
+        ctx.fillStyle = "#ff0000";
+        ctx.fillRect(0, 0, 4, 4);
+        const png = canvas.toBuffer("image/png");
+
+        // Local server: /redirect.png -> 302 -> /image.png which serves the PNG.
+        const server = http.createServer((req, res) => {
+            if (req.url === "/redirect.png") {
+                res.writeHead(302, { Location: "/image.png" });
+                res.end();
+            } else if (req.url === "/image.png") {
+                res.writeHead(200, { "Content-Type": "image/png", "Content-Length": png.length });
+                res.end(png);
+            } else {
+                res.writeHead(404);
+                res.end();
+            }
+        });
+        await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+        const port = server.address().port;
+
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "brs-redirect-"));
+        const brsPath = path.join(tmpDir, "redirectTexture.brs");
+        fs.writeFileSync(
+            brsPath,
+            [
+                "sub Main()",
+                '    msgport = CreateObject("roMessagePort")',
+                '    screen = CreateObject("roScreen", true, 854, 480)',
+                "    screen.SetMessagePort(msgport)",
+                '    mgr = CreateObject("roTextureManager")',
+                "    mgr.SetMessagePort(msgport)",
+                `    uri = "http://127.0.0.1:${port}/redirect.png"`,
+                '    request = CreateObject("roTextureRequest", uri)',
+                "    mgr.RequestTexture(request)",
+                "    msg = wait(0, msgport)",
+                '    if type(msg) = "roTextureRequestEvent" and msg.GetState() = 3 and type(msg.GetBitmap()) = "roBitmap"',
+                '        print "Image downloaded!"',
+                "    else",
+                '        print "Download failed"',
+                "    end if",
+                "end sub",
+                "",
+            ].join("\n")
+        );
+
+        try {
+            const command = ["node", brsCliPath, "redirectTexture.brs", "-c 0"].join(" ");
+            const { stdout } = await exec(command, { cwd: tmpDir });
+            expect(stdout).toContain("Image downloaded!");
+            expect(stdout).not.toContain("Download failed");
+        } finally {
+            await new Promise((resolve) => server.close(resolve));
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+    }, 15000);
+
     it("only warns once for a repeatedly-requested missing local texture", async () => {
         let command = ["node", brsCliPath, "roTextureManagerMissingFile.brs", "-c 0"].join(" ");
 


### PR DESCRIPTION
## Summary

The synchronous `XMLHttpRequest` branch spawned a child node process that issued a single request and ignored 3xx responses, so `download()` (used by `roTextureManager`/`Poster` texture loads) dropped any image behind a redirect, returning `undefined` on a 302. Browsers worked because native XHR follows redirects automatically.

- Rewrite the child-process script to follow 301/302/303/307/308 recursively: switch protocol (http↔https) from the redirect URL, update the `Host` header, demote 303 to GET, cap at 10 redirects, and accumulate the body only from the final response.
- Apply the same hardening (protocol switch, `Host` update, relative-`Location` resolution, redirect cap) to the async branch for parity.

## Test plan

- New CLI regression test: a local HTTP server serves `302 → PNG`; the test asserts `roTextureManager` downloads the texture through the redirect (fails without the fix).
- Full `test/cli/cli.test.js` suite passes (50 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)