### PR TITLE
fix: prevent stack overflow printing a self-referencing associative array

### DIFF
--- a/src/core/brsTypes/components/RoAssociativeArray.ts
+++ b/src/core/brsTypes/components/RoAssociativeArray.ts
@@ -68,9 +68,9 @@ export class RoAssociativeArray extends BrsComponent implements BrsValue, BrsIte
         return [
             "<Component: roAssociativeArray> =",
             "{",
-            ...Array.from(this.elements.entries())
+            ...Array.from(this.elements.keys())
                 .sort()
-                .map(([key, value]) => `    ${key}: ${value.toString(this)}`),
+                .map((key) => `    ${key}: ${this.elements.get(key)!.toString(this)}`),
             "}",
         ].join("\n");
     }
@@ -90,9 +90,9 @@ export class RoAssociativeArray extends BrsComponent implements BrsValue, BrsIte
     }
 
     getValues() {
-        return Array.from(this.elements.values())
+        return Array.from(this.elements.keys())
             .sort()
-            .map((value: BrsType) => value);
+            .map((key) => this.elements.get(key)!);
     }
 
     clearElements() {

--- a/src/extensions/scenegraph/nodes/ContentNode.ts
+++ b/src/extensions/scenegraph/nodes/ContentNode.ts
@@ -285,9 +285,8 @@ export class ContentNode extends Node {
     /** @override */
     getValues() {
         return this.getVisibleFields()
-            .map(([key, value]) => value)
-            .sort()
-            .map((field: Field) => field.getValue());
+            .sort(([keyA], [keyB]) => (keyA < keyB ? -1 : keyA > keyB ? 1 : 0))
+            .map(([, field]) => field.getValue());
     }
 
     /**

--- a/src/extensions/scenegraph/nodes/ContentNode.ts
+++ b/src/extensions/scenegraph/nodes/ContentNode.ts
@@ -285,7 +285,11 @@ export class ContentNode extends Node {
     /** @override */
     getValues() {
         return this.getVisibleFields()
-            .sort(([keyA], [keyB]) => (keyA < keyB ? -1 : keyA > keyB ? 1 : 0))
+            .sort(([keyA], [keyB]) => {
+                if (keyA < keyB) return -1;
+                if (keyA > keyB) return 1;
+                return 0;
+            })
             .map(([, field]) => field.getValue());
     }
 

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -294,8 +294,9 @@ export class Node extends RoSGNode implements BrsValue {
      */
     getValues() {
         return Array.from(this.fields.values())
-            .sort()
-            .map((field: Field) => field.getValue());
+            .map((field: Field) => ({ field, name: field.getName().toLowerCase() }))
+            .toSorted((a, b) => a.name.localeCompare(b.name))
+            .map(({ field }) => field.getValue());
     }
 
     /**


### PR DESCRIPTION
## Summary
- `RoAssociativeArray.toString()` sorted `[key, value]` entries with a bare `.sort()`. With no comparator, JS's default sort coerces each element to a string, which calls the value's `toString()` with **no arguments** — bypassing the `parent`-based cycle guard every `toString(parent)` implementation in this codebase relies on (`if (parent) return "<Component: ...>"`). A self- or mutually-referencing associative array with two or more keys recursed forever during `print`/debug and crashed with `Maximum call stack size exceeded`.
- `roArray` and `roList` printing were unaffected (their `toString()` never sorts). SceneGraph `Node` printing was unaffected too (it already sorts by an explicit string comparator on field names).
- Fixed by sorting AA entries, and node field values, by their plain string key/name instead of letting `.sort()` implicitly stringify the value/field. Also fixed the same latent pattern in `RoAssociativeArray.getValues()`, `Node.getValues()`, and `ContentNode.getValues()`, which had the identical bug (and, in `Node.getValues()`, sorted case-sensitively unlike the rest of the file).

## Test plan
- [x] `npm run lint` / `npm run prettier` pass
- [x] `npm test` — full suite (216 files / 2765 tests) passes
- [x] Manually verified the crash is fixed and correctness is preserved:
  - Self-referencing AA (`a = {}: a.self = a: a.x = 1: print a`) — previously crashed, now prints correctly
  - Mutually-referencing AAs — previously crashed, now prints correctly
  - `roArray`/`roList`/`roSGNode` cyclic printing — unaffected, still correct
  - `AA.Values()` — still returns values in correct key order

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PELxVTSfVFC7Fnr9sy2m6g