### PR TITLE
feat(scenegraph): mock the remaining documented ChannelStore node commands

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -70,7 +70,7 @@ The **BrightScript Engine** implements the BrightScript language specification u
 
 * RAF (Roku Ads Framework) library that exposes `Roku_Ads` object is mocked with the most common methods available returning static values.
 * RED (Roku Event Dispatcher) and Google IMA3 libraries are also mocked.
-* Channel Store components (`ChannelStore`, `roChannelStore` and `roChannelStoreEvent`) are mocked with support for the `fakeServer()` feature.
+* Channel Store components (`ChannelStore`, `roChannelStore` and `roChannelStoreEvent`) are mocked with support for the `fakeServer()` feature: every documented command is implemented, with catalog, purchase, order and account data coming from the `csfake/*.xml` test files (or a canned account) only while `fakeServer` is enabled. The channel credential store (`storeChannelCredData`/`getChannelCred`) is the exception — it holds the app's own artifact in memory and works regardless of `fakeServer`, though the data does not persist between runs or across devices.
 * The Text to Speech components (`roAudioGuide`, `roTextToSpeech` and `roMicrophone`) and the Signing Algorithm components (`roDSA` and `roRSA`) are mocked: they expose their documented methods returning static values, but perform no real speech, recording or cryptographic signing.
 * Several components have their methods and events mocked, they return constant values to prevent crash. Those are mostly related to device behaviors that are not possible to replicate in a browser environment or simply not applicable to the engine.
 

--- a/src/core/brsTypes/components/RoChannelStore.ts
+++ b/src/core/brsTypes/components/RoChannelStore.ts
@@ -377,9 +377,12 @@ export class RoChannelStore extends BrsComponent implements BrsValue {
     private mintPartnerOrderIds() {
         const hasFixture = BrsDevice.fileSystem.existsSync("pkg:/csfake/PlaceOrder.xml");
         const fixture = hasFixture ? this.getFakeOrderData("PlaceOrder") : {};
-        // The XML parser coerces numeric-looking ids to numbers, hence String(); getFakeOrderData
-        // reports a missing file by seeding `id` with the file name, which `hasFixture` rules out.
-        this.partnerOrderId = String(fixture.id ?? "") || genHexAddress();
+        // The XML parser coerces a numeric-looking id to a number, so accept both scalar shapes and
+        // ignore anything else; getFakeOrderData reports a missing file by seeding `id` with the file
+        // name, which `hasFixture` already rules out.
+        const id = fixture.id;
+        const fixtureId = typeof id === "string" || typeof id === "number" ? String(id) : "";
+        this.partnerOrderId = fixtureId || genHexAddress();
         const items = Array.isArray(fixture.order) ? fixture.order : [];
         const first = items[0];
         const purchaseId = first instanceof RoAssociativeArray ? RoChannelStore.textField(first, "purchaseId") : "";

--- a/src/core/brsTypes/components/RoChannelStore.ts
+++ b/src/core/brsTypes/components/RoChannelStore.ts
@@ -1,15 +1,33 @@
 import { BrsValue, ValueKind, BrsString, BrsInvalid, BrsBoolean } from "../BrsType";
 import { BrsComponent } from "./BrsComponent";
-import { BrsType, RoList, RoArray, RoMessagePort, toAssociativeArray, FlexObject } from "..";
+import {
+    BrsType,
+    RoList,
+    RoArray,
+    RoMessagePort,
+    toAssociativeArray,
+    FlexObject,
+    isBrsString,
+    isAnyNumber,
+    jsValueOf,
+} from "..";
 import { Callable, StdlibArgument } from "../Callable";
 import { Interpreter } from "../../interpreter";
 import { Int32 } from "../Int32";
 import { RoChannelStoreEvent } from "../events/RoChannelStoreEvent";
 import { RoAssociativeArray } from "./RoAssociativeArray";
-import { AppData } from "../../common";
+import { AppData, genHexAddress } from "../../common";
 import { XmlDocument, XmlElement, XmlNode } from "xmldoc";
 import { IfSetMessagePort, IfGetMessagePort } from "../interfaces/IfMessagePort";
 import { BrsDevice } from "../../device/BrsDevice";
+import { v5 as uuidv5 } from "uuid";
+
+/**
+ * Payload of a mocked partner-order step (the transactional/TVOD purchase flow), keyed exactly as
+ * `ifChannelStore` documents it. The ChannelStore node publishes the same values but names the order
+ * id `orderId` rather than `id`, and renames that one key at its own edge.
+ */
+type PartnerOrderPayload = Record<string, string>;
 
 export class RoChannelStore extends BrsComponent implements BrsValue {
     readonly kind = ValueKind.Object;
@@ -17,6 +35,8 @@ export class RoChannelStore extends BrsComponent implements BrsValue {
     private readonly order: RoAssociativeArray[];
     private orderInfo: RoAssociativeArray | BrsInvalid;
     private credData: string;
+    private partnerOrderId: string;
+    private partnerPurchaseId: string;
     private fakeServerEnabled: boolean;
     private port?: RoMessagePort;
 
@@ -26,6 +46,8 @@ export class RoChannelStore extends BrsComponent implements BrsValue {
         this.order = [];
         this.orderInfo = BrsInvalid.Instance;
         this.credData = "";
+        this.partnerOrderId = "";
+        this.partnerPurchaseId = "";
         this.fakeServerEnabled = false;
         const setPortIface = new IfSetMessagePort(this);
         const getPortIface = new IfGetMessagePort(this);
@@ -60,22 +82,62 @@ export class RoChannelStore extends BrsComponent implements BrsValue {
         this.fakeServerEnabled = enable;
     }
 
-    setNewOrder(order: RoAssociativeArray[]) {
+    /**
+     * Replaces the current order (shopping cart).
+     * @param order The new order items; an empty array clears the order.
+     * @param orderInfo Order-level metadata (the ChannelStore node's top-level `action` field, i.e.
+     *                  "Upgrade"/"Downgrade"). Omit it to leave the current metadata untouched.
+     */
+    setNewOrder(order: RoAssociativeArray[], orderInfo: RoAssociativeArray | BrsInvalid = BrsInvalid.Instance) {
         this.order.length = 0;
-        if (order.length > 0) this.order.push(...order);
+        this.order.push(...order);
+        this.orderInfo =
+            this.order.length > 0 && orderInfo instanceof RoAssociativeArray ? orderInfo : BrsInvalid.Instance;
     }
 
-    setDeltaOrder(codeValue: string, qtyValue: number) {
-        for (let item of this.order) {
-            const code = item.get(new BrsString("code"));
-            const qty = item.get(new BrsString("qty"));
-            if (code instanceof BrsString && code.value === codeValue && qty instanceof Int32) {
-                item.set(new BrsString("qty"), new Int32(qty.getValue() + qtyValue));
-                return;
+    /**
+     * Applies a quantity delta to one item of the current order.
+     *
+     * A negative quantity reduces the item and removes it from the cart once its running quantity
+     * reaches zero — documented both on the node's `deltaOrder` field and on `ifChannelStore.DeltaOrder`.
+     * @param codeValue Product identifier of the item to change.
+     * @param qtyValue Quantity to add; may be negative.
+     * @returns The item's remaining quantity, or 0 when it was removed or is not in the cart.
+     */
+    setDeltaOrder(codeValue: string, qtyValue: number): number {
+        const codeKey = new BrsString("code");
+        const qtyKey = new BrsString("qty");
+        for (let index = 0; index < this.order.length; index++) {
+            const item = this.order[index];
+            const code = item.get(codeKey);
+            // Match on the code alone: an item whose `qty` is not numeric (an app can set it as a
+            // string on the order ContentNode) still has to update in place rather than be appended
+            // a second time under the same code.
+            if (!isBrsString(code) || code.getValue() !== codeValue) {
+                continue;
             }
+            const qty = item.get(qtyKey);
+            const newQty = (isAnyNumber(qty) ? jsValueOf(qty) : 0) + qtyValue;
+            if (newQty <= 0) {
+                this.order.splice(index, 1);
+                if (this.order.length === 0) this.orderInfo = BrsInvalid.Instance;
+                return 0;
+            }
+            item.set(qtyKey, new Int32(newQty));
+            return newQty;
+        }
+        // A non-positive delta on an item that is not in the cart is a no-op, not a negative line item.
+        if (qtyValue <= 0) {
+            return 0;
         }
         // Add new item to order if not already in the cart
         this.order.push(toAssociativeArray({ code: codeValue, qty: qtyValue }));
+        return qtyValue;
+    }
+
+    /** Returns a snapshot of the current order items, mirroring `ifChannelStore.GetOrder()`. */
+    getOrderItems(): RoAssociativeArray[] {
+        return [...this.order];
     }
 
     getProductData(type: string, status: { code: number; message: string }) {
@@ -90,6 +152,13 @@ export class RoChannelStore extends BrsComponent implements BrsValue {
 
     placeOrder(status: { code: number; message: string }) {
         let order: RoAssociativeArray[] = [];
+        // An empty cart can never be ordered — `DoOrder()` guards this too, but the guard has to live
+        // here as well or the fake order XML's items get reported as purchased for an empty order.
+        if (this.order.length === 0) {
+            status.code = -3;
+            status.message = "Invalid Order";
+            return order;
+        }
         status.code = 1;
         status.message = "Order Succeeded";
         const catalog = this.getFakeProductData("GetCatalog");
@@ -112,6 +181,209 @@ export class RoChannelStore extends BrsComponent implements BrsValue {
             }
         }
         return order;
+    }
+
+    /**
+     * Canned Roku account data backing the mocked user-data commands, keyed by the `requestedUserData`
+     * name (always lowercase) that yields it and holding the result fields that name expands to. The
+     * two key spaces differ: `street` yields both `street1` and `street2`, `firstname` yields
+     * `firstName`. Declared in the reference's table order so an "all" request produces stable output.
+     */
+    private static readonly fakeUserData = new Map<string, Record<string, string>>([
+        ["firstname", { firstName: "John" }],
+        ["lastname", { lastName: "Doe" }],
+        ["email", { email: "john.doe@email.com" }],
+        ["street", { street1: "1155 Coleman Ave", street2: "" }],
+        ["city", { city: "San Jose" }],
+        ["state", { state: "CA" }],
+        ["zip", { zip: "95110" }],
+        ["country", { country: "USA" }],
+        ["phone", { phone: "4085551212" }],
+        ["birth", { birth: "1970-01" }],
+        ["gender", { gender: "Male" }],
+    ]);
+
+    /** Merges the canned account data for the given request names, skipping any unknown one. */
+    private static accountFields(names: Iterable<string>): FlexObject {
+        const data: FlexObject = {};
+        for (const name of names) {
+            Object.assign(data, RoChannelStore.fakeUserData.get(name));
+        }
+        return data;
+    }
+
+    /**
+     * Mocks the account data returned by `GetUserData`/`GetPartialUserData` and by the ChannelStore
+     * node's `getUserData` command.
+     * @param requested "all" (the default) or a comma-separated list of request names.
+     * @param context "signup" (the default) or "signin"; a sign-in RFI screen lists only email/phone
+     *                and ignores any other requested attribute.
+     * @returns The account data, or `undefined` when fakeServer is disabled — callers then report the
+     *          same `invalid` a device returns when the user declines to share their information.
+     */
+    getUserAccountData(requested: string = "all", context: string = "signup"): RoAssociativeArray | undefined {
+        if (!this.fakeServerEnabled) {
+            return undefined;
+        }
+        const names =
+            requested.trim().toLowerCase() === "all"
+                ? [...RoChannelStore.fakeUserData.keys()]
+                : requested.split(",").map((name) => name.trim().toLowerCase());
+        // A sign-in RFI screen lists only email/phone; any other attribute requested is ignored.
+        const signIn = context.trim().toLowerCase() === "signin";
+        const requestNames = signIn ? names.filter((name) => name === "email" || name === "phone") : names;
+        return toAssociativeArray(RoChannelStore.accountFields(requestNames));
+    }
+
+    /**
+     * Mocks `GetUserRegionData` and the node's `getUserRegionData` command.
+     * @returns The region of the mocked account, or `undefined` when fakeServer is disabled.
+     */
+    getRegionData(): RoAssociativeArray | undefined {
+        if (!this.fakeServerEnabled) {
+            return undefined;
+        }
+        return toAssociativeArray(RoChannelStore.accountFields(["state", "zip", "country"]));
+    }
+
+    /**
+     * Mocks `StoreChannelCredData`: stores the artifact that `GetChannelCred` later returns as
+     * `channel_data`.
+     *
+     * Deliberately NOT gated on `fakeServer`, unlike the catalog/order commands: this is the Roku
+     * cloud credential store behind account linking, not a Streaming Store response, and the artifact
+     * it round-trips is the app's own. Gating it would silently discard tokens in production.
+     * @param data The artifact to store.
+     * @returns The documented `{ response, status }` payload, where `response` is a JSON *string* and
+     *          `status` is 0 on success (the inverse of the catalog/order convention).
+     */
+    storeCredData(data: string): RoAssociativeArray {
+        this.credData = data;
+        // `error_detail` is documented as uninitialized on success, so it is omitted entirely.
+        return toAssociativeArray({ response: JSON.stringify({ status: "success", error: "none" }), status: 0 });
+    }
+
+    /**
+     * Mocks `GetChannelCred` and the node's `getChannelCred` command. Not gated on `fakeServer`, for
+     * the reason given on {@link storeCredData}.
+     * @returns The documented `{ channelID, errorCode, json, publisherDeviceID, status }` payload.
+     *          `json` is built with `JSON.stringify` so the documented `ParseJson(channelCred.json)`
+     *          usage succeeds.
+     */
+    getChannelCredData(): RoAssociativeArray {
+        const app = BrsDevice.deviceInfo.appList?.find((app: AppData) => app.running);
+        const channelId = app?.id ?? "dev";
+        const deviceId = BrsDevice.deviceInfo.clientId;
+        const payload: FlexObject = {
+            // A PUCID identifies the same user and app across every device linked to one Roku
+            // account, so derive it deterministically rather than minting a fresh uuid per call.
+            roku_pucid: uuidv5(`${channelId}:${deviceId}`, uuidv5.URL),
+            token_type: "urn:roku:pucid:token_type:pucid_token",
+        };
+        // Returned only when the app actually stored something with StoreChannelCredData().
+        if (this.credData !== "") {
+            payload.channel_data = this.credData;
+        }
+        return toAssociativeArray({
+            channelID: channelId,
+            errorCode: "",
+            json: JSON.stringify(payload),
+            publisherDeviceID: deviceId,
+            status: 0,
+        });
+    }
+
+    /**
+     * Mocks `RequestPartnerOrder`: the billing check that must precede a partner order confirmation.
+     * A successful check remembers its order id so `confirmPartnerOrderData` can validate it.
+     * @param orderInfo The order details; expected to be an associative array.
+     * @param productId The product identifier, when supplied separately from `orderInfo`.
+     * @returns The check result. Every failure code here is an engine choice, not a device
+     *          measurement; they reuse the node's documented status table (-1 unavailable,
+     *          -3 order error, -4 invalid request).
+     */
+    requestPartnerOrderData(orderInfo: BrsType, productId: string): PartnerOrderPayload {
+        if (!this.fakeServerEnabled) {
+            return RoChannelStore.partnerOrderFailure("-1", "fakeServer is not enabled");
+        }
+        if (!(orderInfo instanceof RoAssociativeArray)) {
+            return RoChannelStore.partnerOrderFailure("-4", "Invalid request");
+        }
+        const code = productId.trim() || RoChannelStore.textField(orderInfo, "code");
+        if (code === "") {
+            return RoChannelStore.partnerOrderFailure("-4", "Missing required order field: code");
+        }
+        const price = RoChannelStore.textField(orderInfo, "price");
+        if (price === "") {
+            return RoChannelStore.partnerOrderFailure("-4", "Missing required order field: price");
+        }
+        this.mintPartnerOrderIds();
+        // Prices carry no currency symbol, matching the documented convention for the request fields.
+        return { id: this.partnerOrderId, status: "Success", tax: "0.00", total: price };
+    }
+
+    /**
+     * Mocks `ConfirmPartnerOrder`, the transactional-purchase equivalent of `DoOrder`.
+     * @param orderInfo The confirmation details; must carry the `orderId` from the preceding check.
+     * @param productId The product identifier, when supplied separately from `orderInfo`.
+     * @returns The confirmation payload; fails unless a matching billing check ran first.
+     */
+    confirmPartnerOrderData(orderInfo: BrsType, productId: string): PartnerOrderPayload {
+        if (!this.fakeServerEnabled) {
+            return RoChannelStore.partnerOrderFailure("-1", "fakeServer is not enabled");
+        }
+        if (!(orderInfo instanceof RoAssociativeArray)) {
+            return RoChannelStore.partnerOrderFailure("-4", "Invalid request");
+        }
+        if (this.partnerOrderId === "") {
+            return RoChannelStore.partnerOrderFailure("-3", "requestPartnerOrder must be called first");
+        }
+        if (RoChannelStore.textField(orderInfo, "orderId") !== this.partnerOrderId) {
+            return RoChannelStore.partnerOrderFailure("-3", "Order ID mismatch");
+        }
+        const purchaseId = this.partnerPurchaseId;
+        // An order id is single use: confirming again requires a fresh billing check.
+        this.partnerOrderId = "";
+        this.partnerPurchaseId = "";
+        return { purchaseId, status: "Success" };
+    }
+
+    /** Builds a failed partner-order payload with the documented error keys populated. */
+    private static partnerOrderFailure(errorCode: string, errorMessage: string): PartnerOrderPayload {
+        return { errorCode, errorMessage, status: "Failure" };
+    }
+
+    /**
+     * Reads an entry off an associative array as text, returning "" when it is absent.
+     * A numeric value is accepted: the fields read this way are only ever compared and echoed as
+     * strings, so rejecting the number the XML parser produces would fail a valid order.
+     */
+    private static textField(source: RoAssociativeArray, name: string): string {
+        const value = source.get(new BrsString(name));
+        if (isBrsString(value)) {
+            return value.getValue().trim();
+        }
+        return isAnyNumber(value) ? jsValueOf(value).toString() : "";
+    }
+
+    /**
+     * Mints the pair of ids a partner order reports, from a single read of `csfake/PlaceOrder.xml`.
+     *
+     * Both come from that one fixture, so they are derived together: reading it again at confirm time
+     * would re-stat, re-read and re-parse the same file for one more string. Taking the ids from the
+     * fixture (rather than generating them) is what keeps test output deterministic; with no fixture
+     * present, fall back to the engine's unique-id helper.
+     */
+    private mintPartnerOrderIds() {
+        const hasFixture = BrsDevice.fileSystem.existsSync("pkg:/csfake/PlaceOrder.xml");
+        const fixture = hasFixture ? this.getFakeOrderData("PlaceOrder") : {};
+        // The XML parser coerces numeric-looking ids to numbers, hence String(); getFakeOrderData
+        // reports a missing file by seeding `id` with the file name, which `hasFixture` rules out.
+        this.partnerOrderId = String(fixture.id ?? "") || genHexAddress();
+        const items = Array.isArray(fixture.order) ? fixture.order : [];
+        const first = items[0];
+        const purchaseId = first instanceof RoAssociativeArray ? RoChannelStore.textField(first, "purchaseId") : "";
+        this.partnerPurchaseId = purchaseId || `${this.partnerOrderId}-1`;
     }
 
     getAttestationToken() {
@@ -270,16 +542,19 @@ ZZwGPYCKEHMPrIOOXJ-S9ZjArgaEpBUpMXWJibFxnkpVUVzbC22GEaqz_SjOJXFMQU7TaCKkDeCYVKyl
     }
 
     private isValidProductOrder(catalog: RoAssociativeArray[], item: RoAssociativeArray) {
+        // Order items assembled from a ContentNode hold BOXED values (`roString`/`roInt`), because
+        // that is what `addFields` stores — so match on the unwrapped value, never on `instanceof`.
         const qty = item.get(new BrsString("qty"));
-        if (qty instanceof Int32 && qty.getValue() <= 0) {
+        if (isAnyNumber(qty) && jsValueOf(qty) <= 0) {
+            return false;
+        }
+        const orderCode = item.get(new BrsString("code"));
+        if (!isBrsString(orderCode)) {
             return false;
         }
         return catalog.some((prod) => {
             const prodCode = prod.get(new BrsString("code"));
-            const orderCode = item.get(new BrsString("code"));
-            return (
-                prodCode instanceof BrsString && orderCode instanceof BrsString && prodCode.value === orderCode.value
-            );
+            return isBrsString(prodCode) && prodCode.getValue() === orderCode.getValue();
         });
     }
 
@@ -371,12 +646,8 @@ ZZwGPYCKEHMPrIOOXJ-S9ZjArgaEpBUpMXWJibFxnkpVUVzbC22GEaqz_SjOJXFMQU7TaCKkDeCYVKyl
         },
         impl: (_: Interpreter, order: BrsComponent, orderInfo: RoAssociativeArray | BrsInvalid) => {
             if (order instanceof RoList || order instanceof RoArray) {
-                this.setNewOrder(order.getElements().filter((item) => item instanceof RoAssociativeArray));
-                if (this.order.length > 0 && orderInfo instanceof RoAssociativeArray) {
-                    this.orderInfo = orderInfo;
-                } else {
-                    this.orderInfo = BrsInvalid.Instance;
-                }
+                const items = order.getElements().filter((item) => item instanceof RoAssociativeArray);
+                this.setNewOrder(items, orderInfo);
             }
             return BrsInvalid.Instance;
         },
@@ -389,8 +660,7 @@ ZZwGPYCKEHMPrIOOXJ-S9ZjArgaEpBUpMXWJibFxnkpVUVzbC22GEaqz_SjOJXFMQU7TaCKkDeCYVKyl
             returns: ValueKind.Void,
         },
         impl: (_: Interpreter) => {
-            this.order.length = 0;
-            this.orderInfo = BrsInvalid.Instance;
+            this.setNewOrder([], BrsInvalid.Instance);
             return BrsInvalid.Instance;
         },
     });
@@ -402,8 +672,7 @@ ZZwGPYCKEHMPrIOOXJ-S9ZjArgaEpBUpMXWJibFxnkpVUVzbC22GEaqz_SjOJXFMQU7TaCKkDeCYVKyl
             returns: ValueKind.Int32,
         },
         impl: (_: Interpreter, code: BrsString, qty: Int32) => {
-            this.setDeltaOrder(code.value, qty.getValue());
-            return new Int32(this.order.length);
+            return new Int32(this.setDeltaOrder(code.value, qty.getValue()));
         },
     });
 
@@ -428,12 +697,10 @@ ZZwGPYCKEHMPrIOOXJ-S9ZjArgaEpBUpMXWJibFxnkpVUVzbC22GEaqz_SjOJXFMQU7TaCKkDeCYVKyl
             if (!this.port) {
                 return BrsBoolean.False;
             }
+            // placeOrder rejects an empty cart itself; the fakeServer check has to stay here, or with
+            // fakeServer off but a csfake/ folder present it would report "Invalid Product Order".
             const status = { code: -3, message: "Invalid Order" };
-            if (!this.fakeServerEnabled || this.order.length === 0) {
-                this.port.pushMessage(new RoChannelStoreEvent(this.id, [], status));
-                return BrsBoolean.False;
-            }
-            const order = this.placeOrder(status);
+            const order = this.fakeServerEnabled ? this.placeOrder(status) : [];
             this.port.pushMessage(new RoChannelStoreEvent(this.id, order, status));
             return BrsBoolean.from(status.code === 1);
         },
@@ -458,7 +725,7 @@ ZZwGPYCKEHMPrIOOXJ-S9ZjArgaEpBUpMXWJibFxnkpVUVzbC22GEaqz_SjOJXFMQU7TaCKkDeCYVKyl
             returns: ValueKind.Object,
         },
         impl: (_: Interpreter) => {
-            return BrsInvalid.Instance;
+            return this.getUserAccountData() ?? BrsInvalid.Instance;
         },
     });
 
@@ -469,18 +736,23 @@ ZZwGPYCKEHMPrIOOXJ-S9ZjArgaEpBUpMXWJibFxnkpVUVzbC22GEaqz_SjOJXFMQU7TaCKkDeCYVKyl
             returns: ValueKind.Object,
         },
         impl: (_: Interpreter) => {
-            return toAssociativeArray({ state: "", zip: "", country: "" });
+            return this.getRegionData() ?? toAssociativeArray({ state: "", zip: "", country: "" });
         },
     });
 
     /** Provides a way to request user authorization to share his account information with the calling channel. */
     private readonly getPartialUserData = new Callable("getPartialUserData", {
         signature: {
-            args: [new StdlibArgument("properties", ValueKind.String)],
+            args: [
+                new StdlibArgument("properties", ValueKind.String),
+                new StdlibArgument("requestInfo", ValueKind.Object, BrsInvalid.Instance),
+            ],
             returns: ValueKind.Object,
         },
-        impl: (_: Interpreter, properties: BrsString) => {
-            return BrsInvalid.Instance;
+        impl: (_: Interpreter, properties: BrsString, requestInfo: BrsType) => {
+            const context =
+                requestInfo instanceof RoAssociativeArray ? RoChannelStore.textField(requestInfo, "context") : "";
+            return this.getUserAccountData(properties.value, context || "signup") ?? BrsInvalid.Instance;
         },
     });
 
@@ -491,8 +763,7 @@ ZZwGPYCKEHMPrIOOXJ-S9ZjArgaEpBUpMXWJibFxnkpVUVzbC22GEaqz_SjOJXFMQU7TaCKkDeCYVKyl
             returns: ValueKind.Object,
         },
         impl: (_: Interpreter, data: BrsString) => {
-            this.credData = data.value;
-            return toAssociativeArray({ status: 0 });
+            return this.storeCredData(data.value);
         },
     });
 
@@ -503,20 +774,7 @@ ZZwGPYCKEHMPrIOOXJ-S9ZjArgaEpBUpMXWJibFxnkpVUVzbC22GEaqz_SjOJXFMQU7TaCKkDeCYVKyl
             returns: ValueKind.Object,
         },
         impl: (_: Interpreter) => {
-            let json = "";
-            let status = 400;
-            if (this.credData !== "") {
-                json = `{channel_data="${this.credData}"}`;
-                status = 0;
-            }
-            const app = BrsDevice.deviceInfo.appList?.find((app: AppData) => app.running);
-            const channelCred = {
-                channelId: app?.id ?? "dev",
-                json: json,
-                publisherDeviceId: BrsDevice.deviceInfo.clientId,
-                status: status,
-            };
-            return toAssociativeArray(channelCred);
+            return this.getChannelCredData();
         },
     });
 
@@ -541,7 +799,7 @@ ZZwGPYCKEHMPrIOOXJ-S9ZjArgaEpBUpMXWJibFxnkpVUVzbC22GEaqz_SjOJXFMQU7TaCKkDeCYVKyl
             returns: ValueKind.Object,
         },
         impl: (_: Interpreter, orderInfo: RoAssociativeArray, productId: BrsString) => {
-            return toAssociativeArray({ errorCode: -1, errorMessage: "", status: "Failure" });
+            return toAssociativeArray(this.requestPartnerOrderData(orderInfo, productId.value));
         },
     });
 
@@ -555,7 +813,7 @@ ZZwGPYCKEHMPrIOOXJ-S9ZjArgaEpBUpMXWJibFxnkpVUVzbC22GEaqz_SjOJXFMQU7TaCKkDeCYVKyl
             returns: ValueKind.Object,
         },
         impl: (_: Interpreter, confirmOrderInfo: RoAssociativeArray, productId: BrsString) => {
-            return toAssociativeArray({ errorCode: -1, errorMessage: "", status: "Failure" });
+            return toAssociativeArray(this.confirmPartnerOrderData(confirmOrderInfo, productId.value));
         },
     });
 }

--- a/src/extensions/scenegraph/factory/Serializer.ts
+++ b/src/extensions/scenegraph/factory/Serializer.ts
@@ -1136,8 +1136,12 @@ export function toContentNode(associativeArray: RoAssociativeArray): ContentNode
 export function fromContentNode(contentNode: ContentNode): RoAssociativeArray {
     const result: RoAssociativeArray = new RoAssociativeArray([], true);
 
-    for (const [key, value] of contentNode.getNodeFields()) {
-        result.set(new BrsString(key), value.getValue(false));
+    // Keyed by the field's DECLARED name, not the lowercased map key: the array is case-sensitive, so
+    // taking the map key would strip the casing an app declared (`priceDisplay` -> `pricedisplay`) and
+    // force every consumer to read back through a case-insensitive lookup. This matches how the base
+    // `Node.getElements`/`getNodeFieldsAsAA` already expose field names.
+    for (const field of contentNode.getNodeFields().values()) {
+        result.set(new BrsString(field.getName()), field.getValue(false));
     }
 
     return result;

--- a/src/extensions/scenegraph/nodes/ChannelStore.ts
+++ b/src/extensions/scenegraph/nodes/ChannelStore.ts
@@ -139,16 +139,17 @@ export class ChannelStore extends Node {
         const current = this.getValue("order");
         const order = current instanceof ContentNode ? current : new ContentNode();
         const children = order.getNodeChildren();
-        const index = children.findIndex(
-            (child) => child instanceof ContentNode && ChannelStore.textOf(child.getValue("code")) === code
+        const existing = children.find(
+            (child): child is ContentNode =>
+                child instanceof ContentNode && ChannelStore.textOf(child.getValue("code")) === code
         );
         if (quantity <= 0) {
             // Also the "non-positive delta on an item that was never in the cart" case, hence the guard.
-            if (index >= 0) {
-                order.removeChildrenAtIndex(index, 1);
+            if (existing) {
+                order.removeChildrenAtIndex(children.indexOf(existing), 1);
             }
-        } else if (children[index] instanceof ContentNode) {
-            (children[index] as ContentNode).setValue("qty", new Int32(quantity));
+        } else if (existing) {
+            existing.setValue("qty", new Int32(quantity));
         } else {
             order.appendChildToParent(toContentNode(toAssociativeArray({ code: code, qty: quantity })));
         }

--- a/src/extensions/scenegraph/nodes/ChannelStore.ts
+++ b/src/extensions/scenegraph/nodes/ChannelStore.ts
@@ -5,15 +5,14 @@ import {
     BrsString,
     BrsType,
     Int32,
-    isBrsBoolean,
-    isNumberComp,
+    isAnyNumber,
     isBrsString,
     RoAssociativeArray,
     RoChannelStore,
 } from "brs-engine";
 import { Node } from "./Node";
 import { ContentNode } from "./ContentNode";
-import { jsValueOf, fromContentNode, toContentNode } from "../factory/Serializer";
+import { jsValueOf, fromContentNode, toContentNode, toAssociativeArray } from "../factory/Serializer";
 import { FieldKind, FieldModel } from "../SGTypes";
 import { SGNodeType } from ".";
 
@@ -37,8 +36,18 @@ export class ChannelStore extends Node {
         { name: "fakeServer", type: "boolean", value: "false" },
         { name: "nonce", type: "string" },
         { name: "deviceAttestationToken", type: "node", alwaysNotify: true },
+        { name: "channelCredData", type: "string" },
+        // The reference documents this one result as an roAssociativeArray while every other result
+        // field on this node (`channelCred` included) is a ContentNode — keep that asymmetry.
+        { name: "storeChannelCredDataStatus", type: "assocarray", alwaysNotify: true },
+        { name: "channelCred", type: "node", alwaysNotify: true },
     ];
 
+    /**
+     * Backing store for every command. Deliberately thread-local: it is a plain property rather than
+     * a field, so it never crosses a thread boundary — {@link handleCommand} re-derives the request
+     * state it needs from this node's own fields instead of relying on state pushed into it.
+     */
     private readonly channelStore: RoChannelStore;
 
     constructor(members: AAMember[] = [], readonly name: string = SGNodeType.ChannelStore) {
@@ -52,22 +61,10 @@ export class ChannelStore extends Node {
 
     setValue(index: string, value: BrsType, alwaysNotify?: boolean, kind?: FieldKind) {
         const fieldName = index.toLowerCase();
-        if (fieldName === "order") {
-            const order: RoAssociativeArray[] = [];
-            if (value instanceof ContentNode) {
-                order.push(fromContentNode(value));
-            }
-            this.channelStore.setNewOrder(order);
-        } else if (fieldName === "deltaorder") {
-            if (value instanceof RoAssociativeArray) {
-                const delta = value.get(new BrsString("delta"));
-                const qty = value.get(new BrsString("qty"));
-                if (isBrsString(delta) && isNumberComp(qty)) {
-                    this.channelStore.setDeltaOrder(delta.getValue(), jsValueOf(qty));
-                }
-            }
-        } else if (fieldName === "fakeServer".toLowerCase() && isBrsBoolean(value)) {
-            this.channelStore.setFakeServer(value.toBoolean());
+        if (fieldName === "deltaorder") {
+            // Intercepted before `super`: unlike every other input this is an incremental mutation
+            // of the order, not a snapshot of it.
+            this.applyDeltaOrder(value);
         }
         super.setValue(index, value, alwaysNotify, kind);
         if (fieldName === "command" && isBrsString(value) && value.getValue() !== "") {
@@ -75,12 +72,118 @@ export class ChannelStore extends Node {
         }
     }
 
+    /**
+     * Mirrors the `order` field's ContentNode tree into the backing store.
+     *
+     * The reference puts one child per line item on the order node, while the top node carries only
+     * order-level metadata (`action` = "Upgrade"/"Downgrade", which maps to the component's
+     * `orderInfo`). A childless node is still accepted as a single-item order — that is a legitimate
+     * shape and the one this node used to convert. Setting the field to `invalid` clears the order.
+     * @param value The new value of the `order` field.
+     */
+    private syncOrderFromNode(value: BrsType) {
+        if (!(value instanceof ContentNode)) {
+            this.channelStore.setNewOrder([], BrsInvalid.Instance);
+            return;
+        }
+        const items: RoAssociativeArray[] = [];
+        for (const child of value.getNodeChildren()) {
+            if (child instanceof ContentNode) {
+                items.push(fromContentNode(child));
+            }
+        }
+        const top = fromContentNode(value);
+        if (items.length === 0 && ChannelStore.stringField(top, "code") !== "") {
+            items.push(top);
+        }
+        const hasAction = ChannelStore.stringField(top, "action") !== "";
+        this.channelStore.setNewOrder(items, hasAction ? top : BrsInvalid.Instance);
+    }
+
+    /**
+     * Applies a `deltaOrder` write, then publishes the changed line item back to the `order` field.
+     *
+     * The reference documents the associative array as `{ code, qty }`; `delta` is tolerated as a
+     * legacy spelling of the product code. A negative quantity reduces the item and removes it at 0.
+     * @param value The new value of the `deltaOrder` field.
+     */
+    private applyDeltaOrder(value: BrsType) {
+        if (!(value instanceof RoAssociativeArray)) {
+            return;
+        }
+        let code = ChannelStore.stringField(value, "code");
+        if (code === "") {
+            code = ChannelStore.stringField(value, "delta");
+        }
+        const qty = value.get(new BrsString("qty"));
+        if (code === "" || !isAnyNumber(qty)) {
+            return;
+        }
+        this.syncOrderFromNode(this.getValue("order"));
+        this.publishDeltaItem(code, this.channelStore.setDeltaOrder(code, jsValueOf(qty)));
+    }
+
+    /**
+     * Applies one line-item change to the `order` field, so an order assembled incrementally through
+     * `deltaOrder` reads back as the reference describes: a top node with one child per line item.
+     *
+     * Touches only the item that changed, rather than rebuilding the whole list. Rebuilding would
+     * discard the top node the app holds a reference to (along with its order-level `action`), and
+     * would fire one observer notification per surviving item — quadratic in the number of writes it
+     * takes to fill a cart. One write means one notification, which is what "each time this field is
+     * set, the order field is modified" describes.
+     * @param code Product identifier of the changed line item.
+     * @param quantity Its remaining quantity; 0 means it is no longer in the order.
+     */
+    private publishDeltaItem(code: string, quantity: number) {
+        const current = this.getValue("order");
+        const order = current instanceof ContentNode ? current : new ContentNode();
+        const children = order.getNodeChildren();
+        const index = children.findIndex(
+            (child) => child instanceof ContentNode && ChannelStore.textOf(child.getValue("code")) === code
+        );
+        if (quantity <= 0) {
+            // Also the "non-positive delta on an item that was never in the cart" case, hence the guard.
+            if (index >= 0) {
+                order.removeChildrenAtIndex(index, 1);
+            }
+        } else if (children[index] instanceof ContentNode) {
+            (children[index] as ContentNode).setValue("qty", new Int32(quantity));
+        } else {
+            order.appendChildToParent(toContentNode(toAssociativeArray({ code: code, qty: quantity })));
+        }
+        if (current !== order) {
+            this.setValueSilent("order", order);
+        }
+    }
+
+    /** Reads a string entry off an associative array, returning "" when absent or not a string. */
+    private static stringField(source: RoAssociativeArray, name: string): string {
+        return ChannelStore.textOf(source.get(new BrsString(name)));
+    }
+
+    /** Reads a BrightScript value as trimmed text, returning "" when it is not a string. */
+    private static textOf(value: BrsType): string {
+        return isBrsString(value) ? value.getValue().trim() : "";
+    }
+
     private handleCommand(command: string) {
+        // The backing store holds no authoritative state of its own: every command derives what it
+        // needs from this node's own fields. That matters because `setValueSilent` writes a field
+        // WITHOUT going through setValue() above — a cross-thread copy (Serializer's
+        // `toSGNode`/`updateSGNode`), a Task read-reply, an XML `<interface>` default and
+        // `appendNodeFields` all take that path, so anything pushed from setValue() may be stale.
+        this.channelStore.setFakeServer(this.getValueJS("fakeServer") === true);
+
         switch (command) {
             case "getuserdata":
-            case "getuserregiondata":
-                this.setUserData(command, command === "getuserdata" ? "userData" : "userRegionData");
+                this.setUserData();
                 break;
+            case "getuserregiondata": {
+                const region = this.channelStore.getRegionData();
+                super.setValue("userRegionData", region ? toContentNode(region) : BrsInvalid.Instance);
+                break;
+            }
             case "getcatalog":
             case "getstorecatalog":
                 this.setStoreData("GetCatalog", command === "getcatalog" ? "catalog" : "storeCatalog");
@@ -90,6 +193,9 @@ export class ChannelStore extends Node {
                 this.setStoreData("GetPurchases", "purchases");
                 break;
             case "doorder":
+                // The only command that reads the order, so it is the only one that has to re-derive
+                // it from the field (see the note above on `setValueSilent`).
+                this.syncOrderFromNode(this.getValue("order"));
                 this.doOrder();
                 break;
             case "getdeviceattestationtoken": {
@@ -100,10 +206,46 @@ export class ChannelStore extends Node {
                 super.setValue("deviceAttestationToken", result);
                 break;
             }
+            case "storechannelcreddata": {
+                const data = (this.getValueJS("channelCredData") as string) ?? "";
+                super.setValue("storeChannelCredDataStatus", this.channelStore.storeCredData(data));
+                break;
+            }
+            case "getchannelcred": {
+                super.setValue("channelCred", toContentNode(this.channelStore.getChannelCredData()));
+                break;
+            }
+            case "requestpartnerorder":
+                this.setPartnerOrderStatus("requestPartnerOrder");
+                break;
+            case "confirmpartnerorder":
+                this.setPartnerOrderStatus("confirmPartnerOrder");
+                break;
             default:
                 BrsDevice.stderr.write(`warning,[ChannelStore] Invalid or unhandled 'command': ${command}`);
                 break;
         }
+    }
+
+    /**
+     * Runs one of the two partner-order (transactional purchase) commands and publishes its payload to
+     * the matching status field.
+     * @param command The request field to read; its result field is that name plus "Status".
+     */
+    private setPartnerOrderStatus(command: "requestPartnerOrder" | "confirmPartnerOrder") {
+        const request = this.getValue(command);
+        const orderInfo = request instanceof ContentNode ? fromContentNode(request) : BrsInvalid.Instance;
+        const productId = orderInfo instanceof RoAssociativeArray ? ChannelStore.stringField(orderInfo, "code") : "";
+        const payload =
+            command === "requestPartnerOrder"
+                ? this.channelStore.requestPartnerOrderData(orderInfo, productId)
+                : this.channelStore.confirmPartnerOrderData(orderInfo, productId);
+        const status = new ContentNode();
+        for (const [key, value] of Object.entries(payload)) {
+            // `ifChannelStore` names the order id `id`; this node names the same value `orderId`.
+            status.setValueSilent(key === "id" ? "orderId" : key, new BrsString(value));
+        }
+        super.setValue(`${command}Status`, status);
     }
 
     private setStoreData(command: string, field: string) {
@@ -118,26 +260,21 @@ export class ChannelStore extends Node {
         super.setValue(field, result);
     }
 
-    private setUserData(command: string, field: string) {
-        const result = new ContentNode();
-        const fakeServer = this.getValueJS("fakeServer") as boolean;
-        if (!fakeServer) {
-            super.setValue(field, BrsInvalid.Instance);
-            return;
-        }
-        if (command === "getuserdata") {
-            result.setValueSilent("email", new BrsString("johm.doe@email.com"));
-            result.setValueSilent("firstName", new BrsString("John"));
-            result.setValueSilent("lastName", new BrsString("Doe"));
-            result.setValueSilent("gender", new BrsString("Male"));
-            result.setValueSilent("birth", new BrsString("1970-01"));
-            result.setValueSilent("phone", BrsInvalid.Instance);
-        } else if (fakeServer && command === "getuserregiondata") {
-            result.setValueSilent("state", new BrsString("CA"));
-            result.setValueSilent("zip", new BrsString("90210"));
-            result.setValueSilent("country", new BrsString("USA"));
-        }
-        super.setValue(field, result);
+    /**
+     * Runs `getUserData` and publishes the result.
+     *
+     * Honors both documented inputs: `requestedUserData` selects which account attributes come back,
+     * and `requestedUserDataInfo.context` distinguishes a sign-up request from a sign-in one (which
+     * only ever returns email/phone). Its `forceShowData` sibling is intentionally inert — it only
+     * affects how the on-device Request For Information screen is drawn.
+     */
+    private setUserData() {
+        // Both inputs are app-set fields that may hold any type, so read them as text.
+        const requested = ChannelStore.textOf(this.getValue("requestedUserData")) || "all";
+        const info = this.getValue("requestedUserDataInfo");
+        const context = info instanceof Node ? ChannelStore.textOf(info.getValue("context")) : "";
+        const data = this.channelStore.getUserAccountData(requested, context || "signup");
+        super.setValue("userData", data ? toContentNode(data) : BrsInvalid.Instance);
     }
 
     private doOrder() {

--- a/test/cli/cli-scenegraph.test.js
+++ b/test/cli/cli-scenegraph.test.js
@@ -1423,4 +1423,107 @@ describe.concurrent("cli scenegraph", () => {
             "",
         ]);
     }, 30000);
+
+    it("Mocks every documented ChannelStore node command against the fakeServer data", async () => {
+        let command = ["node", brsCliPath, "-r channelstore-node-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        // Covers the whole command surface documented for the ChannelStore node. Values that come
+        // from a generated id are asserted as "present"/"matches" rather than literally, so the test
+        // does not pin an id; everything else is pinned by csfake/*.xml or the canned account table.
+        //
+        // deltaOrder: the reference spells the associative array { code, qty } (NOT { delta, qty }),
+        // each write republishes the `order` field, and a negative qty removes the line item.
+        // order: one child per line item, with `action` on the top node as order-level metadata.
+        // getUserData: `requestedUserData` selects attributes and a "signin" context narrows the
+        // result to email/phone only.
+        // Republishing keeps the app's own order node and its order-level `action`, and a cart
+        // emptied by a negative quantity cannot be ordered.
+        // getChannelCred: `json` must be real JSON, since the documented usage is ParseJson() on it;
+        // `channel_data` appears only after storeChannelCredData ran.
+        // confirmPartnerOrder must fail without a preceding requestPartnerOrder billing check.
+        // Without fakeServer the store-backed commands report their documented failure payload, but
+        // the credential store still works — it holds the app's own artifact, not a mocked store
+        // response, and a production app never enables fakeServer.
+        // The negative-qty semantics and the individual errorCode values are engine choices, not
+        // device measurements — a device probe may legitimately overturn them.
+        //
+        // The lowercased "fields:" names (firstname/lastname, where a device reports firstName/lastName)
+        // are a KNOWN engine deviation, not the behavior under test: `ContentNode.getElements` returns
+        // the field map's lowercased key rather than the declared field name. The unit suite asserts the
+        // documented casing at the associative-array layer. If `getElements` is ever fixed, update these
+        // two lines rather than assuming the change broke something.
+        expect(stdout.split("\n").map((line) => line.trimEnd())).toEqual([
+            "=== ChannelStore Node Test ===",
+            "-- deltaOrder --",
+            "order children: 2",
+            "  item: TCSMS1 qty=1",
+            "  item: TS1 qty=3",
+            "after remove: 1",
+            "  item: TCSMS1 qty=1",
+            "-- order children --",
+            "orderStatus: 1 Order Succeeded",
+            "  purchased: TS1 $1.99",
+            "  purchased: SKUTAX $0.00",
+            "-- order republish --",
+            "same node: true",
+            "action kept: Upgrade",
+            "  item: TS1 qty=1",
+            "  item: TCSMS1 qty=1",
+            "empty cart children: 0",
+            "empty cart order: -3 Invalid Order",
+            "empty cart items: 0",
+            "-- getUserData (all) --",
+            "firstName: John",
+            "email: john.doe@email.com",
+            "street1: 1155 Coleman Ave",
+            "gender: Male",
+            "fields: birth,city,country,email,firstname,gender,lastname,phone,state,street1,street2,zip",
+            "-- getUserData (email,firstname) --",
+            "fields: email,firstname",
+            "-- getUserData (signin context) --",
+            "fields: email",
+            "-- getUserRegionData --",
+            "region: CA 95110 USA",
+            "-- storeChannelCredData --",
+            "status: 0",
+            "response.status: success",
+            "response.error: none",
+            "-- getChannelCred --",
+            "channelID: dev",
+            "status: 0",
+            "errorCode is empty: true",
+            "json parses: true",
+            "token_type: urn:roku:pucid:token_type:pucid_token",
+            "channel_data: test app cred data",
+            "pucid present: true",
+            "-- getChannelCred (nothing stored) --",
+            "channel_data present: false",
+            "pucid present: true",
+            "-- requestPartnerOrder --",
+            "status: Success",
+            "tax: 0.00",
+            "total matches price: true",
+            "orderId present: true",
+            "-- confirmPartnerOrder --",
+            "status: Success",
+            "purchaseId present: true",
+            "-- confirmPartnerOrder without request --",
+            "status: Failure",
+            "errorCode: -3",
+            "-- fakeServer off --",
+            "userData invalid: true",
+            "storeChannelCredDataStatus.status: 0",
+            "channelCred.status: 0",
+            "channelCred.channel_data: prod token",
+            "requestPartnerOrderStatus.status: Failure",
+            "requestPartnerOrderStatus.errorCode: -1",
+            "=== ChannelStore Node Test Complete ===",
+            "------ Finished 'main.brs' execution [EXIT_USER_NAV] ------",
+            "",
+            "",
+        ]);
+    }, 30000);
 });

--- a/test/cli/resources/channelstore-node-app/components/MainScene.xml
+++ b/test/cli/resources/channelstore-node-app/components/MainScene.xml
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Exercises every command documented for the ChannelStore node against its fakeServer mock: the
+    order/deltaOrder inputs, getUserData's attribute filtering, the channel-credential pair, and the
+    partner-order (transactional purchase) pair. All of these complete synchronously when `command` is
+    assigned, so the results are read back on the next statement; `orderStatus` is read through an
+    observer instead, to prove the result fields still notify.
+-->
+<component name="MainScene" extends="Scene">
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        runDeltaOrder()
+        runOrderWithChildren()
+        runOrderRepublish()
+        runUserData()
+        runChannelCred()
+        runPartnerOrder()
+        runFakeServerOff()
+    end sub
+
+    function newStore(fake as boolean) as object
+        store = createObject("roSGNode", "ChannelStore")
+        store.fakeServer = fake
+        return store
+    end function
+
+    sub printOrder(order as object)
+        for i = 0 to order.getChildCount() - 1
+            item = order.getChild(i)
+            print "  item: " + item.code + " qty=" + item.qty.toStr()
+        end for
+    end sub
+
+    ' Lists a result node's own fields, skipping the base Node ones every node carries, so the
+    ' output shows only which account attributes the request actually returned.
+    function joinKeys(node as object) as string
+        baseFields = { change: true, focusable: true, focusedchild: true, id: true }
+        result = ""
+        for each key in node.keys()
+            if baseFields[key] = invalid
+                if result <> "" then result = result + ","
+                result = result + key
+            end if
+        end for
+        return result
+    end function
+
+    ' `deltaOrder` builds the order incrementally and republishes it, and a negative quantity
+    ' removes the line item.
+    sub runDeltaOrder()
+        print "-- deltaOrder --"
+        store = newStore(true)
+        store.deltaOrder = { code: "TCSMS1", qty: 1 }
+        store.deltaOrder = { code: "TS1", qty: 2 }
+        store.deltaOrder = { code: "TS1", qty: 1 }
+        print "order children: " + store.order.getChildCount().toStr()
+        printOrder(store.order)
+        store.deltaOrder = { code: "TS1", qty: -3 }
+        print "after remove: " + store.order.getChildCount().toStr()
+        printOrder(store.order)
+    end sub
+
+    ' An order carries one child per line item, and `action` on the top node is order metadata.
+    sub runOrderWithChildren()
+        print "-- order children --"
+        store = newStore(true)
+        store.observeFieldScoped("orderStatus", "onOrderStatus")
+        order = createObject("roSGNode", "ContentNode")
+        order.addFields({ action: "Upgrade" })
+        item = createObject("roSGNode", "ContentNode")
+        item.addFields({ code: "TS1", qty: 1 })
+        order.appendChild(item)
+        store.order = order
+        store.command = "doOrder"
+    end sub
+
+    sub onOrderStatus(event as object)
+        status = event.getData()
+        print "orderStatus: " + status.status.toStr() + " " + status.message
+        for i = 0 to status.getChildCount() - 1
+            purchased = status.getChild(i)
+            print "  purchased: " + purchased.code + " " + purchased.total
+        end for
+    end sub
+
+    ' Republishing the order after a deltaOrder write keeps the app's own node and its order-level
+    ' `action`, and a cart emptied by a negative quantity cannot be ordered.
+    sub runOrderRepublish()
+        print "-- order republish --"
+        store = newStore(true)
+        order = createObject("roSGNode", "ContentNode")
+        order.addFields({ action: "Upgrade" })
+        item = createObject("roSGNode", "ContentNode")
+        item.addFields({ code: "TS1", qty: 1 })
+        order.appendChild(item)
+        store.order = order
+        store.deltaOrder = { code: "TCSMS1", qty: 1 }
+        print "same node: "; store.order.isSameNode(order)
+        print "action kept: " + store.order.action
+        printOrder(store.order)
+
+        store.deltaOrder = { code: "TS1", qty: -1 }
+        store.deltaOrder = { code: "TCSMS1", qty: -1 }
+        store.command = "doOrder"
+        print "empty cart children: " + store.order.getChildCount().toStr()
+        print "empty cart order: " + store.orderStatus.status.toStr() + " " + store.orderStatus.message
+        print "empty cart items: " + store.orderStatus.getChildCount().toStr()
+    end sub
+
+    sub runUserData()
+        print "-- getUserData (all) --"
+        store = newStore(true)
+        store.command = "getUserData"
+        data = store.userData
+        print "firstName: " + data.firstName
+        print "email: " + data.email
+        print "street1: " + data.street1
+        print "gender: " + data.gender
+        print "fields: " + joinKeys(data)
+
+        print "-- getUserData (email,firstname) --"
+        store.requestedUserData = "email,firstname"
+        store.command = "getUserData"
+        print "fields: " + joinKeys(store.userData)
+
+        print "-- getUserData (signin context) --"
+        info = createObject("roSGNode", "ContentNode")
+        info.addFields({ context: "signin" })
+        store.requestedUserDataInfo = info
+        store.command = "getUserData"
+        print "fields: " + joinKeys(store.userData)
+
+        print "-- getUserRegionData --"
+        store.command = "getUserRegionData"
+        region = store.userRegionData
+        print "region: " + region.state + " " + region.zip + " " + region.country
+    end sub
+
+    sub runChannelCred()
+        print "-- storeChannelCredData --"
+        store = newStore(true)
+        store.channelCredData = "test app cred data"
+        store.command = "storeChannelCredData"
+        result = store.storeChannelCredDataStatus
+        print "status: " + result.status.toStr()
+        response = parseJson(result.response)
+        print "response.status: " + response.status
+        print "response.error: " + response.error
+
+        print "-- getChannelCred --"
+        store.command = "getChannelCred"
+        cred = store.channelCred
+        print "channelID: " + cred.channelID
+        print "status: " + cred.status.toStr()
+        print "errorCode is empty: "; (cred.errorCode = "")
+        json = parseJson(cred.json)
+        print "json parses: "; (json <> invalid)
+        print "token_type: " + json.token_type
+        print "channel_data: " + json.channel_data
+        print "pucid present: "; (json.roku_pucid <> invalid and json.roku_pucid <> "")
+
+        print "-- getChannelCred (nothing stored) --"
+        fresh = newStore(true)
+        fresh.command = "getChannelCred"
+        freshJson = parseJson(fresh.channelCred.json)
+        print "channel_data present: "; (freshJson.channel_data <> invalid)
+        print "pucid present: "; (freshJson.roku_pucid <> invalid)
+    end sub
+
+    sub runPartnerOrder()
+        print "-- requestPartnerOrder --"
+        store = newStore(true)
+        request = createObject("roSGNode", "ContentNode")
+        request.addFields({ code: "TS1", priceDisplay: "3.99", price: "2.99", title: "Test Movie", couponCode: "SAVE1", contentKey: "sku-1" })
+        store.requestPartnerOrder = request
+        store.command = "requestPartnerOrder"
+        reqStatus = store.requestPartnerOrderStatus
+        print "status: " + reqStatus.status
+        print "tax: " + reqStatus.tax
+        print "total matches price: "; (reqStatus.total = "2.99")
+        print "orderId present: "; (reqStatus.orderId <> "")
+
+        print "-- confirmPartnerOrder --"
+        confirm = createObject("roSGNode", "ContentNode")
+        confirm.addFields({ orderId: reqStatus.orderId, code: "TS1", price: "2.99", title: "Test Movie" })
+        store.confirmPartnerOrder = confirm
+        store.command = "confirmPartnerOrder"
+        confirmStatus = store.confirmPartnerOrderStatus
+        print "status: " + confirmStatus.status
+        print "purchaseId present: "; (confirmStatus.purchaseId <> "")
+
+        ' Confirming without a preceding billing check must fail.
+        print "-- confirmPartnerOrder without request --"
+        fresh = newStore(true)
+        fresh.confirmPartnerOrder = confirm
+        fresh.command = "confirmPartnerOrder"
+        print "status: " + fresh.confirmPartnerOrderStatus.status
+        print "errorCode: " + fresh.confirmPartnerOrderStatus.errorCode
+    end sub
+
+    ' Without fakeServer the store-backed commands report their documented failure payload, but the
+    ' credential store still works: it holds the app's own artifact rather than a mocked store
+    ' response, so a production app (which never enables fakeServer) must still be able to use it.
+    sub runFakeServerOff()
+        print "-- fakeServer off --"
+        store = newStore(false)
+        store.command = "getUserData"
+        print "userData invalid: "; (store.userData = invalid)
+        store.channelCredData = "prod token"
+        store.command = "storeChannelCredData"
+        print "storeChannelCredDataStatus.status: " + store.storeChannelCredDataStatus.status.toStr()
+        store.command = "getChannelCred"
+        print "channelCred.status: " + store.channelCred.status.toStr()
+        print "channelCred.channel_data: " + parseJson(store.channelCred.json).channel_data
+        request = createObject("roSGNode", "ContentNode")
+        request.addFields({ code: "TS1", price: "2.99" })
+        store.requestPartnerOrder = request
+        store.command = "requestPartnerOrder"
+        print "requestPartnerOrderStatus.status: " + store.requestPartnerOrderStatus.status
+        print "requestPartnerOrderStatus.errorCode: " + store.requestPartnerOrderStatus.errorCode
+    end sub
+    ]]></script>
+</component>

--- a/test/cli/resources/channelstore-node-app/csfake/CheckOrder.xml
+++ b/test/cli/resources/channelstore-node-app/csfake/CheckOrder.xml
@@ -1,0 +1,29 @@
+<result xmlns="http://api.roku.com/order" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+<!--********** Copyright 2016 Roku Corp.  All Rights Reserved. **********-->
+
+        <errorCode i:nil="true" xmlns=""/>
+        <errorDetails i:nil="true" xmlns=""/>
+        <errorMessage xmlns=""/>
+        <status xmlns="">Success</status>
+        <order>
+                <id xmlns="">6150b008-c494-4b15-9afe-ab6e5563e16a</id>
+                <items xmlns="">
+                        <orderItem>
+                                <amount>$1.99</amount>
+                                <code>TS1</code>
+                                <description>Test Subscription</description>
+                                <name>Test Subscription</name>
+                                <purchaseId i:nil="true"/>
+                                <qty>1</qty>
+                                <total>$1.99</total>
+                        </orderItem>
+                </items>
+                <shipping xmlns="">$0.00</shipping>
+                <shippingCode i:nil="true" xmlns=""/>
+                <shippingOptions i:nil="true" xmlns=""/>
+                <subtotal xmlns="">$1.99</subtotal>
+                <tax xmlns="">$1.00</tax>
+                <total xmlns="">$1.99</total>
+        </order>
+</result>
+

--- a/test/cli/resources/channelstore-node-app/csfake/GetCatalog.xml
+++ b/test/cli/resources/channelstore-node-app/csfake/GetCatalog.xml
@@ -1,0 +1,77 @@
+<result xmlns="http://api.roku.com/products" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+<!--********** Copyright 2016 Roku Corp.  All Rights Reserved. **********-->
+
+        <errorCode i:nil="true" xmlns=""/>
+        <errorDetails i:nil="true" xmlns=""/>
+        <errorMessage xmlns=""/>
+        <status xmlns="">Success</status>
+        <products>
+                <product xmlns="">
+                        <HDPosterUrl i:nil="true"/>
+                        <SDPosterUrl i:nil="true"/>
+                        <code>TS1</code>
+                        <cost>$1.99</cost>
+                        <description/>
+                        <expirationDate i:nil="true"/>
+                        <freeTrialQuantity>12</freeTrialQuantity>
+                        <freeTrialType>Months</freeTrialType>
+                        <fulfills xmlns:a="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+                        <id>5409d06c-332d-4458-a03a-d07268a97f7e</id>
+                        <isUpgrade>false</isUpgrade>
+                        <maxQty>8</maxQty>
+                        <name>Test Subscription</name>
+                        <productType>Consumable</productType>
+                        <purchaseDate>0001-01-01T00:00:00</purchaseDate>
+                        <purchaseId i:nil="true"/>
+                        <qty>1</qty>
+                        <renewalDate i:nil="true"/>
+                        <trialType>None</trialType>
+                        <upsellProduct i:nil="true"/>
+                </product>
+                <product xmlns="">
+                        <HDPosterUrl i:nil="true"/>
+                        <SDPosterUrl i:nil="true"/>
+                        <code>TCSMS1</code>
+                        <cost>$4.99</cost>
+                        <description/>
+                        <expirationDate i:nil="true"/>
+                        <freeTrialQuantity>0</freeTrialQuantity>
+                        <freeTrialType>None</freeTrialType>
+                        <fulfills xmlns:a="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+                        <id>8d082292-74a3-4658-82dd-c4c6f4032284</id>
+                        <isUpgrade>true</isUpgrade>
+                        <maxQty>8</maxQty>
+                        <name>Monthly Subscription</name>
+                        <productType>MonthlySub</productType>
+                        <purchaseDate>0001-01-01T00:00:00</purchaseDate>
+                        <purchaseId i:nil="true"/>
+                        <qty>1</qty>
+                        <renewalDate i:nil="true"/>
+                        <trialType>None</trialType>
+                        <upsellProduct i:nil="true"/>
+                </product>
+                <product xmlns="">
+                        <HDPosterUrl i:nil="true"/>
+                        <SDPosterUrl i:nil="true"/>
+                        <code>NW1</code>
+                        <cost>$0.99</cost>
+                        <description>Nifty Widget</description>
+                        <expirationDate i:nil="true"/>
+                        <freeTrialQuantity>0</freeTrialQuantity>
+                        <freeTrialType>None</freeTrialType>
+                        <fulfills xmlns:a="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+                        <id>a2c91cd4-5f69-4ae5-98f9-12c63b69d408</id>
+                        <isUpgrade>false</isUpgrade>
+                        <maxQty>8</maxQty>
+                        <name>Nifty Widget Number 2</name>
+                        <productType>NonConsumable</productType>
+                        <purchaseDate>0001-01-01T00:00:00</purchaseDate>
+                        <purchaseId i:nil="true"/>
+                        <qty>0</qty>
+                        <renewalDate i:nil="true"/>
+                        <trialType>None</trialType>
+                        <upsellProduct i:nil="true"/>
+                </product>
+        </products>
+</result>
+

--- a/test/cli/resources/channelstore-node-app/csfake/GetPurchases.xml
+++ b/test/cli/resources/channelstore-node-app/csfake/GetPurchases.xml
@@ -1,0 +1,51 @@
+<result xmlns="http://api.roku.com/products" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+<!--********** Copyright 2016 Roku Corp.  All Rights Reserved. **********-->
+
+        <errorCode i:nil="true" xmlns=""/>
+        <errorDetails i:nil="true" xmlns=""/>
+        <errorMessage xmlns=""/>
+        <status xmlns="">Success</status>
+        <products>
+                <product xmlns="">
+                        <code>TS1</code>
+                        <cost>$1.99</cost>
+                        <description/>
+                        <expirationDate>2014-04-29T22:17:48</expirationDate>
+                        <freeTrialQuantity>12</freeTrialQuantity>
+                        <freeTrialType>None</freeTrialType>
+                        <fulfills i:nil="true" xmlns:a="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+                        <id>00000000-0000-0000-0000-000000000000</id>
+                        <inDunning>true</inDunning>
+                        <maxQty i:nil="true"/>
+                        <name>Test Subscription</name>
+                        <productType>Consumable</productType>
+                        <purchaseDate>2013-04-29T22:17:48</purchaseDate>
+                        <purchaseId>6c8ad138-692f-48ef-b6ef-9657bb9b8059</purchaseId>
+                        <qty>3</qty>
+                        <renewalDate>2014-04-29T22:17:48</renewalDate>
+                        <status>Valid</status>
+                        <upsellProduct i:nil="true"/>
+                </product>
+                <product xmlns="">
+                        <code>NW1</code>
+                        <cost>$0.99</cost>
+                        <description>Nifty Widget Number 2</description>
+                        <expirationDate i:nil="true"/>
+                        <freeTrialQuantity>0</freeTrialQuantity>
+                        <freeTrialType>None</freeTrialType>
+                        <fulfills i:nil="true" xmlns:a="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+                        <id>00000000-0000-0000-0000-000000000000</id>
+                        <inDunning>false</inDunning>
+                        <maxQty i:nil="true"/>
+                        <name>Nifty Widget</name>
+                        <productType>NonConsumable</productType>
+                        <purchaseDate>2013-04-29T23:29:20</purchaseDate>
+                        <purchaseId>16fa3acf-28b7-4ab2-b94b-f6d23834bd09</purchaseId>
+                        <qty>1</qty>
+                        <renewalDate i:nil="true"/>
+                        <status>Valid</status>
+                        <upsellProduct i:nil="true"/>
+                </product>
+        </products>
+</result>
+

--- a/test/cli/resources/channelstore-node-app/csfake/PlaceOrder.xml
+++ b/test/cli/resources/channelstore-node-app/csfake/PlaceOrder.xml
@@ -1,0 +1,38 @@
+<result xmlns="http://api.roku.com/order" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+<!--********** Copyright 2016 Roku Corp.  All Rights Reserved. **********-->
+
+        <errorCode i:nil="true" xmlns=""/>
+        <errorDetails i:nil="true" xmlns=""/>
+        <errorMessage xmlns=""/>
+        <status xmlns="">Success</status>
+        <order>
+                <id xmlns="">6150b008-c494-4b15-9afe-ab6e5563e16a</id>
+                <items xmlns="">
+                        <orderItem>
+                                <amount>$1.99</amount>
+                                <code>TS1</code>
+                                <description i:nil="true"/>
+                                <name i:nil="true"/>
+                                <purchaseId>12345</purchaseId>
+                                <qty>1</qty>
+                                <total>$1.99</total>
+                        </orderItem>
+                        <orderItem>
+                                <amount>$0.00</amount>
+                                <code>SKUTAX</code>
+                                <description i:nil="true"/>
+                                <name i:nil="true"/>
+                                <purchaseId i:nil="true"/>
+                                <qty>1</qty>
+                                <total>$0.00</total>
+                        </orderItem>
+                </items>
+                <shipping xmlns="">$0.00</shipping>
+                <shippingCode i:nil="true" xmlns=""/>
+                <shippingOptions i:nil="true" xmlns=""/>
+                <subtotal xmlns="">$1.99</subtotal>
+                <tax xmlns="">$0.00</tax>
+                <total xmlns="">$1.99</total>
+        </order>
+</result>
+

--- a/test/cli/resources/channelstore-node-app/manifest
+++ b/test/cli/resources/channelstore-node-app/manifest
@@ -1,0 +1,4 @@
+title=ChannelStore Node Commands
+major_version=1
+minor_version=0
+build_version=1

--- a/test/cli/resources/channelstore-node-app/source/main.brs
+++ b/test/cli/resources/channelstore-node-app/source/main.brs
@@ -1,0 +1,12 @@
+sub Main()
+    print "=== ChannelStore Node Test ==="
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+    scene = screen.CreateScene("MainScene")
+    screen.show()
+    for i = 0 to 5
+        msg = wait(20, port)
+    end for
+    print "=== ChannelStore Node Test Complete ==="
+end sub

--- a/test/extensions/scenegraph/ChannelStoreCommands.test.js
+++ b/test/extensions/scenegraph/ChannelStoreCommands.test.js
@@ -1,0 +1,409 @@
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { ChannelStore, ContentNode, toContentNode } = scenegraph;
+const { BrsBoolean, BrsString, Int32, RoAssociativeArray, RoChannelStore, isInvalid, toAssociativeArray } = core;
+
+// The mocked ChannelStore commands, checked against Roku's reference for the node
+// (REFERENCES/scenegraph/control-nodes/channelstore.md) and for ifChannelStore. The end-to-end
+// pass lives in test/cli/cli-scenegraph.test.js ("Mocks every documented ChannelStore node
+// command"); this file covers the pure conversion/filtering logic without spawning the CLI.
+//
+// Two things asserted here are ENGINE CHOICES rather than device measurements, and a device probe
+// may legitimately overturn them: that a negative `deltaOrder` quantity removes the line item once
+// it reaches zero (the reference says it removes the item but not what a partial decrement does),
+// and the individual `errorCode` values on a failed partner order.
+
+/** A fakeServer-enabled store, i.e. one whose mocks are active. */
+function fakeStore() {
+    const store = new RoChannelStore();
+    store.setFakeServer(true);
+    return store;
+}
+
+/** The keys of an associative array, in insertion order. */
+function keysOf(aa) {
+    return [...aa.elements.keys()];
+}
+
+/** A plain string read off an associative array. */
+function stringOf(aa, name) {
+    return aa.get(new BrsString(name)).getValue();
+}
+
+/** A ChannelStore node with fakeServer already enabled. */
+function fakeNode() {
+    const node = new ChannelStore();
+    node.setValue("fakeServer", BrsBoolean.True);
+    return node;
+}
+
+/** Builds a ContentNode from plain field values. */
+function contentNode(fields) {
+    return toContentNode(toAssociativeArray(fields));
+}
+
+describe("ChannelStore mocked commands", () => {
+    describe("user account data", () => {
+        // Note the result names differ from the request names: `street` yields street1 + street2 and
+        // `firstname` yields firstName.
+        test.each([
+            [
+                "all",
+                "signup",
+                // The default request, in the reference's own table order.
+                ["firstName","lastName","email","street1","street2","city","state","zip","country","phone","birth","gender"], // prettier-ignore
+            ],
+            // Surrounding whitespace is tolerated, and the fields follow the order requested.
+            ["email, street ,firstname", "signup", ["email", "street1", "street2", "firstName"]],
+            // An unknown attribute is ignored rather than yielding an empty field.
+            ["email,nosuchattribute", "signup", ["email"]],
+            // "lists only email or phone attributes ... Other attributes are ignored even if specified".
+            ["all", "signin", ["email", "phone"]],
+            ["firstname,zip", "signin", []],
+        ])("getUserAccountData(%p, %p) returns the fields %p", (requested, context, expected) => {
+            expect(keysOf(fakeStore().getUserAccountData(requested, context))).toEqual(expected);
+        });
+
+        test("returns the canned value for a requested attribute", () => {
+            expect(stringOf(fakeStore().getUserAccountData("firstname"), "firstName")).toBe("John");
+        });
+
+        test("no account or region data is mocked while fakeServer is off", () => {
+            const store = new RoChannelStore();
+            expect(store.getUserAccountData()).toBeUndefined();
+            expect(store.getRegionData()).toBeUndefined();
+        });
+
+        test("region data matches the account's own state, zip and country", () => {
+            const region = fakeStore().getRegionData();
+            const account = fakeStore().getUserAccountData();
+            expect(keysOf(region)).toEqual(["state", "zip", "country"]);
+            for (const name of ["state", "zip", "country"]) {
+                expect(stringOf(region, name)).toBe(stringOf(account, name));
+            }
+        });
+    });
+
+    describe("channel credentials", () => {
+        test("storeChannelCredData reports success as status 0 with a JSON response string", () => {
+            // Note the inverted convention: this command and getChannelCred document 0 as success,
+            // while catalog/purchases/orderStatus document 1.
+            const result = fakeStore().storeCredData("token-1");
+            expect(result.get(new BrsString("status")).getValue()).toBe(0);
+            expect(JSON.parse(stringOf(result, "response"))).toEqual({ status: "success", error: "none" });
+        });
+
+        test("the credential store works without fakeServer, unlike the catalog/order commands", () => {
+            // This is the Roku cloud credential store behind account linking, not a Streaming Store
+            // response, and the artifact is the app's own — a production app never calls
+            // fakeServer(true), so gating it here would silently discard its token.
+            const store = new RoChannelStore();
+            expect(store.storeCredData("token-1").get(new BrsString("status")).getValue()).toBe(0);
+            const cred = store.getChannelCredData();
+            expect(cred.get(new BrsString("status")).getValue()).toBe(0);
+            expect(JSON.parse(stringOf(cred, "json")).channel_data).toBe("token-1");
+        });
+
+        test("getChannelCred returns parseable JSON and adds channel_data only once stored", () => {
+            // The reference's own sample calls ParseJson() on this field, so it has to be real JSON.
+            const store = fakeStore();
+            const before = store.getChannelCredData();
+            expect(keysOf(before)).toEqual(["channelID", "errorCode", "json", "publisherDeviceID", "status"]);
+            expect(before.get(new BrsString("status")).getValue()).toBe(0);
+            expect(stringOf(before, "errorCode")).toBe("");
+
+            const payload = JSON.parse(stringOf(before, "json"));
+            expect(payload.token_type).toBe("urn:roku:pucid:token_type:pucid_token");
+            expect(payload.roku_pucid).toMatch(/^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/);
+            // "not returned if you have not used the StoreChannelCredData method".
+            expect(payload.channel_data).toBeUndefined();
+
+            store.storeCredData("token-1");
+            const after = JSON.parse(stringOf(store.getChannelCredData(), "json"));
+            expect(after.channel_data).toBe("token-1");
+            // A PUCID is stable for the same user and app, so it must not change between calls.
+            expect(after.roku_pucid).toBe(payload.roku_pucid);
+        });
+
+        test("the mocked PUCID is stable for the same app and device", () => {
+            const first = JSON.parse(stringOf(new RoChannelStore().getChannelCredData(), "json"));
+            const second = JSON.parse(stringOf(new RoChannelStore().getChannelCredData(), "json"));
+            expect(first.roku_pucid).toBe(second.roku_pucid);
+        });
+    });
+
+    describe("deltaOrder", () => {
+        test("adds, increments and removes an item, returning the quantity remaining", () => {
+            const store = fakeStore();
+            expect(store.setDeltaOrder("A", 2)).toBe(2);
+            expect(store.setDeltaOrder("A", 3)).toBe(5);
+            expect(store.setDeltaOrder("A", -2)).toBe(3);
+            expect(store.getOrderItems()).toHaveLength(1);
+            // Reaching zero deletes the line item instead of leaving an empty one behind.
+            expect(store.setDeltaOrder("A", -3)).toBe(0);
+            expect(store.getOrderItems()).toHaveLength(0);
+        });
+
+        test("a non-positive delta on an item that is not in the cart is a no-op", () => {
+            const store = fakeStore();
+            expect(store.setDeltaOrder("A", -1)).toBe(0);
+            expect(store.setDeltaOrder("A", 0)).toBe(0);
+            expect(store.getOrderItems()).toHaveLength(0);
+        });
+
+        test("updates a line item in place even when its stored quantity is not numeric", () => {
+            // An app can set `qty` as a string on the order ContentNode; matching on the code alone
+            // keeps that from appending a second line item under the same code.
+            const store = fakeStore();
+            store.setNewOrder([toAssociativeArray({ code: "A", qty: "2" })]);
+            expect(store.setDeltaOrder("A", 1)).toBe(1);
+            expect(store.getOrderItems()).toHaveLength(1);
+        });
+    });
+
+    describe("placing an order", () => {
+        test("an empty cart cannot be ordered", () => {
+            // Without this guard the fake order XML's items are reported as purchased for an order
+            // that holds nothing — reachable by removing the last item with a negative deltaOrder.
+            const store = fakeStore();
+            store.setDeltaOrder("A", 1);
+            store.setDeltaOrder("A", -1);
+            const status = { code: 0, message: "" };
+            expect(store.placeOrder(status)).toHaveLength(0);
+            expect(status).toEqual({ code: -3, message: "Invalid Order" });
+        });
+    });
+
+    describe("partner orders", () => {
+        const orderInfo = () => toAssociativeArray({ code: "MOVIE1", price: "2.99", priceDisplay: "3.99" });
+
+        test("a billing check succeeds and echoes the price back as the total", () => {
+            // Keyed as ifChannelStore documents it — the order id is `id` here; the ChannelStore node
+            // renames that one key to `orderId` at its own edge.
+            const result = fakeStore().requestPartnerOrderData(orderInfo(), "MOVIE1");
+            expect(Object.keys(result)).toEqual(["id", "status", "tax", "total"]);
+            expect(result).toMatchObject({ status: "Success", tax: "0.00", total: "2.99" });
+            expect(result.id).not.toBe("");
+        });
+
+        test("accepts a numeric price, which an app can set directly on the request node", () => {
+            const numericPrice = toAssociativeArray({ code: "MOVIE1", price: 2.99 });
+            expect(fakeStore().requestPartnerOrderData(numericPrice, "MOVIE1")).toMatchObject({
+                status: "Success",
+                total: "2.99",
+            });
+        });
+
+        test("a request missing a required field is rejected as an invalid request", () => {
+            const store = fakeStore();
+            const rejected = [
+                toAssociativeArray({ code: "MOVIE1" }), // no price
+                toAssociativeArray({ price: "2.99" }), // no code
+                new BrsString("nope"), // not an associative array at all
+            ];
+            for (const request of rejected) {
+                expect(store.requestPartnerOrderData(request, "")).toMatchObject({
+                    status: "Failure",
+                    errorCode: "-4",
+                });
+            }
+        });
+
+        test("a confirmation needs a preceding billing check, and consumes its order id", () => {
+            const store = fakeStore();
+            // "The user's billing status must first be confirmed with the requestPartnerOrder command".
+            expect(store.confirmPartnerOrderData(orderInfo(), "MOVIE1")).toMatchObject({
+                status: "Failure",
+                errorCode: "-3",
+            });
+
+            const { id } = store.requestPartnerOrderData(orderInfo(), "MOVIE1");
+            const confirmation = toAssociativeArray({ orderId: id, code: "MOVIE1", price: "2.99" });
+            const confirmed = store.confirmPartnerOrderData(confirmation, "MOVIE1");
+            expect(Object.keys(confirmed)).toEqual(["purchaseId", "status"]);
+            expect(confirmed.status).toBe("Success");
+            expect(confirmed.purchaseId).not.toBe("");
+
+            // Replaying the same confirmation must not purchase twice.
+            expect(store.confirmPartnerOrderData(confirmation, "MOVIE1")).toMatchObject({
+                status: "Failure",
+                errorCode: "-3",
+            });
+        });
+
+        test("a confirmation carrying the wrong order id is rejected", () => {
+            const store = fakeStore();
+            store.requestPartnerOrderData(orderInfo(), "MOVIE1");
+            const mismatched = toAssociativeArray({ orderId: "not-the-order", code: "MOVIE1", price: "2.99" });
+            expect(store.confirmPartnerOrderData(mismatched, "MOVIE1")).toMatchObject({
+                status: "Failure",
+                errorCode: "-3",
+            });
+        });
+
+        test("both steps fail while fakeServer is off", () => {
+            const store = new RoChannelStore();
+            for (const step of ["requestPartnerOrderData", "confirmPartnerOrderData"]) {
+                expect(store[step](orderInfo(), "MOVIE1")).toMatchObject({ status: "Failure", errorCode: "-1" });
+            }
+        });
+    });
+
+    describe("the node's order field", () => {
+        /** Reads back the `order` field's line items as `[code, qty]` pairs. */
+        function lineItems(node) {
+            return node
+                .getValue("order")
+                .getNodeChildren()
+                .map((child) => [child.getValue("code").getValue(), child.getValue("qty").getValue()]);
+        }
+
+        test("takes one line item per child, and republishes the order on a deltaOrder write", () => {
+            const node = fakeNode();
+            const order = new ContentNode();
+            order.appendChildToParent(contentNode({ code: "A", qty: 1 }));
+            order.appendChildToParent(contentNode({ code: "B", qty: 2 }));
+            node.setValue("order", order);
+
+            // The reference documents the associative array as { code, qty }; the write also
+            // republishes `order`, which is what makes the round-trip observable here.
+            node.setValue("deltaOrder", toAssociativeArray({ code: "B", qty: 3 }));
+            expect(lineItems(node)).toEqual([
+                ["A", 1],
+                ["B", 5],
+            ]);
+        });
+
+        test("accepts a childless order node as a single line item", () => {
+            // The shape this node has always converted, and a legitimate one-item order.
+            const node = fakeNode();
+            node.setValue("order", contentNode({ code: "A", qty: 2 }));
+            node.setValue("deltaOrder", toAssociativeArray({ code: "A", qty: 1 }));
+            expect(lineItems(node)).toEqual([["A", 3]]);
+        });
+
+        test("tolerates `delta` as a legacy spelling of the product code", () => {
+            const node = fakeNode();
+            node.setValue("deltaOrder", toAssociativeArray({ delta: "A", qty: 1 }));
+            expect(lineItems(node)).toEqual([["A", 1]]);
+        });
+
+        test("republishing keeps the same node and its order-level action metadata", () => {
+            // The app holds its own reference to the order node, and the top node carries the
+            // `action` ("Upgrade"/"Downgrade") that drives a subscription change — a freshly built
+            // replacement node would drop both.
+            const node = fakeNode();
+            const order = new ContentNode();
+            order.setValueSilent("action", new BrsString("Upgrade"));
+            order.appendChildToParent(contentNode({ code: "A", qty: 1 }));
+            node.setValue("order", order);
+
+            node.setValue("deltaOrder", toAssociativeArray({ code: "B", qty: 1 }));
+            expect(node.getValue("order")).toBe(order);
+            expect(order.getValue("action").getValue()).toBe("Upgrade");
+            expect(lineItems(node)).toEqual([
+                ["A", 1],
+                ["B", 1],
+            ]);
+        });
+
+        test("setting the order to invalid clears it", () => {
+            const node = fakeNode();
+            node.setValue("order", contentNode({ code: "A", qty: 2 }));
+            node.setValue("order", core.BrsInvalid.Instance);
+            // Re-adding the same code starts from scratch rather than incrementing the cleared item.
+            node.setValue("deltaOrder", toAssociativeArray({ code: "A", qty: 1 }));
+            expect(lineItems(node)).toEqual([["A", 1]]);
+        });
+    });
+
+    describe("the node's command dispatch", () => {
+        test("getUserData honors requestedUserData and the requestedUserDataInfo context", () => {
+            const node = fakeNode();
+            node.setValue("requestedUserData", new BrsString("email,zip"));
+            node.setValue("command", new BrsString("getUserData"));
+            let userData = node.getValue("userData");
+            expect(userData.getValue("email").getValue()).toBe("john.doe@email.com");
+            expect(userData.getValue("zip").getValue()).toBe("95110");
+
+            node.setValue("requestedUserDataInfo", contentNode({ context: "signin" }));
+            node.setValue("command", new BrsString("getUserData"));
+            userData = node.getValue("userData");
+            expect(userData.getValue("email").getValue()).toBe("john.doe@email.com");
+            // A sign-in RFI screen never returns the zip code.
+            expect(isInvalid(userData.getValue("zip"))).toBe(true);
+        });
+
+        test("a non-string requestedUserDataInfo context is treated as a signup request", () => {
+            // The field can hold any type, and this write happens after super.setValue, so a raw
+            // JS type error here escapes Node.setValue's guard and crashes the app.
+            const node = fakeNode();
+            const info = new ContentNode();
+            info.setValueSilent("context", new Int32(1));
+            node.setValue("requestedUserDataInfo", info);
+            node.setValue("command", new BrsString("getUserData"));
+            // Signup returns the full set, so a field a signin request would drop is present.
+            expect(node.getValue("userData").getValue("zip").getValue()).toBe("95110");
+        });
+
+        test("getUserData reports invalid while fakeServer is off, as a declined request does", () => {
+            const node = new ChannelStore();
+            node.setValue("command", new BrsString("getUserData"));
+            expect(isInvalid(node.getValue("userData"))).toBe(true);
+        });
+
+        test("storeChannelCredData publishes an associative array, getChannelCred a ContentNode", () => {
+            // The reference is asymmetric here on purpose: storeChannelCredDataStatus is documented
+            // as an roAssociativeArray while channelCred is documented as a ContentNode.
+            const node = fakeNode();
+            node.setValue("channelCredData", new BrsString("token-1"));
+            node.setValue("command", new BrsString("storeChannelCredData"));
+            const status = node.getValue("storeChannelCredDataStatus");
+            expect(status).toBeInstanceOf(RoAssociativeArray);
+            expect(JSON.parse(stringOf(status, "response")).status).toBe("success");
+
+            node.setValue("command", new BrsString("getChannelCred"));
+            const cred = node.getValue("channelCred");
+            expect(cred).toBeInstanceOf(ContentNode);
+            expect(JSON.parse(cred.getValue("json").getValue()).channel_data).toBe("token-1");
+        });
+
+        test("the partner-order commands publish the documented success and failure fields", () => {
+            const node = fakeNode();
+            node.setValue(
+                "requestPartnerOrder",
+                contentNode({ code: "MOVIE1", price: "2.99", priceDisplay: "3.99", title: "Test Movie" })
+            );
+            node.setValue("command", new BrsString("requestPartnerOrder"));
+            const request = node.getValue("requestPartnerOrderStatus");
+            // This field names the order id `orderId`; ifChannelStore names the same value `id`.
+            expect(request.getValue("status").getValue()).toBe("Success");
+            expect(request.getValue("total").getValue()).toBe("2.99");
+            const orderId = request.getValue("orderId").getValue();
+            expect(orderId).not.toBe("");
+
+            node.setValue("confirmPartnerOrder", contentNode({ orderId: orderId, code: "MOVIE1", price: "2.99" }));
+            node.setValue("command", new BrsString("confirmPartnerOrder"));
+            const confirmation = node.getValue("confirmPartnerOrderStatus");
+            expect(confirmation.getValue("status").getValue()).toBe("Success");
+            expect(confirmation.getValue("purchaseId").getValue()).not.toBe("");
+
+            // Confirming again reuses a consumed order id and must report the failure keys instead.
+            node.setValue("command", new BrsString("confirmPartnerOrder"));
+            const replay = node.getValue("confirmPartnerOrderStatus");
+            expect(replay.getValue("status").getValue()).toBe("Failure");
+            expect(replay.getValue("errorCode").getValue()).toBe("-3");
+            expect(replay.getValue("errorMessage").getValue()).not.toBe("");
+        });
+
+        test("the command dispatch reads fakeServer from the field, not from an earlier write", () => {
+            // XML-initialized fields and cross-thread copies both bypass setValue(), so the command
+            // has to re-derive the request state from the node's own fields.
+            const node = new ChannelStore();
+            node.setValueSilent("fakeServer", BrsBoolean.True);
+            node.setValue("command", new BrsString("getUserData"));
+            expect(node.getValue("userData").getValue("email").getValue()).toBe("john.doe@email.com");
+        });
+    });
+});


### PR DESCRIPTION
## Why

Roku documents **twelve** values for the SceneGraph `ChannelStore` node's `command` field. Four had no implementation at all and fell through to a `warning,[ChannelStore] Invalid or unhandled 'command'` on stderr, so an app using Roku Pay channel-credential storage (the standard "don't re-enter your password on a new device" flow) or TVOD transactional purchases waited forever on an `observeField` that never fired.

| command | missing input field | missing output field |
| --- | --- | --- |
| `storeChannelCredData` | `channelCredData` | `storeChannelCredDataStatus` |
| `getChannelCred` | — | `channelCred` |
| `requestPartnerOrder` | *(field existed, never read)* | *(field existed, never written)* |
| `confirmPartnerOrder` | *(field existed, never read)* | *(field existed, never written)* |

Mapping the reference (`external/dev-doc/.../scenegraph/control-nodes/channelstore.md` and `interfaces/ifchannelstore.md`) onto the code also surfaced deviations in commands that *were* implemented, which broke the documented usage patterns.

## What changed

The mocks live on `RoChannelStore` as shared helpers, so the component's own canned-failure stubs (`getUserData`, `getPartialUserData`, `requestPartnerOrder`, `confirmPartnerOrder`) are implemented by the same code — one source of truth for both APIs. `getPartialUserData` also gained its missing `requestInfo` argument.

**Spec deviations fixed**

- **`deltaOrder` read the wrong key.** It looked for `delta`; the reference says `code`. So the documented `{ code: "Item1", qty: 1 }` write was silently ignored.
- **`deltaOrder` could not remove.** A negative quantity now reduces the item and removes it at zero, and it returns the item's remaining quantity rather than the cart length.
- **`deltaOrder` never republished `order`.** The reference: "Each time this field is set, the **order** field is modified." An incrementally built cart read back empty.
- **The `order` node's child items were dropped** — only the top node was converted, so a multi-item order became a one-item order. Top-level `action` (`Upgrade`/`Downgrade`) maps to the component's `orderInfo`.
- **`getUserData` ignored its inputs** (`requestedUserData`, `requestedUserDataInfo.context`) and returned 6 of the 12 documented `userData` fields.
- **`getChannelCred`'s `json` was not JSON** (`{channel_data="..."}`), so the reference's own `ParseJson(channelCred.json)` returned `invalid`. `roku_pucid` is now a `uuidv5` derived from app + device, so it's stable across calls like a real PUCID.
- **`doOrder` reported "Order Succeeded" for an empty cart**, returning the fake order XML's two items as purchases — newly reachable once a negative `deltaOrder` could empty the cart.
- **`isValidProductOrder` used `instanceof BrsString`/`Int32`**, but `addFields` stores boxed `roString`/`roInt`, so a real order item never matched the catalog.

**Two supporting changes outside the node**

- `Serializer.fromContentNode` now keys the associative array by each field's **declared** name instead of the lowercased field-map key. It was building a case-*sensitive* array from lowercased keys, forcing every consumer to read back through a case-insensitive lookup, and it diverged from `Node.getElements`/`getNodeFieldsAsAA` which already do this. All three call sites are in `ChannelStore`.
- `ChannelStore` no longer mirrors `fakeServer`/`order` into the backing store from `setValue`. `setValueSilent` writes a field **without** going through `setValue` — a cross-thread copy (`toSGNode`/`updateSGNode`), a Task read-reply, an XML `<interface>` default and `appendNodeFields` all take that path — so each command derives what it needs from the node's own fields. This removes a data-loss path where a Task-owned copy applied a delta to an empty cart and then overwrote the real order's children with just that item.

## Behavior note worth reviewing

Mocked results require `fakeServer`, matching how `getCatalog`/`doOrder`/`getUserData` already behave, so a shipped app can't mistake one for a real Roku Pay result.

**The credential store is deliberately exempt.** `storeChannelCredData`/`getChannelCred` hold the app's *own* artifact rather than a Streaming Store response, and a production app never calls `fakeServer(true)` — gating them would silently discard tokens in production, which is a regression against the previous unconditional behavior. Side effect: `getChannelCred` with nothing stored now returns `status: 0` with `channel_data` absent, instead of the old `400`. That matches the reference (`0` = success; `channel_data` is "not returned if you have not used the StoreChannelCredData method"), and `400` appears in no documented status table.

Engine choices, not device measurements — a device probe may legitimately overturn them, and they're commented as such:

- that a negative `deltaOrder` quantity removes the line item at zero
- the individual `errorCode` values on a failed partner order (`-1`/`-3`/`-4`, reusing the node's own status table)
- that a partner `orderId` is single-use

## Testing

- **New CLI fixture** `test/cli/resources/channelstore-node-app/` + a case in `cli-scenegraph.test.js`, driving all twelve commands end-to-end through the SceneGraph runtime. Generated ids are asserted as "present"/"matches" rather than literally; everything else is pinned by `csfake/*.xml` or the canned account table.
- **New unit suite** `test/extensions/scenegraph/ChannelStoreCommands.test.js` (33 tests) for the filtering/conversion logic without a subprocess.
- `npm run lint`, `npm run prettier`, and the full `npm test` are green: **217 files, 2799 tests**. The existing "Channel Store Test" expectations needed no changes.

Verified end-to-end that no `Invalid or unhandled 'command'` warning remains for any documented command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
