### PR TITLE
chore(release): bump version to 2.5.2 and update changelog with baseline, packaging and stability fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
+<a name="v2.5.2"></a>
+
+## [v2.5.2 - Text Baseline, Packaging and Stability Fixes](https://github.com/lvcabral/brs-engine/releases/tag/v2.5.2) - 29 August 2026
+
+This patch release fixes single-line text sitting too close to the top of its box across every SceneGraph `Label`, grid caption, keyboard and PIN pad — text now draws against the alphabetic baseline using a font-metric constant instead of an approximation of the font's max ascent, and a related regression that clipped descenders under that constant is also fixed. Also fixes a crash on encrypted `.bpk` startup and missing `pkg:/source/*.brs` component-library scripts once decrypted, a stack overflow printing a self- or mutually-referencing associative array, and SceneGraph apps driving their main loop with `sleep()`+`getMessage()`/`peekMessage()` instead of `wait()` never rendering a frame. Read the full release notes below for more details.
+
+### Release Changes
+
+#### Core Engine
+
+* (brs) Fixed a stack overflow printing a self- or mutually-referencing associative array by [@lvcabral](https://github.com/lvcabral) in [#1201](https://github.com/lvcabral/brs-engine/pull/1201)
+* (draw2d) Center single-line text on the alphabetic baseline via a font-metric constant, fixing both top-heavy centering and descender clipping by [@lvcabral](https://github.com/lvcabral) in [#1202](https://github.com/lvcabral/brs-engine/pull/1202)
+
+#### Node.js Library and CLI
+
+* (cli) Fixed an encrypted `.bpk` startup crash and missing `pkg:/source/*.brs` component-library scripts by [@lvcabral](https://github.com/lvcabral) in [#1199](https://github.com/lvcabral/brs-engine/pull/1199)
+
+#### SceneGraph Extension (`brs-scenegraph` release v0.5.2)
+
+* (rsg) Service SceneGraph timers/rendering through `sleep()`+`getMessage()` poll loops, not just `wait()` by [@lvcabral](https://github.com/lvcabral) in [#1200](https://github.com/lvcabral/brs-engine/pull/1200)
+
+[Full Changelog][v2.5.2]
+
 <a name="v2.5.1"></a>
 
 ## [v2.5.1 - DASH/HLS Playback Fixes](https://github.com/lvcabral/brs-engine/releases/tag/v2.5.1) - 18 August 2026
@@ -1810,6 +1833,7 @@ The following is the list of components implemented (some partially or just mock
 
 [Full Changelog][v0.1.0-emu]
 
+[v2.5.2]: https://github.com/lvcabral/brs-engine/compare/v2.5.1...v2.5.2
 [v2.5.1]: https://github.com/lvcabral/brs-engine/compare/v2.5.0...v2.5.1
 [v2.5.0]: https://github.com/lvcabral/brs-engine/compare/v2.4.0...v2.5.0
 [v2.4.0]: https://github.com/lvcabral/brs-engine/compare/v2.3.0...v2.4.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brs-engine-workspace",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "brs-engine-workspace",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -14211,7 +14211,7 @@
     },
     "packages/browser": {
       "name": "brs-engine",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "license": "MIT",
       "dependencies": {
         "@lvcabral/libwebp": "^0.2.0",
@@ -14288,7 +14288,7 @@
     },
     "packages/node": {
       "name": "brs-node",
-      "version": "2.5.0",
+      "version": "2.5.2",
       "license": "MIT",
       "dependencies": {
         "@lvcabral/libwebp": "^0.2.0",
@@ -14371,7 +14371,7 @@
     },
     "packages/scenegraph": {
       "name": "brs-scenegraph",
-      "version": "0.5.0",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "p-settle": "^5.1.1",
@@ -14391,7 +14391,7 @@
         "zip-webpack-plugin": "^4.0.3"
       },
       "peerDependencies": {
-        "brs-engine": "^2.5.0"
+        "brs-engine": "^2.5.2"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brs-engine-workspace",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "private": true,
   "title": "BrightScript Simulation Engine",
   "description": "BrightScript Simulation Engine - Run Roku apps on Browsers and Node.js",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brs-engine",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "title": "BrightScript Simulation Engine",
   "description": "BrightScript Simulation Engine - Run Roku apps on Browsers and Electron",
   "author": "Marcelo Lv Cabral <marcelo@lvcabral.com> (https://lvcabral.com/)",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brs-node",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "title": "BrightScript Simulation Engine",
   "description": "BrightScript Simulation Engine - Run Roku apps on Node.js or Terminal (CLI)",
   "author": "Marcelo Lv Cabral <marcelo@lvcabral.com> (https://lvcabral.com/)",

--- a/packages/scenegraph/CHANGELOG.md
+++ b/packages/scenegraph/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to `brs-scenegraph` extension will be documented in this file.
 
+<a name="v0.5.2"></a>
+
+## [v0.5.2 (beta) - Poll-Loop Rendering Fix](https://github.com/lvcabral/brs-engine/releases/tag/brs-sg-v0.5.2) - 29 August 2026
+
+This patch release fixes SceneGraph apps that drive their main loop with `sleep()`+`getMessage()`/`peekMessage()` instead of `wait(timeout, port)` never rendering a frame — `RoSGScreen`'s port callback needs a live interpreter to service timers, animations, tasks and rendering, and it was silently getting none. Read the full release notes below for more details.
+
+### Release Changes
+
+* (rsg) Service SceneGraph timers/rendering through `sleep()`+`getMessage()` poll loops, not just `wait()` by [@lvcabral](https://github.com/lvcabral) in [#1200](https://github.com/lvcabral/brs-engine/pull/1200)
+
+[Full Changelog][v0.5.2]
+
 <a name="v0.5.1"></a>
 
 ## [v0.5.1 (beta) - Poster and TrickPlayBar Fixes](https://github.com/lvcabral/brs-engine/releases/tag/brs-sg-v0.5.1) - 19 August 2026
@@ -388,6 +400,7 @@ This first alpha delivers the **SceneGraph** runtime as a standalone extension t
   * Media + utility nodes: `Audio`, `Video`, `SoundEffect`, `Task`, `Timer`, `ChannelStore`.
 * Published merged `assets/common.zip` so SceneGraph fonts, locale data, dialogs, and imagery are available through the simulated `common:/` volume in both `brs-engine` and `brs-node` packages.
 
+[v0.5.2]: https://github.com/lvcabral/brs-engine/compare/brs-sg-v0.5.1...brs-sg-v0.5.2
 [v0.5.1]: https://github.com/lvcabral/brs-engine/compare/brs-sg-v0.5.0...brs-sg-v0.5.1
 [v0.5.0]: https://github.com/lvcabral/brs-engine/compare/brs-sg-v0.4.0...brs-sg-v0.5.0
 [v0.4.0]: https://github.com/lvcabral/brs-engine/compare/brs-sg-v0.3.0...brs-sg-v0.4.0

--- a/packages/scenegraph/package.json
+++ b/packages/scenegraph/package.json
@@ -1,6 +1,6 @@
 {
     "name": "brs-scenegraph",
-    "version": "0.5.1",
+    "version": "0.5.2",
     "description": "SceneGraph addon for BrightScript Simulation Engine",
     "author": "Marcelo Lv Cabral <marcelo@lvcabral.com> (https://lvcabral.com/)",
     "license": "MIT",
@@ -42,7 +42,7 @@
         "p-settle": "^5.1.1"
     },
     "peerDependencies": {
-        "brs-engine": "^2.5.1"
+        "brs-engine": "^2.5.2"
     },
     "devDependencies": {
         "@types/node": "^22.13.2",


### PR DESCRIPTION
## Summary
- Bumps `brs-engine`/`brs-node`/workspace root to **v2.5.2** and `brs-scenegraph` to **v0.5.2** (peer dependency updated to match).
- Updates `CHANGELOG.md` and `packages/scenegraph/CHANGELOG.md` with the changes since v2.5.1 / brs-sg-v0.5.1:
  - #1199 – encrypted `.bpk` startup crash and missing `pkg:/source/*.brs` component-library scripts
  - #1200 – SceneGraph rendering/timers not serviced through `sleep()`+`getMessage()`/`peekMessage()` poll loops
  - #1201 – stack overflow printing a self- or mutually-referencing associative array
  - #1202 – single-line text centering on the alphabetic baseline instead of an approximate font-metric offset, plus a descender-clipping fix

## Test plan
- [x] `npm run lint`
- [x] `npx vitest run` — 216 files / 2765 tests passing
- [x] `npm install --package-lock-only` to sync `package-lock.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WvHzfGgFsUViCcAgyoZsrK