### PR TITLE
feat(cli): notify the user when a new brs-node version is published

### DIFF
--- a/docs/run-as-cli.md
+++ b/docs/run-as-cli.md
@@ -19,6 +19,17 @@ You have two options to install the CLI application:
     $ npm link
     ```
 
+## Keeping the CLI Up to Date
+
+When running on an interactive terminal, the CLI checks the npm registry (at most once a day, in background) for a newer release of `brs-node`, and shows a notice with the command to upgrade the installation it detected (global, local or `npx`):
+
+```console
+Update available: 2.3.0 -> 2.4.0
+Run npm install -g brs-node@latest to update.
+```
+
+The check never delays the startup nor the exit: the notice is displayed from the previously cached result, while the registry request runs in background and is dropped if the app finishes first. To disable it, set either the `BRS_NO_UPDATE_CHECK` or the `NO_UPDATE_NOTIFIER` environment variable; it is also skipped when the output is redirected (not a terminal) or when `CI` is set.
+
 ## Usage
 
 Once installed, you can execute the `brs-cli` command, which operates as a REPL, runs source files or creates encrypted app packages.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -32,6 +32,7 @@ import {
     closeLogFile,
 } from "./display";
 import { startKeyboardControl, stopKeyboardControl, handleDebuggerCommand } from "./keyboard";
+import { startUpdateCheck, printUpdateNotice } from "./update";
 import { isNumber } from "../api/util";
 import {
     DebugPrompt,
@@ -109,6 +110,9 @@ program
         if (!checkParameters()) {
             return;
         }
+        // Reads the cached npm registry result (and refreshes it in background when stale),
+        // so `printUpdateNotice()` can report a new release without adding startup latency.
+        startUpdateCheck();
         if (typeof deviceData === "object") {
             // Custom feature that apps can inspect using `roDeviceInfo.hasFeature()` and change behavior when ran under CLI
             deviceData.customFeatures.push("platform_cli");
@@ -315,6 +319,7 @@ function displayTitle() {
     /// #else
     console.log(`\n${appTitle} [${chalk.cyanBright(appVersion)}]\n`);
     /// #endif
+    printUpdateNotice();
 }
 
 /**
@@ -323,6 +328,9 @@ function displayTitle() {
  * @param payload - The application payload containing code, device info, and options
  */
 async function runApp(payload: AppPayload) {
+    // Covers the paths that don't display the title (`.brs` files and `--root` apps); it
+    // only prints once per process, and always before the frame output takes the terminal.
+    printUpdateNotice();
     payload.password = program.pack;
     if (program.ecp && !workerReady) {
         // Load ECP service as Worker
@@ -399,6 +407,9 @@ async function runApp(payload: AppPayload) {
             process.exitCode = 1;
             console.log(chalk.redBright(msg));
         }
+        // On a first run the registry response usually arrives while the app is running,
+        // so report it here (no-op when the notice was already displayed at startup).
+        printUpdateNotice();
     } catch (err: any) {
         console.error(chalk.red(`Error executing app: ${err.message}`));
         process.exitCode = 1;

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -1,0 +1,211 @@
+/*---------------------------------------------------------------------------------------------
+ *  BrightScript Engine (https://github.com/lvcabral/brs-engine)
+ *
+ *  Copyright (c) 2019-2026 Marcelo Lv Cabral. All Rights Reserved.
+ *
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import fs from "node:fs";
+import path from "node:path";
+import https from "node:https";
+import chalk from "chalk";
+import envPaths from "env-paths";
+import packageInfo from "../../packages/node/package.json";
+
+const REGISTRY_HOST = "registry.npmjs.org";
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // Query the registry at most once a day
+const REQUEST_TIMEOUT_MS = 5000;
+const MAX_RESPONSE_BYTES = 1024 * 1024;
+const paths = envPaths("brs", { suffix: "cli" });
+const cacheFile = path.resolve(paths.cache, "update-check.json");
+
+type UpdateCache = { lastCheck: number; latest: string };
+type Version = { major: number; minor: number; patch: number; pre: string };
+
+let latestVersion = "";
+let noticeDisplayed = false;
+
+/**
+ * Reads the cached registry result (so a notice can be shown with zero latency) and,
+ * when the cache is stale, refreshes it in the background for the next run.
+ * Safe to call unconditionally: it is a no-op when the check is disabled.
+ */
+export function startUpdateCheck() {
+    if (!isCheckEnabled()) {
+        return;
+    }
+    const cache = readCache();
+    latestVersion = cache?.latest ?? "";
+    if (!cache || Date.now() - cache.lastCheck >= CHECK_INTERVAL_MS) {
+        // Stamp the attempt before the request: a short-lived run can exit before the
+        // response arrives (the socket is unref'd), and the registry must not be queried
+        // again on every such invocation.
+        writeCache(latestVersion);
+        fetchLatestVersion();
+    }
+}
+
+/**
+ * Displays the "update available" notice, at most once per process, when the last known
+ * published version is newer than the running one.
+ */
+export function printUpdateNotice() {
+    if (noticeDisplayed || !isCheckEnabled() || !isNewer(latestVersion, packageInfo.version)) {
+        return;
+    }
+    noticeDisplayed = true;
+    const versions = `${chalk.gray(packageInfo.version)} ${chalk.gray("->")} ${chalk.greenBright(latestVersion)}`;
+    console.log(`${chalk.yellowBright("Update available:")} ${versions}`);
+    console.log(`${chalk.yellow("Run")} ${chalk.cyanBright(upgradeCommand())} ${chalk.yellow("to update.")}\n`);
+}
+
+/**
+ * The check is opt-out and only runs on an interactive terminal, so it never interferes
+ * with scripted/CI usage nor pollutes redirected output.
+ * @returns True when the CLI may check for (and report) a new version
+ */
+function isCheckEnabled() {
+    return (
+        process.stdout.isTTY === true &&
+        !process.env.CI &&
+        !process.env.BRS_NO_UPDATE_CHECK &&
+        !process.env.NO_UPDATE_NOTIFIER
+    );
+}
+
+/**
+ * Suggests the command that upgrades the way this copy of the CLI was installed:
+ * `npx` when running from the npx cache, a local install when it lives under the
+ * current directory's `node_modules`, a global install otherwise (the common case).
+ * @returns The upgrade command to display in the notice
+ */
+function upgradeCommand() {
+    const installPath = path.resolve(__dirname);
+    if (installPath.split(path.sep).includes("_npx")) {
+        return `npx ${packageInfo.name}@latest`;
+    }
+    const localModules = path.resolve(process.cwd(), "node_modules");
+    if (installPath.startsWith(localModules + path.sep)) {
+        return `npm install ${packageInfo.name}@latest`;
+    }
+    return `npm install -g ${packageInfo.name}@latest`;
+}
+
+/**
+ * Reads the cached registry result from disk.
+ * @returns The cached entry, or undefined when missing or malformed
+ */
+function readCache(): UpdateCache | undefined {
+    try {
+        const content = fs.readFileSync(cacheFile, "utf8");
+        const parsed = JSON.parse(content);
+        if (typeof parsed?.lastCheck === "number" && typeof parsed?.latest === "string") {
+            return parsed as UpdateCache;
+        }
+    } catch {
+        // No cache yet (or an unreadable one): treat it as a first run.
+    }
+    return undefined;
+}
+
+/**
+ * Persists the registry result so the next run can notify without any network access.
+ * @param latest - The version published under the `latest` dist-tag
+ */
+function writeCache(latest: string) {
+    try {
+        fs.mkdirSync(paths.cache, { recursive: true });
+        const cache: UpdateCache = { lastCheck: Date.now(), latest };
+        fs.writeFileSync(cacheFile, JSON.stringify(cache));
+    } catch {
+        // A read-only cache directory just means the check runs again next time.
+    }
+}
+
+/**
+ * Queries the npm registry for the version published under the `latest` dist-tag and
+ * caches it. The socket is unref'd so a pending request never delays the CLI exit (a run
+ * shorter than the round-trip simply leaves the refresh to a later one), and every
+ * failure is silent - a version check must never break or slow down a run.
+ */
+function fetchLatestVersion() {
+    try {
+        const request = https.get(
+            {
+                host: REGISTRY_HOST,
+                path: `/${packageInfo.name}/latest`,
+                headers: { accept: "application/json", "user-agent": `brs-cli/${packageInfo.version}` },
+                timeout: REQUEST_TIMEOUT_MS,
+            },
+            (response) => {
+                if (response.statusCode !== 200) {
+                    response.resume();
+                    return;
+                }
+                let body = "";
+                response.setEncoding("utf8");
+                response.on("data", (chunk: string) => {
+                    body += chunk;
+                    if (body.length > MAX_RESPONSE_BYTES) {
+                        request.destroy();
+                    }
+                });
+                response.on("end", () => {
+                    try {
+                        const version = JSON.parse(body)?.version;
+                        if (typeof version === "string" && parseVersion(version)) {
+                            latestVersion = version;
+                            writeCache(version);
+                        }
+                    } catch {
+                        // Unexpected payload: ignore it and retry on the next run.
+                    }
+                });
+                response.on("error", () => {});
+            }
+        );
+        request.on("socket", (socket) => socket.unref());
+        request.on("timeout", () => request.destroy());
+        request.on("error", () => {});
+    } catch {
+        // Offline or a blocked registry: nothing to report.
+    }
+}
+
+/**
+ * Splits a semantic version into its comparable parts.
+ * @param version - The version string to parse (a leading `v` is tolerated)
+ * @returns The parsed version, or undefined when it is not semver-like
+ */
+function parseVersion(version: string): Version | undefined {
+    const parts = /^v?(\d+)\.(\d+)\.(\d+)(?:-([\w.-]+))?/.exec(version.trim());
+    if (!parts) {
+        return undefined;
+    }
+    return { major: +parts[1], minor: +parts[2], patch: +parts[3], pre: parts[4] ?? "" };
+}
+
+/**
+ * Compares two versions, treating a pre-release as older than its own final release
+ * (so a user on `2.4.0-beta.1` is notified when `2.4.0` ships).
+ * @param latest - The version published on the registry
+ * @param current - The version of the running CLI
+ * @returns True when `latest` supersedes `current`
+ */
+export function isNewer(latest: string, current: string) {
+    const published = parseVersion(latest);
+    const running = parseVersion(current);
+    if (!published || !running) {
+        return false;
+    }
+    if (published.major !== running.major) {
+        return published.major > running.major;
+    }
+    if (published.minor !== running.minor) {
+        return published.minor > running.minor;
+    }
+    if (published.patch !== running.patch) {
+        return published.patch > running.patch;
+    }
+    return published.pre === "" && running.pre !== "";
+}

--- a/test/cli/cli-update.test.js
+++ b/test/cli/cli-update.test.js
@@ -1,0 +1,63 @@
+const fs = require("fs");
+const path = require("path");
+const Module = require("module");
+const ts = require("typescript");
+
+function loadUpdateChecker() {
+    const filePath = path.join(__dirname, "../../src/cli/update.ts");
+    const source = fs.readFileSync(filePath, "utf8");
+    const { outputText } = ts.transpileModule(source, {
+        compilerOptions: {
+            module: ts.ModuleKind.CommonJS,
+            target: ts.ScriptTarget.ES2019,
+            esModuleInterop: true,
+            resolveJsonModule: true,
+        },
+        fileName: filePath,
+    });
+
+    const moduleExports = { exports: {} };
+    const compiled = new Function("exports", "require", "module", "__filename", "__dirname", outputText);
+
+    compiled(moduleExports.exports, Module.createRequire(filePath), moduleExports, filePath, path.dirname(filePath));
+
+    return moduleExports.exports;
+}
+
+const { isNewer } = loadUpdateChecker();
+
+describe("cli/update", () => {
+    describe("isNewer", () => {
+        it("detects a newer major, minor or patch release", () => {
+            expect(isNewer("3.0.0", "2.3.0")).toBe(true);
+            expect(isNewer("2.4.0", "2.3.9")).toBe(true);
+            expect(isNewer("2.3.1", "2.3.0")).toBe(true);
+        });
+
+        it("does not report the same or an older version", () => {
+            expect(isNewer("2.3.0", "2.3.0")).toBe(false);
+            expect(isNewer("2.2.9", "2.3.0")).toBe(false);
+            expect(isNewer("1.9.9", "2.0.0")).toBe(false);
+            expect(isNewer("2.3.0", "2.4.0-beta.1")).toBe(false);
+        });
+
+        it("compares each part numerically, not as text", () => {
+            expect(isNewer("2.10.0", "2.9.0")).toBe(true);
+            expect(isNewer("2.9.0", "2.10.0")).toBe(false);
+            expect(isNewer("10.0.0", "9.0.0")).toBe(true);
+        });
+
+        it("treats a pre-release as older than its own final release", () => {
+            expect(isNewer("2.4.0", "2.4.0-beta.1")).toBe(true);
+            expect(isNewer("2.4.0-beta.2", "2.4.0")).toBe(false);
+            expect(isNewer("2.4.0-beta.2", "2.4.0-beta.1")).toBe(false);
+        });
+
+        it("ignores versions that are not semver-like", () => {
+            expect(isNewer("", "2.3.0")).toBe(false);
+            expect(isNewer("latest", "2.3.0")).toBe(false);
+            expect(isNewer("2.4", "2.3.0")).toBe(false);
+            expect(isNewer("v2.4.0", "2.3.0")).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
## Motivation

The CLI gave no signal when a newer release was available, so a globally installed copy (`npm install -g brs-node`) silently stayed behind indefinitely.

## Changes

New `src/cli/update.ts`:

- **`startUpdateCheck()`** — reads a cached registry result from `envPaths("brs", { suffix: "cli" }).cache/update-check.json`, and refreshes it in background (npm registry `latest` dist-tag) when older than 24 h.
- **`printUpdateNotice()`** — prints once per process:
  ```
  Update available: 2.3.0 -> 2.4.0
  Run npm install -g brs-node@latest to update.
  ```
  The suggested command follows the detected installation: `npx brs-node@latest` from the npx cache, `npm install brs-node@latest` under the current directory's `node_modules`, `-g` otherwise (the common case).
- **`isNewer()`** — numeric semver comparison that also treats a pre-release as older than its own final release, so a user on `2.4.0-beta.1` is notified when `2.4.0` ships.

Wired into `src/cli/index.ts` at three points: end of `displayTitle()` (REPL and package runs), start of `runApp()` (`.brs` files and `--root` apps, which display no title — and always before the frame output takes over the terminal), and after the "Finished ... execution" line, so a first run whose response arrives while the app is running still reports it.

## Behavior guarantees

- **No added latency:** the notice comes from the cache; the request runs in background with the socket `unref`'d, so it never delays the exit (a run shorter than the round-trip just leaves the refresh to a later one). The `lastCheck` stamp is written *before* the request, so such a run does not re-query on every invocation.
- **Never breaks a run:** offline, blocked registry, non-200, malformed payload and a read-only cache directory are all silent no-ops.
- **Opt-out and non-intrusive:** only runs on an interactive terminal (TTY), and is skipped when `CI`, `BRS_NO_UPDATE_CHECK` or `NO_UPDATE_NOTIFIER` is set — so scripted usage, redirected output and the test suite are unaffected.

## Testing

- New `test/cli/cli-update.test.js` covering the `isNewer` matrix (major/minor/patch, numeric vs. textual comparison, pre-release ordering, non-semver input).
- Full `test/cli/` suite green (80 passed).
- Manual runs on a pty verifying the notice, the cache write, the non-TTY skip and the `BRS_NO_UPDATE_CHECK` opt-out.
- `npm run lint` and `npm run prettier` clean.

Documented in `docs/run-as-cli.md` ("Keeping the CLI Up to Date").

🤖 Generated with [Claude Code](https://claude.com/claude-code)