### PR TITLE
fix(cli): repair encrypted-package startup crash and component script resolution

### DIFF
--- a/src/core/LexerParser.ts
+++ b/src/core/LexerParser.ts
@@ -116,6 +116,12 @@ export function parseDecodedTokens(fs: FileSystem, manifest: Map<string, any>, d
     let tokens: Token[] = [];
     for (let [, value] of decodedTokens) {
         const token: any = value;
+        if (token === null || token === undefined) {
+            // Packages produced before the empty-source-file preprocessor fix can carry a stray
+            // null/undefined entry in the pcode stream (an artifact of a fully empty/preprocessed-
+            // away .brs file). Skip it rather than crash, so already-packed .bpk apps keep working.
+            continue;
+        }
         if (token.literal) {
             if (token.kind === "Integer") {
                 const literal: number = token.literal.value;
@@ -137,7 +143,7 @@ export function parseDecodedTokens(fs: FileSystem, manifest: Map<string, any>, d
         tokens.push(token);
         if (token.kind === "Eof") {
             const parseResults = parser.parse(tokens);
-            if (parseResults.errors.length > 0 || parseResults.statements.length === 0) {
+            if (parseResults.errors.length > 0) {
                 throw new Error("Error parsing the tokens!");
             }
             parseLibraries(fs, parseResults, lib, manifest);

--- a/src/core/device/FileSystem.ts
+++ b/src/core/device/FileSystem.ts
@@ -42,6 +42,15 @@ export class FileSystem {
      * are completely unaffected.
      */
     private readonly overlay: Map<string, string> = new Map();
+    /**
+     * Permanent, session-lifetime store of decrypted `pkg:/source/*.brs` text, separate from
+     * `overlay`. SceneGraph component libraries can be loaded lazily at any point during a run
+     * (long after `overlay` is cleared post-startup), and their components may reference the host
+     * app's own `pkg:/source/*.brs` files via `<script>` tags. This store is only ever consulted by
+     * `readProtectedSource` — never by `existsSync`/`readFileSync`/`findSync` — so it does not
+     * reopen the app's own BrightScript source to `ReadAsciiFile`/`roFileSystem`/`MatchFiles`.
+     */
+    private readonly protectedSource: Map<string, string> = new Map();
     private _root?: string;
     private _ext?: string;
 
@@ -91,6 +100,7 @@ export class FileSystem {
         ext?: string
     ) {
         this.overlay.clear();
+        this.protectedSource.clear();
         const fsConfig = { mounts: {}, caseFold: "lower" as const };
         // Basic mounts: common:, tmp:, cachefs:, pkg:
         if (zenFS.mounts.has("/common:")) zenFS.umount("common:");
@@ -329,22 +339,55 @@ export class FileSystem {
     }
 
     /**
+     * Normalizes an overlay/protected-source key to a lowercase `pkg:/...` path. Keys may be
+     * relative (e.g. "components/foo.xml") or full pkg: URIs.
+     */
+    private normalizeSourceKey(key: string): string {
+        let normalized = key.trim().toLowerCase().replaceAll("\\", "/");
+        if (!normalized.startsWith("pkg:/")) {
+            normalized = `pkg:/${normalized.replace(/^\/+/, "")}`;
+        }
+        return normalized.replaceAll(/\/+/g, "/");
+    }
+
+    /** Normalizes and copies `files` into `target`, keyed by `normalizeSourceKey`. */
+    private loadNormalized(target: Map<string, string>, files: Map<string, string> | Record<string, string>) {
+        const entries = files instanceof Map ? files.entries() : Object.entries(files);
+        for (const [key, content] of entries) {
+            target.set(this.normalizeSourceKey(key), content);
+        }
+    }
+
+    /**
      * Restores a set of decrypted pkg: files into the in-memory overlay so they can be read as if
      * they were present in the package. Used when running an encrypted package whose component
-     * files were stripped from the zip. Keys may be relative (e.g. "components/foo.xml") or full
-     * pkg: URIs; both are normalized to lowercase `pkg:/...`.
+     * files were stripped from the zip.
      * @param files Map (or record) of file path to text content.
      */
     setSourceOverlay(files: Map<string, string> | Record<string, string>) {
-        const entries = files instanceof Map ? files.entries() : Object.entries(files);
-        for (const [key, content] of entries) {
-            let normalized = key.trim().toLowerCase().replaceAll("\\", "/");
-            if (!normalized.startsWith("pkg:/")) {
-                normalized = `pkg:/${normalized.replace(/^\/+/, "")}`;
-            }
-            normalized = normalized.replaceAll(/\/+/g, "/");
-            this.overlay.set(normalized, content);
-        }
+        this.loadNormalized(this.overlay, files);
+    }
+
+    /**
+     * Populates the permanent, session-lifetime protected-source store (see `protectedSource`).
+     * Unlike `setSourceOverlay`, this is never cleared mid-run and is only ever consulted via
+     * `readProtectedSource`, so it stays invisible to the app's own file-reading BrightScript APIs.
+     * @param files Map (or record) of file path to text content.
+     */
+    setProtectedSource(files: Map<string, string> | Record<string, string>) {
+        this.loadNormalized(this.protectedSource, files);
+    }
+
+    /**
+     * Reads a decrypted `pkg:/source/*.brs` file from the permanent protected-source store. For use
+     * only by internal SceneGraph component-script resolution (e.g. a lazily-loaded component
+     * library's `<script uri="pkg:/source/...">` reference) — never wire this into a BrightScript-
+     * facing file API.
+     * @param uri File URI (relative or full `pkg:/...`).
+     * @returns The file's text content, or undefined if not present.
+     */
+    readProtectedSource(uri: string): string | undefined {
+        return this.protectedSource.get(this.normalizeSourceKey(uri));
     }
 
     /** Clears the decrypted pkg: file overlay. */

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -920,9 +920,17 @@ interface SerializedPCode {
     pcode: Token[];
     /**
      * Decrypted raw-text pkg: files that were stripped from the package and folded into the
-     * encrypted blob (SceneGraph component .brs/.xml). Absent in legacy packages.
+     * encrypted blob (SceneGraph component .brs/.xml). Restored into the transient overlay, cleared
+     * once the initial component scan completes. Absent in legacy packages.
      */
     files?: Record<string, string>;
+    /**
+     * Decrypted pkg:/source/*.brs raw text, kept separate from `files` because it must be restored
+     * into the permanent `protectedSource` store instead — general-purpose overlay lookups
+     * (existsSync/readFileSync/findSync, i.e. the app's own file-reading BrightScript APIs) must
+     * never see it. Absent in legacy packages and in packages with no SceneGraph components.
+     */
+    sourceFiles?: Record<string, string>;
 }
 
 /**
@@ -1061,40 +1069,62 @@ export interface RunResult {
     packedFiles?: string[];
 }
 /**
- * Collects the SceneGraph component source files (.brs and .xml under pkg:/components) so they can
- * be folded into the encrypted package blob and stripped from the distributed zip.
- * @returns the raw-text file contents keyed by relative lowercase path, plus the list of those paths.
+ * Collects the SceneGraph component source files (.brs and .xml under pkg:/components), plus every
+ * pkg:/source/**\/*.brs file already loaded into `sourceMap`, so they can be folded into the
+ * encrypted package blob. Component files are also stripped from the distributed zip (returned in
+ * `packedFiles`); `pkg:/source/**` is already unconditionally dropped by `updateAppZip`, but its raw
+ * text is still needed in the blob because SceneGraph component `<script uri="pkg:/source/...">`
+ * references (including ones loaded lazily by a component library, main or bundled) are resolved by
+ * reading the file directly, independent of the tokenized pcode used to run the main thread. Only
+ * collected when the app has SceneGraph components at all (`pkg:/components` exists) — a plain non-SG
+ * app has no consumer for it.
+ * @param fsys the interpreter file system, used to walk pkg:/components.
+ * @param sourceMap the app's already-loaded pkg:/source/*.brs text (same content that was tokenized),
+ *                   reused here instead of re-reading those files from disk.
+ * @returns the component files (also stripped from the zip) and pkg:/source files (blob-only, kept out
+ *          of the strip list) separately, both keyed by relative lowercase path.
  */
-function collectComponentFiles(fsys: typeof BrsDevice.fileSystem): {
-    files: Record<string, string>;
+function collectComponentFiles(
+    fsys: typeof BrsDevice.fileSystem,
+    sourceMap: Map<string, string>
+): {
+    componentFiles: Record<string, string>;
+    sourceFiles: Record<string, string>;
     packedFiles: string[];
 } {
-    const files: Record<string, string> = {};
+    const componentFiles: Record<string, string> = {};
+    const sourceFiles: Record<string, string> = {};
     const packedFiles: string[] = [];
     if (!fsys?.existsSync("pkg:/components")) {
-        return { files, packedFiles };
+        return { componentFiles, sourceFiles, packedFiles };
     }
     const root = fsys.root;
+    const toRelKey = (fsPath: string) => {
+        // findSync returns backend paths: "pkg:/xxx/..." for zip-mounted packages, or an absolute
+        // "<root>/xxx/..." path in --root folder mode. Reduce both to the package-relative, lowercase
+        // key used for the encrypted blob and the strip list.
+        let rel = fsPath;
+        if (root && rel.toLowerCase().startsWith(root.toLowerCase())) {
+            rel = rel.slice(root.length);
+        } else {
+            rel = rel.replace(/^pkg:\//i, "");
+        }
+        return rel.replaceAll("\\", "/").replace(/^\/+/, "").toLowerCase();
+    };
     const found = [...fsys.findSync("pkg:/components", "xml"), ...fsys.findSync("pkg:/components", "brs")];
     for (const fsPath of found) {
         try {
-            // findSync returns backend paths: "pkg:/components/..." for zip-mounted packages, or an
-            // absolute "<root>/components/..." path in --root folder mode. Reduce both to the
-            // package-relative, lowercase key used for the encrypted blob and the strip list.
-            let rel = fsPath;
-            if (root && rel.toLowerCase().startsWith(root.toLowerCase())) {
-                rel = rel.slice(root.length);
-            } else {
-                rel = rel.replace(/^pkg:\//i, "");
-            }
-            rel = rel.replaceAll("\\", "/").replace(/^\/+/, "").toLowerCase();
-            files[rel] = fsys.readFileSync(fsPath, "utf8") as string;
+            const rel = toRelKey(fsPath);
+            componentFiles[rel] = fsys.readFileSync(fsPath, "utf8") as string;
             packedFiles.push(rel);
         } catch (err: any) {
             BrsDevice.stderr.write(`error,Error reading component file ${fsPath} - ${err.message}`);
         }
     }
-    return { files, packedFiles };
+    for (const [pkgPath, text] of sourceMap) {
+        sourceFiles[pkgPath.replace(/^pkg:\//i, "").toLowerCase()] = text;
+    }
+    return { componentFiles, sourceFiles, packedFiles };
 }
 
 /**
@@ -1112,6 +1142,13 @@ function restoreEncryptedFiles(pcode: Buffer, iv: string, password: string): Map
     if (spcode.files && Object.keys(spcode.files).length > 0) {
         BrsDevice.fileSystem.setSourceOverlay(spcode.files);
     }
+    if (spcode.sourceFiles && Object.keys(spcode.sourceFiles).length > 0) {
+        // Kept out of setSourceOverlay (never reachable via existsSync/readFileSync/findSync) and
+        // never cleared: a SceneGraph component library can be loaded lazily at any point during
+        // the run, and its components may reference these pkg:/source/*.brs files via
+        // <script uri="pkg:/source/...">, long after the post-startup clearSourceOverlay() runs.
+        BrsDevice.fileSystem.setProtectedSource(spcode.sourceFiles);
+    }
     return new Map(Object.entries(spcode.pcode));
 }
 
@@ -1127,12 +1164,15 @@ async function runSource(
     if (exitReason !== AppExitReason.Crashed) {
         if (password.length > 0) {
             const tokens = parseResult.tokens;
-            const { files, packedFiles } = collectComponentFiles(BrsDevice.fileSystem);
+            const { componentFiles, sourceFiles, packedFiles } = collectComponentFiles(BrsDevice.fileSystem, sourceMap);
             const iv = crypto.randomBytes(12).toString("base64");
             const cipher = crypto.createCipheriv(algorithm, password, iv);
             const payloadToEncode: SerializedPCode = { pcode: tokens };
-            if (Object.keys(files).length > 0) {
-                payloadToEncode.files = files;
+            if (Object.keys(componentFiles).length > 0) {
+                payloadToEncode.files = componentFiles;
+            }
+            if (Object.keys(sourceFiles).length > 0) {
+                payloadToEncode.sourceFiles = sourceFiles;
             }
             const deflated = zlibSync(encode(payloadToEncode));
             const source = Buffer.from(deflated);

--- a/src/core/preprocessor/Parser.ts
+++ b/src/core/preprocessor/Parser.ts
@@ -179,6 +179,7 @@ export class Parser {
         function brightScriptChunk(): CC.BrightScript | undefined {
             let chunkTokens: Token[] = [];
             while (
+                !isAtEnd() &&
                 !check(
                     Lexeme.HashIf,
                     Lexeme.HashElseIf,
@@ -189,10 +190,6 @@ export class Parser {
                 )
             ) {
                 chunkTokens.push(advance());
-
-                if (isAtEnd()) {
-                    break;
-                }
             }
 
             if (chunkTokens.length > 0) {

--- a/src/extensions/scenegraph/parser/ComponentScopeResolver.ts
+++ b/src/extensions/scenegraph/parser/ComponentScopeResolver.ts
@@ -179,11 +179,17 @@ export class ComponentScopeResolver {
                     filename = script.uri.replaceAll(/[/\\]+/g, path.posix.sep);
                     try {
                         contents = fs.readFileSync(filename, "utf-8");
-                        script.content = contents;
                     } catch (err) {
-                        let errno = (err as NodeJS.ErrnoException)?.errno || -4858;
-                        throw new Error(`brs: can't open file '${filename}': [Errno ${errno}]`);
+                        // A lazily-loaded component library's script can reference the host app's
+                        // own pkg:/source/*.brs after clearSourceOverlay() already ran; those
+                        // survive in the permanent protected-source store instead.
+                        contents = fs.readProtectedSource(filename);
+                        if (contents === undefined) {
+                            let errno = (err as NodeJS.ErrnoException)?.errno || -4858;
+                            throw new Error(`brs: can't open file '${filename}': [Errno ${errno}]`);
+                        }
                     }
+                    script.content = contents;
                 } else if (script.content === undefined) {
                     throw new Error("brs: invalid script object");
                 } else {


### PR DESCRIPTION
## Summary
- Fixes an off-by-one in the conditional-compilation chunk parser (`brightScriptChunk`) that re-entered its token loop at EOF and pushed a stray `undefined` token whenever a source file was empty or fully excluded by conditional compilation. For an encrypted `.bpk` this token survived pack time and crashed at run time (`Cannot read properties of null (reading 'literal')`) once decoded. The decoder also now tolerates a stray null/undefined pcode entry so already-packaged `.bpk` files keep working without a repack.
- Fixes `pkg:/source/*.brs` files referenced by SceneGraph component `<script uri="pkg:/source/...">` tags (a common shared-library pattern) not being folded into the encrypted blob, causing `can't open file` errors after decrypt.
- Fixes those same files not surviving long enough for component libraries loaded lazily at runtime, by restoring them through a separate, permanent store on `FileSystem` that's wired only into the SceneGraph component-script loader — never into the general file APIs the app's own BrightScript can call — so decrypted source text stays unreadable to the running app.

## Test plan
- [x] `npm run lint` / `npm run prettier`
- [x] Full test suite (`npx vitest run`): 216 files / 2764 tests passing, including `test/cli/cli-bpk.test.js` and `test/cli/cli-scenegraph.test.js`
- [x] Manually packed and ran a real-world encrypted SceneGraph app (including a bundled component library) through the CLI to confirm the startup crash, the `can't open file` errors, and the resulting crash are all gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)