### PR TITLE
fix(rsg): stop findNode searching a node that has no component ancestor

### DIFF
--- a/src/extensions/scenegraph/components/RoSGNode.ts
+++ b/src/extensions/scenegraph/components/RoSGNode.ts
@@ -1752,6 +1752,37 @@ export abstract class RoSGNode extends BrsComponent implements BrsValue, ISGNode
     }
 
     /**
+     * Whether anything above this node (or the node itself) roots a findNode search space.
+     *
+     * `ifSGNodeDict` scopes findNode to the descendants of the subject's *nearest component
+     * ancestor*, so a node with none — a plain node built with CreateObject and never attached —
+     * has no tree of its own to search, however many children it has. Device-confirmed: a detached
+     * `Node` holding ten `ContentNode` children returns `invalid` for its own child's id.
+     *
+     * The Scene counts as a component root, which is what keeps the global node searchable: its
+     * parent is the Scene, so the Scene's subtree is its search space.
+     * @returns True when a component ancestor exists.
+     */
+    private hasComponentAncestor(): boolean {
+        // Widened so the identity check type-checks against the polymorphic `this`.
+        const scene: RoSGNode | undefined = sgRoot.scene;
+        const rootsComponent = (node: RoSGNode) =>
+            node === scene || sgRoot.nodeDefMap.has(node.nodeSubtype.toLowerCase());
+
+        if (rootsComponent(this)) {
+            return true;
+        }
+        let ancestor: RoSGNode | BrsInvalid = this.getNodeParent();
+        while (ancestor instanceof RoSGNode) {
+            if (rootsComponent(ancestor)) {
+                return true;
+            }
+            ancestor = ancestor.getNodeParent();
+        }
+        return false;
+    }
+
+    /**
      * Resolves a findNode miss against the component scope the subject node belongs to.
      *
      * A device does not rely on the parent chain alone: a node created inside a component's script
@@ -1805,6 +1836,13 @@ export abstract class RoSGNode extends BrsComponent implements BrsValue, ISGNode
                 // node appended to m.global via m.global.findNode(). Skipping the self-search keeps
                 // that boundary — every other node's subtree is part of its ancestor's anyway, so
                 // searching it first is only a shortcut.
+                if (!this.hasComponentAncestor()) {
+                    // Nothing roots a search space above this node, so its own tree is not one
+                    // either — a device returns invalid for `detachedNode.findNode(<its own child>)`.
+                    // `findRootNode()` would just hand back the subject, so skip both walks and let
+                    // only the executing component's scope apply.
+                    return this.findInComponentScope(interpreter, id);
+                }
                 // Widened to RoSGNode so the comparison type-checks: `sgRoot.mGlobal` is a `Global`,
                 // which TypeScript sees as having no overlap with the polymorphic `this`.
                 const globalNode: RoSGNode = sgRoot.mGlobal;

--- a/test/extensions/scenegraph/ComponentScopeFindNode.test.js
+++ b/test/extensions/scenegraph/ComponentScopeFindNode.test.js
@@ -61,6 +61,44 @@ describe("findNode falls back to the executing component's scope", () => {
         expect(isInvalid(callFindNode(attached, "HomeScreen", scene))).toBe(true);
     });
 
+    test("a detached node does not search its own subtree", () => {
+        const { scene } = sceneWithScreen();
+        // Device-confirmed: a plain node built with CreateObject and never attached has no
+        // component ancestor, so its own children are not a search space however many it has.
+        const detachedRoot = new Node([], "Node");
+        const child = new Node([], "ContentNode");
+        child.setValue("id", new BrsString("Item7"), false);
+        detachedRoot.appendChildToParent(child);
+
+        expect(isInvalid(callFindNode(detachedRoot, "Item7", scene))).toBe(true);
+    });
+
+    test("an attached node still reaches its own subtree through its component ancestor", () => {
+        const { scene } = sceneWithScreen();
+        const group = new Node([], "Group");
+        const child = new Node([], "ContentNode");
+        child.setValue("id", new BrsString("Item7"), false);
+        group.appendChildToParent(child);
+        scene.appendChildToParent(group);
+
+        expect(callFindNode(group, "Item7", scene)).toBe(child);
+    });
+
+    test("a detached custom component root searches its own subtree — it is its own scope", () => {
+        const { scene } = sceneWithScreen();
+        const def = new ComponentDefinition("pkg:/components/DetachedHelper.xml");
+        def.name = "DetachedHelper";
+        def.xmlNode = { attr: { name: "DetachedHelper", extends: "Group" } };
+        sgRoot.setNodeDefMap(new Map([["detachedhelper", def]]));
+
+        const helper = new Node([], "DetachedHelper");
+        const child = new Node([], "ContentNode");
+        child.setValue("id", new BrsString("Inner"), false);
+        helper.appendChildToParent(child);
+
+        expect(callFindNode(helper, "Inner", scene)).toBe(child);
+    });
+
     test("without an executing component there is no scope to fall back to", () => {
         const { scene } = sceneWithScreen();
         const detached = new Node([], "Group");


### PR DESCRIPTION
## Root cause

`ifSGNodeDict` scopes `findNode` to the descendants of the subject's **nearest component ancestor**. A plain node built with `CreateObject` and never attached has none, so its own children are not a search space — however many it has.

Found by the rendezvous conformance app (`out/rendezvous-test/`) run on real hardware:

| probe | device | before | after |
| --- | --- | --- | --- |
| detached `Node` with 10 children → `findNode("Item7")` | `invalid` | `ContentNode#Item7` | `invalid` |

Both existing steps were wrong for that case: the self-search walks the subject's subtree directly, and `findRootNode()` simply hands the subject back when it has no parent. So removing only the self-search would not have been enough.

## Fix

When nothing above the node (or the node itself) roots a component, skip both walks and let only the executing component's scope apply — the mechanism added in #1097.

The Scene counts as a component root, which is what keeps the global node searchable: its parent is the Scene (#1095), so the Scene's subtree is its search space.

## ⚠️ This is a narrowing

Cases that used to return a node now return `invalid`. That direction matters: an app relying on `detachedNode.findNode(...)` **worked here and would fail on hardware**, so the previous behavior hid app bugs rather than causing simulator failures. Same risk profile as #1096.

Unchanged, and re-verified against the device baselines:

- an **attached** node still reaches its own subtree through its component ancestor
- a **detached custom component root** still searches its own subtree — it is its own scope
- all 16 probes of the `findNode` conformance app still match the device, including `m.global.findNode(...)`, the detached-plain-node component-scope fallback, and every negative control
- the rest of the rendezvous app is unaffected

## Tests

`ComponentScopeFindNode.test.js` — three new cases: a detached node does not search its own subtree, an attached node still does through its ancestor, and a detached custom component root remains its own scope.

Verified with a clean `npm run clean && npm run build` (0 TypeScript errors). Full suite green (2243), lint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)