### PR TITLE
fix(rsg): don't crash when a Task sets a node-valued field to invalid

### DIFF
--- a/src/extensions/scenegraph/nodes/Task.ts
+++ b/src/extensions/scenegraph/nodes/Task.ts
@@ -775,7 +775,10 @@ export class Task extends Node {
     private handleSetFieldRequest(node: Node, update: ThreadUpdate) {
         const oldValue = node.getValue(update.key);
         let value: BrsType;
-        if (!this.inThread && oldValue instanceof Node && oldValue.getAddress() === update.value._address_) {
+        // `update.value` is null when the other thread set the field to `invalid` (jsValueOf maps it
+        // to null), which is a legitimate way to clear a node-valued field — reading `_address_` off
+        // it threw and killed the whole task-update pass.
+        if (!this.inThread && oldValue instanceof Node && oldValue.getAddress() === update.value?._address_) {
             // Update existing node to preserve references
             value = updateSGNode(update.value, oldValue);
         } else {

--- a/test/cli/cli.test.js
+++ b/test/cli/cli.test.js
@@ -984,6 +984,23 @@ describe.concurrent("cli", () => {
         expect(lines).toContain("------ Finished 'main.brs' execution [EXIT_USER_NAV] ------");
     }, 30000);
 
+    it("Clears a node-valued field set to invalid from a Task thread", async () => {
+        let command = ["node", brsCliPath, "-r task-clear-node-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        // Setting a node-valued field to `invalid` from a task sends an update whose value is null.
+        // The render side read `_address_` off it to decide whether to reconcile against the node it
+        // already held, which threw and aborted the whole task-update pass — the task's later writes
+        // never landed and the app hung waiting for them.
+        const lines = stdout.split("\n").map((line) => line.trimEnd());
+        expect(lines).toContain("PAYLOAD: Payload");
+        expect(lines).toContain("PAYLOAD: invalid");
+        expect(lines).toContain("FINISHED: task completed");
+        expect(lines).toContain("=== Task Clear Node Repro Complete ===");
+    }, 30000);
+
     it("Resolves an anonymous function observer registered by its toStr() name", async () => {
         let command = ["node", brsCliPath, "-r anon-observer-app", "source/main.brs", "-c 0"].join(" ");
 

--- a/test/cli/resources/task-clear-node-app/components/ClearingTask.xml
+++ b/test/cli/resources/task-clear-node-app/components/ClearingTask.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="ClearingTask" extends="Task">
+    <interface>
+        <field id="payload" type="node" />
+        <field id="finished" type="boolean" value="false" />
+    </interface>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.top.functionName = "runTask"
+    end sub
+
+    sub runTask()
+        ' Hand a node to the render thread, then clear it. The render side still holds the
+        ' node while the incoming update carries a null value for that node-valued field.
+        node = createObject("roSGNode", "ContentNode")
+        node.id = "Payload"
+        m.top.payload = node
+        m.top.payload = invalid
+        m.top.finished = true
+    end sub
+    ]]></script>
+</component>

--- a/test/cli/resources/task-clear-node-app/components/MainScene.xml
+++ b/test/cli/resources/task-clear-node-app/components/MainScene.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="MainScene" extends="Scene">
+    <interface>
+        <field id="done" type="boolean" value="false" />
+    </interface>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.task = createObject("roSGNode", "ClearingTask")
+        m.task.observeField("payload", "onPayload")
+        m.task.observeField("finished", "onFinished")
+        m.task.control = "run"
+    end sub
+
+    sub onPayload(event as object)
+        node = event.getData()
+        if node = invalid
+            print "PAYLOAD: invalid"
+        else
+            print "PAYLOAD: "; node.id
+        end if
+    end sub
+
+    sub onFinished(event as object)
+        print "FINISHED: task completed"
+        m.top.done = true
+    end sub
+    ]]></script>
+</component>

--- a/test/cli/resources/task-clear-node-app/manifest
+++ b/test/cli/resources/task-clear-node-app/manifest
@@ -1,0 +1,4 @@
+title=Task Thread Repro
+major_version=1
+minor_version=0
+build_version=1

--- a/test/cli/resources/task-clear-node-app/source/main.brs
+++ b/test/cli/resources/task-clear-node-app/source/main.brs
@@ -1,0 +1,13 @@
+sub Main()
+    print "=== Task Clear Node Repro ==="
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+    scene = screen.CreateScene("MainScene")
+    screen.show()
+    for i = 0 to 250
+        msg = wait(20, port)
+        if scene.done then exit for
+    end for
+    print "=== Task Clear Node Repro Complete ==="
+end sub


### PR DESCRIPTION
## Root cause

Clearing a node-valued field from a task — `m.top.payload = invalid` — sends a thread update whose value is `null` (`jsValueOf` maps `invalid` to `null`). The render side reads `_address_` off that value to decide whether to reconcile against the node it already holds:

```ts
if (!this.inThread && oldValue instanceof Node && oldValue.getAddress() === update.value._address_) {
```

When the field currently holds a node and the incoming value is `null`, that throws:

```
[sg] Error processing task YBPluginRokuVideo (thread 7): Cannot read properties of null (reading '_address_')
TypeError: Cannot read properties of null (reading '_address_')
    at Task.handleSetFieldRequest
    at Task.processThreadUpdate
    at SGRoot.processTasks
```

The throw escapes `processThreadUpdate` and aborts the **whole task-update pass**, so the task's later writes never land and an app waiting on them hangs. Clearing a reference this way is ordinary — analytics and player plugins do it on teardown.

## Fix

Guard the address comparison. A null value falls through to `brsValueOf`, which yields `invalid` and clears the field as intended.

## Pre-existing

Present since the rendezvous thread-update implementation (#856, Feb 2026) — reproduced on clean `master`, unrelated to the recent SceneGraph work. It is the only unguarded `update.value` access in the file.

## Tests

New `task-clear-node-app` + a `cli.test.js` case: a task hands a node to the render thread, then clears it. Asserts the observer sees the node, then `invalid`, then that the task still reaches completion.

Confirmed the test catches the regression — reverting the one-character guard makes it fail with the original `TypeError`.

## Verification

Clean `npm run clean && npm run build` (0 TypeScript errors), lint and prettier clean.

Full suite: 2239 passed, **2 failed** — both `ECP query/r2d2-bitmaps`, caused by another process holding port 8060 on the test machine (`lsof` shows Electron). Unrelated to this change; they pass when that port is free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)