### PR TITLE
fix(package): resolve locale-relative manifest icon and splash paths

### DIFF
--- a/src/api/package.ts
+++ b/src/api/package.ts
@@ -6,7 +6,7 @@
  *  Licensed under the MIT License. See LICENSE in the repository root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { drawSplashScreen, clearDisplay, drawIconAsSplash } from "./display";
-import { bufferToBase64, parseCSV, SubscribeCallback } from "./util";
+import { bufferToBase64, parseCSV, resolvePackageAsset, stripEncryptedComponentDirs, SubscribeCallback } from "./util";
 import { unzipSync, zipSync, strFromU8, strToU8, Zippable, Unzipped } from "fflate";
 import { addSound, audioCodecs } from "./sound";
 import { addVideo, videoFormats } from "./video";
@@ -219,17 +219,14 @@ function processManifest(content: string): number {
     const iconKey = resKeys.find((key) => manifestMap.has(`mm_icon_focus_${key}`));
     const icon = manifestMap.get(`mm_icon_focus_${iconKey}`);
 
-    let iconFile;
-    if (icon?.slice(0, 5) === "pkg:/") {
-        iconFile = currentZip[icon.slice(5)];
-        if (iconFile) {
-            if (Platform.inBrowser) {
-                bufferToBase64(iconFile).then(function (iconBase64: string) {
-                    notifyAll("icon", iconBase64);
-                });
-            } else {
-                notifyAll("icon", Buffer.from(iconFile).toString("base64"));
-            }
+    const iconFile = resolvePackageAsset(currentZip, icon, deviceData.locale);
+    if (iconFile) {
+        if (Platform.inBrowser) {
+            bufferToBase64(iconFile).then(function (iconBase64: string) {
+                notifyAll("icon", iconBase64);
+            });
+        } else {
+            notifyAll("icon", Buffer.from(iconFile).toString("base64"));
         }
     }
     // Set Launch Time to calculate Splash Time later
@@ -246,11 +243,9 @@ function processManifest(content: string): number {
 function showSplashOrIcon(splash?: string, iconFile?: Uint8Array) {
     if (typeof createImageBitmap !== "undefined") {
         clearDisplay(true);
-        if (splash?.slice(0, 5) === "pkg:/") {
-            const splashFile = currentZip[splash.slice(5)];
-            if (splashFile) {
-                createImageBitmap(new Blob([splashFile as BlobPart])).then(drawSplashScreen);
-            }
+        const splashFile = resolvePackageAsset(currentZip, splash, deviceData.locale);
+        if (splashFile) {
+            createImageBitmap(new Blob([splashFile as BlobPart])).then(drawSplashScreen);
         } else if (iconFile) {
             createImageBitmap(new Blob([iconFile as BlobPart])).then(drawIconAsSplash);
         }
@@ -302,32 +297,6 @@ export function updateAppZip(source: Uint8Array, iv: string, packedFiles: string
     newZip["source/data"] = [source, { level: 0 }];
     newZip["source/var"] = [strToU8(iv), { level: 0 }];
     return zipSync(newZip, { level: 6 });
-}
-
-/**
- * After encrypted component files are stripped, removes the now-empty `components/` directory tree
- * (which would otherwise leak the app's structure), keeping directories that still hold surviving
- * (non-encrypted) assets, plus a single top-level `components/` marker so an encrypted SceneGraph app
- * remains detectable when the package is loaded.
- * @param newZip Zip being assembled.
- * @param stripped Set of lowercase paths folded into the encrypted blob.
- */
-export function stripEncryptedComponentDirs(newZip: Zippable, stripped: Set<string>) {
-    if (![...stripped].some((file) => file.startsWith("components/"))) {
-        return;
-    }
-    const survivors = Object.keys(newZip).filter(
-        (file) => !file.endsWith("/") && file.toLowerCase().startsWith("components/")
-    );
-    for (const key of Object.keys(newZip)) {
-        const lcase = key.toLowerCase();
-        if (key.endsWith("/") && lcase.startsWith("components/") && lcase !== "components/") {
-            if (!survivors.some((file) => file.toLowerCase().startsWith(lcase))) {
-                delete newZip[key];
-            }
-        }
-    }
-    newZip["components/"] ??= new Uint8Array(0);
 }
 
 /**

--- a/src/api/util.ts
+++ b/src/api/util.ts
@@ -7,9 +7,67 @@
  *--------------------------------------------------------------------------------------------*/
 import { BufferType, DataBufferIndex, DataBufferSize, DataType, Platform } from "../core/common";
 import packageInfo from "../../packages/browser/package.json";
+import { Unzipped, Zippable } from "fflate";
 
 // Module callback function definition
 export type SubscribeCallback = (event: string, data?: any) => void;
+
+/**
+ * Resolves a `pkg:/` manifest asset path against a loaded zip, honoring the
+ * `pkg:/locale/images/` convention (Roku maps it to the current locale folder,
+ * falling back to `default`/`en_US`). The FileSystem isn't mounted yet at
+ * manifest-processing time, so this queries the unzipped map directly. Mirrors
+ * the resolution order in RoTextureManager.loadLocalFile.
+ * @param zip The unzipped package map (keyed by package-relative path)
+ * @param pkgPath Manifest path (expected to start with `pkg:/`)
+ * @param locale Current device locale
+ * @returns Resolved file data, or undefined if not found
+ */
+export function resolvePackageAsset(
+    zip: Unzipped,
+    pkgPath: string | undefined,
+    locale: string
+): Uint8Array | undefined {
+    if (pkgPath?.slice(0, 5) !== "pkg:/") {
+        return undefined;
+    }
+    const rel = pkgPath.slice(5);
+    let file = zip[rel];
+    if (!file && rel.startsWith("locale/images/")) {
+        const name = rel.substring("locale/images/".length);
+        file =
+            zip[`locale/${locale}/images/${name}`] ??
+            zip[`locale/default/images/${name}`] ??
+            zip[`locale/en_US/images/${name}`];
+    }
+    return file;
+}
+
+/**
+ * Prunes the now-empty `components/` subtree from a rebuilt encrypted package,
+ * keeping only directories that still hold surviving non-encrypted assets plus a
+ * single top-level `components/` marker (so the browser can still detect a
+ * SceneGraph app whose component XML has been stripped).
+ * @param newZip The rebuilt package being written
+ * @param stripped The set of paths that were removed (folded into the encrypted blob)
+ */
+export function stripEncryptedComponentDirs(newZip: Zippable, stripped: Set<string>) {
+    if (![...stripped].some((file) => file.startsWith("components/"))) {
+        return;
+    }
+    const survivors = Object.keys(newZip).filter(
+        (file) => !file.endsWith("/") && file.toLowerCase().startsWith("components/")
+    );
+    for (const key of Object.keys(newZip)) {
+        const lcase = key.toLowerCase();
+        if (key.endsWith("/") && lcase.startsWith("components/") && lcase !== "components/") {
+            if (!survivors.some((file) => file.toLowerCase().startsWith(lcase))) {
+                delete newZip[key];
+            }
+        }
+    }
+    newZip["components/"] ??= new Uint8Array(0);
+}
 
 /**
  * Gets the path to the API library script.

--- a/src/cli/package.ts
+++ b/src/cli/package.ts
@@ -5,7 +5,13 @@
  *
  *  Licensed under the MIT License. See LICENSE in the repository root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { bufferToBase64, parseCSV, SubscribeCallback } from "../api/util";
+import {
+    bufferToBase64,
+    parseCSV,
+    resolvePackageAsset,
+    stripEncryptedComponentDirs,
+    SubscribeCallback,
+} from "../api/util";
 import { unzipSync, zipSync, strFromU8, strToU8, Zippable, Unzipped } from "fflate";
 import {
     DefaultDeviceInfo,
@@ -177,17 +183,14 @@ function processManifest(content: string): number {
     const iconKey = resKeys.find((key) => manifestMap.has(`mm_icon_focus_${key}`));
     const icon = manifestMap.get(`mm_icon_focus_${iconKey}`);
 
-    let iconFile;
-    if (icon?.slice(0, 5) === "pkg:/") {
-        iconFile = currentZip[icon.slice(5)];
-        if (iconFile) {
-            if (Platform.inBrowser) {
-                bufferToBase64(iconFile).then(function (iconBase64: string) {
-                    notifyAll("icon", iconBase64);
-                });
-            } else {
-                notifyAll("icon", Buffer.from(iconFile).toString("base64"));
-            }
+    const iconFile = resolvePackageAsset(currentZip, icon, deviceData.locale);
+    if (iconFile) {
+        if (Platform.inBrowser) {
+            bufferToBase64(iconFile).then(function (iconBase64: string) {
+                notifyAll("icon", iconBase64);
+            });
+        } else {
+            notifyAll("icon", Buffer.from(iconFile).toString("base64"));
         }
     }
     // Set Launch Time to calculate Splash Time later
@@ -233,32 +236,6 @@ export function updateAppZip(source: Uint8Array, iv: string, packedFiles: string
     newZip["source/data"] = [source, { level: 0 }];
     newZip["source/var"] = [strToU8(iv), { level: 0 }];
     return zipSync(newZip, { level: 6 });
-}
-
-/**
- * After encrypted component files are stripped, removes the now-empty `components/` directory tree
- * (which would otherwise leak the app's structure), keeping directories that still hold surviving
- * (non-encrypted) assets, plus a single top-level `components/` marker so an encrypted SceneGraph app
- * remains detectable when the package is loaded.
- * @param newZip Zip being assembled.
- * @param stripped Set of lowercase paths folded into the encrypted blob.
- */
-function stripEncryptedComponentDirs(newZip: Zippable, stripped: Set<string>) {
-    if (![...stripped].some((file) => file.startsWith("components/"))) {
-        return;
-    }
-    const survivors = Object.keys(newZip).filter(
-        (file) => !file.endsWith("/") && file.toLowerCase().startsWith("components/")
-    );
-    for (const key of Object.keys(newZip)) {
-        const lcase = key.toLowerCase();
-        if (key.endsWith("/") && lcase.startsWith("components/") && lcase !== "components/") {
-            if (!survivors.some((file) => file.toLowerCase().startsWith(lcase))) {
-                delete newZip[key];
-            }
-        }
-    }
-    newZip["components/"] ??= new Uint8Array(0);
 }
 
 /**


### PR DESCRIPTION
## Problem

The app icon was not being returned by the engine for apps whose `manifest` declares the icon with a **locale-relative** path, e.g.:

```
mm_icon_focus_hd=pkg:/locale/images/channel-icon-hd-290x218.png
mm_icon_focus_sd=pkg:/locale/images/channel-icon-sd-246x140.png
```

Roku resolves `pkg:/locale/images/<file>` to the current locale folder (falling back to `default`/`en_US`). The package zip contains no literal `locale/images/` entry — only `locale/default/images/…`, `locale/es_ES/images/…`, etc. But `processManifest` did a raw `currentZip[path]` lookup with **no locale resolution**, so the packaged icon was never found and no `icon` event (nor icon-as-splash) was emitted.

The FHD→HD→SD selection/fallback itself was working correctly (the array `["hd","fhd"]` prefers HD, with FHD as fallback) and is **unchanged**. The failure was purely in the zip lookup.

## Fix

- Add locale-aware resolution mirroring `RoTextureManager.loadLocalFile` (current locale → `default` → `en_US`), applied to both the **icon** and **splash** lookups, in the browser API (`src/api/package.ts`) and the CLI (`src/cli/package.ts`).
- **Deduplicate while here:** move the now-shared `resolvePackageAsset` helper and the already-identical `stripEncryptedComponentDirs` into `src/api/util.ts` (the canonical shared util module both layers already import from), removing the duplicated copies in both `package.ts` files.

## Verification

- Simulated against a real affected package: the old raw lookup returned `undefined` (the bug); the new resolver returns the correct icon bytes, falling through to `locale/default/images/…` for an unlisted locale and picking the locale-specific icon (`es_ES`) when present. Plain non-locale `pkg:/` icon paths still resolve unchanged via the first lookup.
- `npm run lint` and `npm run prettier:write` pass.
- All three packages build (`build:api`, `build:cli`, `build:sg`).
- All 54 `test/cli/cli.test.js` tests pass, including the `.bpk` encryption suite that exercises the relocated `stripEncryptedComponentDirs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)