### PR TITLE
fix(rsg): correct mid-render boundingRect() measurement of composite nodes

### DIFF
--- a/src/extensions/scenegraph/nodes/LayoutGroup.ts
+++ b/src/extensions/scenegraph/nodes/LayoutGroup.ts
@@ -123,18 +123,33 @@ export class LayoutGroup extends Group {
 
         const addAfter = this.shouldAddSpacingAfterChild();
 
-        this.metricsUsedThisPass = undefined;
-        if (layoutChildren.length && this.layoutDirty) {
-            this.measureUnsizedChildren(layoutChildren, interpreter);
-            this.metricsUsedThisPass = new WeakMap<Node, LayoutMetrics>();
-            this.applyLayout(layoutChildren, direction, spacings, addAfter, this.metricsUsedThisPass);
-            this.layoutDirty = false;
-        }
+        // On a measurement pass (no draw target — getBoundingRect's full-tree refresh and its
+        // single-subtree fallback both render with draw2D undefined), converge the layout in this one
+        // pass instead of deferring to the next frame. When a child's settled size differs from what
+        // applyLayout used (a wrapped Label laid out at a shorter height then rendered taller shifts
+        // its siblings), synchronizeChildMetrics re-dirties the layout; a one-shot boundingRect() query
+        // would otherwise read the pre-convergence size. A real frame draw (draw2D present) keeps
+        // maxPasses = 1, preserving its next-frame correction. Capped at 2 to terminate.
+        const maxPasses = draw2D === undefined && layoutChildren.length ? 2 : 1;
+        for (let pass = 0; pass < maxPasses; pass++) {
+            this.metricsUsedThisPass = undefined;
+            if (layoutChildren.length && this.layoutDirty) {
+                this.measureUnsizedChildren(layoutChildren, interpreter);
+                this.metricsUsedThisPass = new WeakMap<Node, LayoutMetrics>();
+                this.applyLayout(layoutChildren, direction, spacings, addAfter, this.metricsUsedThisPass);
+                this.layoutDirty = false;
+            }
 
-        super.renderNode(interpreter, origin, angle, opacity, draw2D);
+            super.renderNode(interpreter, origin, angle, opacity, draw2D);
 
-        if (layoutChildren.length) {
-            this.synchronizeChildMetrics(layoutChildren, direction);
+            if (layoutChildren.length) {
+                this.synchronizeChildMetrics(layoutChildren, direction);
+            }
+
+            // Stop once the layout settled (or on a live frame's single pass).
+            if (!this.layoutDirty) {
+                break;
+            }
         }
     }
 

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -985,12 +985,10 @@ export class Node extends RoSGNode implements BrsValue {
      * @returns Bounding rectangle in the requested coordinate space.
      */
     getBoundingRect(type: string, interpreter?: Interpreter): Rect {
-        // A bounding-rect query refreshes layout by rendering the whole tree from the root. When
-        // this is called from BrightScript that itself runs *during* a render (an observer or a
-        // freshly created item component's init() calling localBoundingRect/boundingRect), the
-        // re-render would re-enter rendering and recurse until the stack overflows (e.g. JellyRock
-        // RowList items measuring labels). Skip the refresh while a render is in progress and return
-        // the rects already computed by the active pass.
+        // A bounding-rect query refreshes layout by rendering the tree, then returns a cached rect.
+        // When called from BrightScript that runs *during* a render (an observer or a freshly created
+        // item component's init() measuring a Label), a full refresh would re-enter rendering and
+        // overflow the stack, so it is skipped while a render is in progress.
         if (interpreter && !sgRoot.rendering) {
             this.refreshLayoutFromRoot(interpreter);
         } else if (
@@ -999,24 +997,34 @@ export class Node extends RoSGNode implements BrsValue {
             !sgRoot.measuring &&
             (this.rectLocal.width <= 0 || this.rectLocal.height <= 0)
         ) {
-            // A query raised *during* an active render, on a node this pass has not fully laid out
-            // yet (its local rect is degenerate in either dimension) — most commonly a freshly-created
-            // ArrayGrid item component measuring its own content synchronously (e.g. a button sizing
-            // its background from `elementsGroup.boundingRect().width`) before the pass reaches it.
-            // Either dimension being zero signals "not measured": a text label first measured while
-            // its text was still empty caches width 0 but a non-zero (text-independent) line height,
-            // so requiring BOTH to be zero would skip the refresh and return a stale zero width. A
-            // full-tree refresh from the scene root is unavailable here (it would re-enter the owning
-            // grid's item creation and recurse), so instead render only THIS node's own subtree to
-            // populate its rects. The grid is an ancestor, so a local pass cannot re-enter item
-            // creation. `.width`/`.height` are translation-invariant, so measuring at origin [0,0]
-            // yields the correct size; the true toScene/toParent origin is recomputed when the pass
-            // reaches this node. `measuring` bounds nested queries.
+            // Mid-render query on a node this pass hasn't laid out yet (its local rect is degenerate).
+            // A full refresh is unavailable (it would re-enter the owning grid's item creation and
+            // recurse), so render just this node's own subtree to populate its rects. Either dimension
+            // zero signals "not measured" — a label first measured with empty text caches width 0 but
+            // a non-zero line height, so requiring both zero would skip the refresh and return a stale
+            // width. Measuring at origin [0,0] is fine: width/height are translation-invariant and the
+            // true origin is recomputed when the pass reaches the node. `measuring` bounds nested queries.
+            //
+            // The subtree render's updateParentRects would union this child into its parent's cached
+            // bounds, but the parent hasn't been laid out this pass — unioning one child pollutes it
+            // with a partial rect (e.g. a button measured from its content group before its larger
+            // background sibling renders), making a later query on the parent skip its own fallback and
+            // return the too-small rect. Snapshot/restore the parent's rects so it stays degenerate and
+            // re-measures its full subtree when queried.
+            const parent = this.parent instanceof Node ? this.parent : undefined;
+            const savedLocal = parent ? { ...parent.rectLocal } : undefined;
+            const savedToParent = parent ? { ...parent.rectToParent } : undefined;
+            const savedToScene = parent ? { ...parent.rectToScene } : undefined;
             sgRoot.measuring = true;
             try {
                 this.renderNode(interpreter, [0, 0], 0, 1);
             } finally {
                 sgRoot.measuring = false;
+                if (parent && savedLocal && savedToParent && savedToScene) {
+                    parent.rectLocal = savedLocal;
+                    parent.rectToParent = savedToParent;
+                    parent.rectToScene = savedToScene;
+                }
             }
         }
         switch (type) {

--- a/test/extensions/scenegraph/MidRenderParentMeasure.test.js
+++ b/test/extensions/scenegraph/MidRenderParentMeasure.test.js
@@ -1,0 +1,192 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsDevice, BrsBoolean, BrsString, Float, Int32, RoArray, Interpreter } = core;
+
+/**
+ * Regression: a mid-render boundingRect() query on a not-yet-laid-out node renders only that node's
+ * own subtree to measure it (getBoundingRect's single-subtree fallback, used while sgRoot.rendering
+ * is true). That subtree render ends in updateParentRects, which unions the measured node into its
+ * PARENT's cached bounds. But the parent has not been laid out this pass, so unioning only this one
+ * child leaves the parent with a partial rect built from a single child.
+ *
+ * The real-world shape: a fit-to-content button (a Group) holds a content LayoutGroup plus a
+ * separate, larger background sibling. The button sizes its background from
+ * elementsGroup.boundingRect() during its own itemContent observer (mid-render). Later the item's
+ * container measures the button itself to position it. If the first measurement polluted the button's
+ * rectLocal with just the content group's size, the button's own query saw a non-degenerate rect,
+ * skipped its fallback, and returned the too-small content size — so the button was positioned as if
+ * it were only as big as its text (mis-aligned, and too short), correcting only on a later re-display.
+ * On a real device the button measures its full size (background included) on the first render.
+ *
+ * The fix snapshots and restores the immediate parent's rects around the measurement so measuring a
+ * child never corrupts the parent's cached bounds.
+ */
+describe("mid-render measurement does not pollute the parent's bounds", () => {
+    let interpreter;
+
+    beforeAll(() => {
+        // Label font-typed defaults need the common: fonts; mount once.
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+    });
+
+    afterEach(() => {
+        sgRoot.rendering = false;
+        sgRoot.setFocused();
+    });
+
+    function vector(values) {
+        return new RoArray(values.map((v) => new Float(v)));
+    }
+
+    /**
+     * Scene > button(Group) > [ background(Rectangle 516x105), elementsGroup(horiz LayoutGroup >
+     * Label) ]. Mirrors a fit-to-content button whose visible size is its background, not its text.
+     */
+    function buildButton() {
+        const scene = SGNodeFactory.createNode("Scene");
+        const button = SGNodeFactory.createNode("Group");
+        const background = SGNodeFactory.createNode("Rectangle");
+        background.setValue("width", new Float(516));
+        background.setValue("height", new Float(105));
+        const elementsGroup = SGNodeFactory.createNode("LayoutGroup");
+        elementsGroup.setValue("layoutDirection", new BrsString("horiz"));
+        const label = SGNodeFactory.createNode("Label");
+        label.setValue("text", new BrsString("Sign Up to Save Progress"));
+        elementsGroup.appendChildToParent(label);
+        button.appendChildToParent(background);
+        button.appendChildToParent(elementsGroup);
+        scene.appendChildToParent(button);
+        return { scene, button, background, elementsGroup, label };
+    }
+
+    test("measuring the content group mid-render then the button returns the button's full size", () => {
+        const { button, elementsGroup } = buildButton();
+
+        // Mirror the on-device order: while a render is active, the button sizes its background from
+        // its content group first, then the container measures the button to position it.
+        sgRoot.rendering = true;
+        const contentRect = elementsGroup.getBoundingRect("toParent", interpreter);
+        const buttonRect = button.getBoundingRect("toParent", interpreter);
+        sgRoot.rendering = false;
+
+        // The content group is just the text (narrower and shorter than the background).
+        expect(contentRect.width).toBeGreaterThan(0);
+        expect(contentRect.height).toBeLessThan(105);
+        // The button spans its full background, not the collapsed content size.
+        expect(buttonRect.width).toBe(516);
+        expect(buttonRect.height).toBe(105);
+    });
+
+    test("measuring a child leaves the parent's cached rect untouched (still degenerate)", () => {
+        const { button, elementsGroup } = buildButton();
+
+        sgRoot.rendering = true;
+        elementsGroup.getBoundingRect("toParent", interpreter);
+        // The button was NOT queried, so its cached local rect must remain degenerate — measuring the
+        // child alone must not have unioned a partial size into it.
+        expect(button.rectLocal.width <= 0 || button.rectLocal.height <= 0).toBe(true);
+        sgRoot.rendering = false;
+    });
+});
+
+/**
+ * Regression: a mid-render boundingRect() query on a vertical LayoutGroup must return the CONVERGED
+ * stacked height, not a pre-convergence one. A LayoutGroup positions each child below the previous
+ * using the previous child's measured size; if a wrapped Label was first measured at a shorter (e.g.
+ * single-line) height and only later renders at its true multi-line height, every sibling below it
+ * shifts. On a live frame synchronizeChildMetrics catches this and corrects on the next frame, but a
+ * mid-render boundingRect() query is one-shot — an app centering the group from that height bakes in
+ * the pre-convergence value and the block sits too high until a later re-display. The fix re-runs the
+ * layout within the measurement pass (bounded) so the stack settles before the query reads it.
+ */
+describe("mid-render measurement converges a vertical LayoutGroup's stacked height", () => {
+    let interpreter;
+
+    beforeAll(() => {
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+    });
+
+    afterEach(() => {
+        sgRoot.rendering = false;
+        sgRoot.setFocused();
+    });
+
+    function vector(values) {
+        return new RoArray(values.map((v) => new Float(v)));
+    }
+
+    /** Scene > vert LayoutGroup(spacing 15) > two wrapped labels. Returns the true (rendered) heights. */
+    function buildStack() {
+        const scene = SGNodeFactory.createNode("Scene");
+        const group = SGNodeFactory.createNode("LayoutGroup");
+        group.setValue("layoutDirection", new BrsString("vert"));
+        group.setValue("itemSpacings", vector([15]));
+        const title = SGNodeFactory.createNode("Label");
+        title.setValue("width", new Float(633));
+        title.setValue("wrap", BrsBoolean.True);
+        title.setValue("maxLines", new Int32(2));
+        title.setValue("text", new BrsString("Sign Up to Save Your Progress and more words to force two lines"));
+        const description = SGNodeFactory.createNode("Label");
+        description.setValue("width", new Float(633));
+        description.setValue("wrap", BrsBoolean.True);
+        description.setValue("maxLines", new Int32(3));
+        description.setValue("text", new BrsString("Pick up right where you left off."));
+        group.appendChildToParent(title);
+        group.appendChildToParent(description);
+        scene.appendChildToParent(group);
+        const trueTitleHeight = title.rectLocal.height;
+        const descriptionHeight = description.rectLocal.height;
+        return { group, title, description, trueTitleHeight, descriptionHeight };
+    }
+
+    // The genuine trigger (a label whose first measurement precedes its true wrapped height) is
+    // browser-async-font-specific: Node's node-canvas measures synchronously, so a label always
+    // reports its true height by layout time here and the bug cannot occur naturally. Seed a stale
+    // single-line title rect to stand in for that mid-flight state; without convergence the group
+    // stacks the description against the stale height and reports a too-short total.
+    function seedStaleTitleRect(title) {
+        const stale = { x: 0, y: 0, width: 633, height: 20 };
+        title.rectLocal = { ...stale };
+        title.rectToParent = { ...stale };
+        title.rectToScene = { ...stale };
+    }
+
+    test("mid-render fallback stacks the second label below the first's true height, not a stale one", () => {
+        const { group, title, description, trueTitleHeight, descriptionHeight } = buildStack();
+        seedStaleTitleRect(title);
+
+        // Query raised during an active render → getBoundingRect's single-subtree fallback.
+        sgRoot.rendering = true;
+        const rect = group.getBoundingRect("toParent", interpreter);
+        sgRoot.rendering = false;
+
+        expect(description.getValueJS("translation")[1]).toBeCloseTo(trueTitleHeight + 15, 1);
+        expect(rect.height).toBeCloseTo(trueTitleHeight + 15 + descriptionHeight, 1);
+    });
+
+    test("full-tree refresh (query outside a render) also converges the stacked height", () => {
+        const { group, title, description, trueTitleHeight, descriptionHeight } = buildStack();
+        seedStaleTitleRect(title);
+
+        // rendering is false → getBoundingRect takes the refreshLayoutFromRoot path, which also renders
+        // with no draw target, so the same convergence must apply.
+        const rect = group.getBoundingRect("toParent", interpreter);
+
+        expect(description.getValueJS("translation")[1]).toBeCloseTo(trueTitleHeight + 15, 1);
+        expect(rect.height).toBeCloseTo(trueTitleHeight + 15 + descriptionHeight, 1);
+    });
+});


### PR DESCRIPTION
## Problem

A custom SceneGraph component used as a RowList item positions its children by reading `boundingRect()` on composite sub-nodes in a one-shot handler. On the **first** render its button and left-hand text block were mis-positioned; navigating away and back rendered them correctly. Diagnosed by comparing instrumented logs from a real Roku against the simulator.

Two distinct engine defects, both in the mid-render measurement path:

### 1. A measured child polluted its parent's cached bounds

`Node.getBoundingRect`'s single-subtree measurement fallback ends in `updateParentRects`, which unions the measured node into its parent's cached bounds. But the parent hasn't been laid out this pass, so unioning a single child left the parent with a partial rect — e.g. a fit-to-content button measured from its content group *before* its larger background sibling rendered came out 434×40 instead of 516×105. A later query on the parent then saw a non-degenerate rect, skipped its own fallback, and returned the too-small size, so the button landed too far right and too high.

**Fix:** snapshot and restore the immediate parent's three rects around the measurement, so measuring a child never corrupts the parent — it stays degenerate and re-measures its full subtree when queried.

### 2. A vertical LayoutGroup returned a pre-convergence stacked height

A `LayoutGroup` stacks each child below the previous using the previous child's measured size. When a wrapped `Label` was first measured at a shorter (e.g. single-line) height and only later rendered at its true multi-line height, every sibling below it shifted. On a live frame `synchronizeChildMetrics` catches this and corrects on the **next** frame — but a one-shot `boundingRect()` query never runs that frame, so it read the pre-convergence height and the text block sat too high.

**Fix:** on a measurement pass, converge the layout within the same pass (bounded to 2 iterations). Gated on `draw2D === undefined`, which covers **both** `getBoundingRect`'s full-tree refresh and its single-subtree fallback, while a real frame draw keeps its next-frame correction. Skipped for childless groups to avoid a redundant second render.

## Testing

- New regression suite `test/extensions/scenegraph/MidRenderParentMeasure.test.js` (4 tests) covering parent-bound pollution (both the button-full-size and parent-stays-degenerate cases) and LayoutGroup convergence on both the mid-render-fallback and full-tree-refresh paths. Each was confirmed to fail without its fix.
- Full SceneGraph suite: 495/495 pass.
- Full CLI suite: 56/56 pass, including the re-entrant bounding-rect guard, grid/button measurement, PanelSet, and RowList focus-band regression apps.
- Verified end-to-end in the desktop app against a real Roku for parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)