### PR TITLE
fix(scenegraph): service SceneGraph via sleep()+getMessage() poll loops

### DIFF
--- a/.claude/docs/threading-and-rendezvous.md
+++ b/.claude/docs/threading-and-rendezvous.md
@@ -38,6 +38,19 @@ Node-host invariants (all mirror the browser API):
   `Interpreter.checkDebugger` therefore **throws `BlockEnd("debug-exit")` when already in EXIT mode**
   instead of returning — otherwise an app in `while true : wait(0, port)` live-locks with `wait` returning
   instantly (the pre-fix home-key hang).
+- **`getMessage()`/`peekMessage()` must thread the live `Interpreter` through `updateMessageQueue`,
+  exactly like `wait()` does.** They dispatch through the same generic `callbackMap` as `wait()`
+  (`RoMessagePort.ts`), and `RoSGScreen`'s callback (`getNewEvents`) early-returns with no work done when
+  its `interpreter` argument is falsy — it needs a live interpreter to service timers/animations/
+  tasks/rendering. A refactor once made `getMessage`/`peekMessage` call `updateMessageQueue()` with no
+  arguments, which silently stopped SceneGraph from ever being serviced through those two calls (a real
+  app driving its main loop with `sleep()+getMessage()` instead of `wait()` never rendered a frame, with
+  no error) — nothing caught it because the only prior test only asserted `getMessage()` "doesn't crash."
+  A distinct non-blocking sentinel (`PORT_NO_WAIT`, not `0` — `0` already means "block indefinitely" by
+  this codebase's convention, see `wait()` above) marks the call as a poll rather than a wait; `Task.ts`'s
+  `getNewEvents` must treat that sentinel as "poll once, don't block" rather than converting it to an
+  infinite `Atomics.wait`. Regression: "Services SceneGraph timers/rendering through a sleep()+
+  getMessage() poll loop" in `test/cli/cli-scenegraph.test.js`.
 
 ## Rendezvous architecture (multi-threaded Tasks)
 

--- a/src/core/brsTypes/components/RoMessagePort.ts
+++ b/src/core/brsTypes/components/RoMessagePort.ts
@@ -7,6 +7,10 @@ import { Int32 } from "../Int32";
 import { DebugCommand } from "../../common";
 import { BrsDevice } from "../../device/BrsDevice";
 
+/** Sentinel passed as the callback `wait` argument for a non-blocking poll (`GetMessage`/`PeekMessage`).
+ *  Distinct from `0`, which by convention (see `wait()` below) means "block indefinitely". */
+export const PORT_NO_WAIT = -1;
+
 export class RoMessagePort extends BrsComponent implements BrsValue {
     readonly kind = ValueKind.Object;
     private readonly messageQueue: BrsEvent[];
@@ -136,8 +140,8 @@ export class RoMessagePort extends BrsComponent implements BrsValue {
             args: [],
             returns: ValueKind.Dynamic,
         },
-        impl: (_: Interpreter) => {
-            this.updateMessageQueue();
+        impl: (interpreter: Interpreter) => {
+            this.updateMessageQueue(interpreter, PORT_NO_WAIT);
             return this.getNextMessage();
         },
     });
@@ -148,8 +152,8 @@ export class RoMessagePort extends BrsComponent implements BrsValue {
             args: [],
             returns: ValueKind.Dynamic,
         },
-        impl: (_: Interpreter) => {
-            this.updateMessageQueue();
+        impl: (interpreter: Interpreter) => {
+            this.updateMessageQueue(interpreter, PORT_NO_WAIT);
             if (this.messageQueue.length > 0) {
                 return this.messageQueue[0];
             }

--- a/src/extensions/scenegraph/nodes/Task.ts
+++ b/src/extensions/scenegraph/nodes/Task.ts
@@ -21,6 +21,7 @@ import {
     DataType,
     LogLevel,
     getNow,
+    PORT_NO_WAIT,
 } from "brs-engine";
 import { sgClock } from "../SGClock";
 import { sgRoot } from "../SGRoot";
@@ -736,8 +737,10 @@ export class Task extends Node {
             if (BrsDevice.pauseIfDebugging()) {
                 return new Array<BrsEvent>();
             }
-            const timeout = wait === 0 ? undefined : wait;
-            this.taskBuffer.waitVersion(0, timeout);
+            if (wait !== PORT_NO_WAIT) {
+                const timeout = wait === 0 ? undefined : wait;
+                this.taskBuffer.waitVersion(0, timeout);
+            }
             this.processThreadUpdate();
         }
         return new Array<BrsEvent>();

--- a/src/node/host.ts
+++ b/src/node/host.ts
@@ -90,6 +90,10 @@ let finishApp: ((result: AppResult) => void) | undefined;
 // overrides the reason the worker posts, mirroring the browser API's terminate(reason) —
 // the worker only knows it was told to EXIT, not that the user pressed home.
 let terminateReason: AppExitReason | undefined;
+// Fallback force-terminate timer armed by terminateApp(); cleared in cleanupApp() so a graceful
+// exit (the worker's own "end" message) doesn't leave a stale timer that could fire against a
+// later, unrelated app run once this one has already finished.
+let terminateTimer: NodeJS.Timeout | undefined;
 
 /**
  * Executes a BrightScript app on a dedicated worker thread, with SceneGraph Task support.
@@ -155,10 +159,10 @@ export function terminateApp(reason: AppExitReason = AppExitReason.UserNav, time
     terminateReason = reason;
     Atomics.store(controlArray, DataType.DBG, DebugCommand.EXIT);
     Atomics.notify(controlArray, DataType.DBG);
-    const timer = setTimeout(() => {
+    terminateTimer = setTimeout(() => {
         finishApp?.({ exitReason: reason });
     }, timeoutMs);
-    timer.unref();
+    terminateTimer.unref();
 }
 
 /**
@@ -194,6 +198,8 @@ async function cleanupApp() {
     currentPayload = undefined;
     controlArray = undefined;
     terminateReason = undefined;
+    clearTimeout(terminateTimer);
+    terminateTimer = undefined;
     if (worker) {
         worker.removeAllListeners();
         await worker.terminate().catch(() => {});

--- a/test/cli/cli-scenegraph.test.js
+++ b/test/cli/cli-scenegraph.test.js
@@ -1151,6 +1151,27 @@ describe.concurrent("cli scenegraph", () => {
         ]);
     }, 30000);
 
+    it("Services SceneGraph timers/rendering through a sleep()+getMessage() poll loop, not just wait()", async () => {
+        let command = ["node", brsCliPath, "-r sleep-poll-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        // Some real-world apps drive their main loop with sleep()+getMessage()/peekMessage() instead
+        // of wait(timeout, port). getMessage()/peekMessage() used to call updateMessageQueue() with no
+        // Interpreter, so roSGScreen's port callback (which needs the live Interpreter to service
+        // timers/animations/tasks/rendering) silently no-opped - the scene never ran and "TIMER FIRED"
+        // never printed, even though the app didn't crash.
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "=== Sleep Poll Main Loop Repro ===",
+            "TIMER FIRED",
+            "=== Sleep Poll Main Loop Repro Complete ===",
+            "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+    }, 30000);
+
     // This asserts a ~20ms wall-clock budget around a 125ms Timer chain, so it is opted out of the
     // suite's concurrency (not measured while sibling CLI child processes run) and retried: under a
     // fully loaded machine, scheduler noise alone can push a healthy run past the bound. Retrying is

--- a/test/cli/resources/sleep-poll-app/components/MainScene.xml
+++ b/test/cli/resources/sleep-poll-app/components/MainScene.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="MainScene" extends="Scene">
+    <interface>
+        <field id="exitApp" type="boolean" value="false" />
+    </interface>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        timer = createObject("roSGNode", "Timer")
+        timer.duration = 0.05
+        timer.repeat = false
+        m.timer = timer
+        timer.observeField("fire", "onTimerFire")
+        timer.control = "start"
+    end sub
+
+    sub onTimerFire()
+        print "TIMER FIRED"
+        m.top.exitApp = true
+    end sub
+    ]]></script>
+</component>

--- a/test/cli/resources/sleep-poll-app/manifest
+++ b/test/cli/resources/sleep-poll-app/manifest
@@ -1,0 +1,4 @@
+title=Sleep Poll Main Loop Repro
+major_version=1
+minor_version=0
+build_version=1

--- a/test/cli/resources/sleep-poll-app/source/main.brs
+++ b/test/cli/resources/sleep-poll-app/source/main.brs
@@ -1,0 +1,23 @@
+sub main()
+    print "=== Sleep Poll Main Loop Repro ==="
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+    scene = screen.CreateScene("MainScene")
+    screen.show()
+
+    ' Mirrors a real-world app's main loop: instead of the idiomatic `wait(timeout, port)`,
+    ' it polls with sleep() + getMessage()/peekMessage().
+    appIsAlive = true
+    iterations = 0
+    while appIsAlive and iterations < 200
+        msg = port.getMessage()
+        if type(msg) = "roSGScreenEvent"
+            if msg.isScreenClosed() then appIsAlive = false
+        end if
+        if port.peekMessage() = invalid then sleep(16)
+        if scene.exitApp then appIsAlive = false
+        iterations = iterations + 1
+    end while
+    print "=== Sleep Poll Main Loop Repro Complete ==="
+end sub


### PR DESCRIPTION
## Summary
- `RoMessagePort.getMessage()`/`peekMessage()` called `updateMessageQueue()` with no `Interpreter`, so `RoSGScreen`'s port callback (which needs a live interpreter to service timers/animations/tasks/rendering) silently no-opped — an app driving its SceneGraph main loop with `sleep()+getMessage()`/`peekMessage()` instead of `wait(timeout, port)` never rendered a frame, with no error.
- Threads the interpreter through both calls via a new non-blocking sentinel (`PORT_NO_WAIT`, distinct from `0`, which already means "block indefinitely"); `Task.ts`'s matching port callback treats the sentinel as "poll once, don't block" instead of an infinite `Atomics.wait`.
- Also fixes an unrelated bug found during review: `terminateApp()`'s fallback force-terminate timer was never cleared on a graceful exit, so it could leak into and prematurely resolve a later app run.

## Test plan
- [x] `npm run lint`
- [x] `npm run build:api && npm run build:cli`
- [x] New regression test: "Services SceneGraph timers/rendering through a sleep()+getMessage() poll loop, not just wait()" in `test/cli/cli-scenegraph.test.js`
- [x] Full suite: `npm test` (216 files / 2765 tests passing)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01PELxVTSfVFC7Fnr9sy2m6g