### PR TITLE
fix(control): prevent space key from triggering page down in browsers

### DIFF
--- a/src/api/control.ts
+++ b/src/api/control.ts
@@ -306,6 +306,10 @@ function handleKeyboardEvent(event: KeyboardEvent, mod: number) {
         event.preventDefault();
     } else if (!["Alt", "Control", "Meta", "Shift", "Tab", "Dead"].includes(event.key)) {
         sendKey(`lit_${event.key}`, mod, RemoteType.WD);
+        if (event.key === " ") {
+            // Prevent Space on Browsers (that cause a PgDown)
+            event.preventDefault();
+        }
     }
 }
 


### PR DESCRIPTION
Most browsers handle the space key as page-down when not in a text field, so we have to call `preventDefault()` when the simulator is hosted in a page that can be scrolled up/down,  and the user is typing in a Keyboard dialog in the BrightScript app.