### PR TITLE
fix(control): prevent browser default action on held keys

### DIFF
--- a/src/api/control.ts
+++ b/src/api/control.ts
@@ -265,13 +265,12 @@ export function setCustomKeys(newKeys: Map<string, string>) {
 
 /**
  * Handles keyboard key down events.
- * Ignores repeated key events.
+ * Auto-repeated events are not sent to the app, but are still handled
+ * to prevent the browser default action while a key is held down.
  * @param event Keyboard event
  */
 function keyDownHandler(event: KeyboardEvent) {
-    if (!event.repeat) {
-        handleKeyboardEvent(event, 0);
-    }
+    handleKeyboardEvent(event, 0, event.repeat);
 }
 /**
  * Handles keyboard key up events.
@@ -285,8 +284,10 @@ function keyUpHandler(event: KeyboardEvent) {
  * Handles modifier keys and maps to Roku remote keys.
  * @param event Keyboard event
  * @param mod Key modifier (0 = down, 100 = up)
+ * @param repeat If true the key is auto-repeating: the browser default action is
+ *               still prevented, but no key event is sent to the app
  */
-function handleKeyboardEvent(event: KeyboardEvent, mod: number) {
+function handleKeyboardEvent(event: KeyboardEvent, mod: number, repeat = false) {
     if (!controls.keyboard) {
         return;
     }
@@ -302,10 +303,14 @@ function handleKeyboardEvent(event: KeyboardEvent, mod: number) {
     }
     const key = keysMap.get(keyCode);
     if (key && key.toLowerCase() !== "ignore") {
-        sendKey(key, mod, RemoteType.WD);
+        if (!repeat) {
+            sendKey(key, mod, RemoteType.WD);
+        }
         event.preventDefault();
     } else if (!["Alt", "Control", "Meta", "Shift", "Tab", "Dead"].includes(event.key)) {
-        sendKey(`lit_${event.key}`, mod, RemoteType.WD);
+        if (!repeat) {
+            sendKey(`lit_${event.key}`, mod, RemoteType.WD);
+        }
         if (event.key === " ") {
             // Prevent Space on Browsers (that cause a PgDown)
             event.preventDefault();


### PR DESCRIPTION
## Problem

Keys consumed by the engine (arrows, `PageUp`/`PageDown`, `Space`) still triggered the browser's default action — scrolling the host page — when the user **pressed and held** them. A single tap behaved correctly.

## Root cause

`keyDownHandler` in `src/api/control.ts` returned early on `event.repeat`, which suppressed `event.preventDefault()` along with `sendKey()`:

```ts
function keyDownHandler(event: KeyboardEvent) {
    if (!event.repeat) {
        handleKeyboardEvent(event, 0);
    }
}
```

So only the first keydown of a press was prevented; every auto-repeat keydown after it reached the browser untouched.

## Fix

Move the repeat check from the dispatch site into the send decision. `handleKeyboardEvent()` takes a `repeat` flag that gates only the two `sendKey()` calls, leaving `preventDefault()` unconditional within its existing branches.

Behavior deliberately preserved:

- Repeats are still **not** forwarded to the app — one key-down per physical press, unchanged `roUniversalControlEvent` timing.
- Keys mapped to `"ignore"` keep falling through to the browser.
- Unmapped literal keys other than `Space` keep their browser default, same narrow scope as #1084 (broadening it would swallow shortcuts like `Ctrl+F`, which the literal branch sees as `event.key === "f"`).

## Testing

`src/api/control.ts` has no automated coverage (there is no `test/api/` suite), so this was verified by inspection of the event path; manual browser check: run `npm start`, shrink the window so the page can scroll, then press and hold each of `ArrowUp`/`ArrowDown`/`ArrowLeft`/`ArrowRight`, `PageUp`/`PageDown` and `Space` — the page must not scroll, and the app registers exactly one key press per hold.

`npm run lint` passes; `src/` is prettier-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)