### PR TITLE
refactor(core): simplify IfDraw2D.ts and add unit tests

### DIFF
--- a/src/core/brsTypes/interfaces/IfDraw2D.ts
+++ b/src/core/brsTypes/interfaces/IfDraw2D.ts
@@ -71,11 +71,7 @@ export class IfDraw2D {
         ctx.save();
         // Set context properties (alpha blending, smoothing)
         setContextGlobalAlpha(ctx, style.alpha);
-        const smoothing = object.scaleMode === 1;
-        ctx.imageSmoothingEnabled = smoothing;
-        if (smoothing && "imageSmoothingQuality" in ctx) {
-            ctx.imageSmoothingQuality = "high";
-        }
+        applyScaleModeSmoothing(ctx, object.scaleMode);
         // Draw the cropped and scaled image using ctx.drawImage directly
         const chunk: DrawChunk = {
             sx: sourceRect.x,
@@ -105,8 +101,7 @@ export class IfDraw2D {
         rgba?: number,
         opacity?: number
     ) {
-        const baseX = this.component.x;
-        const baseY = this.component.y;
+        const { x: baseX, y: baseY } = this.component;
         const ctx = this.component.getContext();
         const style = resolveBlitStyle(rgba, opacity);
         ctx.save();
@@ -137,8 +132,7 @@ export class IfDraw2D {
         scaleX: number = 1,
         scaleY: number = 1
     ) {
-        const baseX = this.component.x;
-        const baseY = this.component.y;
+        const { x: baseX, y: baseY } = this.component;
         const ctx = this.component.getContext();
         ctx.save();
         // Default to top-left corner if centerX and centerY are not provided
@@ -183,8 +177,7 @@ export class IfDraw2D {
             // nothing to draw
             return;
         }
-        const baseX = this.component.x;
-        const baseY = this.component.y;
+        const { x: baseX, y: baseY } = this.component;
         const ctx = this.component.getContext();
         ctx.save();
         ctx.globalAlpha = opacity;
@@ -209,8 +202,7 @@ export class IfDraw2D {
             // nothing to draw
             return;
         }
-        const baseX = this.component.x;
-        const baseY = this.component.y;
+        const { x: baseX, y: baseY } = this.component;
         const ctx = this.component.getContext();
         ctx.save();
         ctx.globalAlpha = opacity;
@@ -351,62 +343,36 @@ export class IfDraw2D {
         const targetCW = Math.max(0, drawW - lw - rw); // Target center width
         const targetCH = Math.max(0, drawH - th - bh); // Target center height
 
-        const drawPart = (
-            sx: number,
-            sy: number,
-            sw: number,
-            sh: number,
-            dx: number,
-            dy: number,
-            dw: number,
-            dh: number
-        ) => {
-            // Ensure destination coords/dims are integers to potentially avoid sub-pixel gaps/overlaps
-            const i_dx = Math.round(dx);
-            const i_dy = Math.round(dy);
-            const i_dw = Math.round(dw);
-            const i_dh = Math.round(dh);
-            // Only draw if source and rounded destination dimensions are positive
-            if (sw > 0 && sh > 0 && i_dw > 0 && i_dh > 0) {
-                drawChunk(ctx, image, { sx, sy, sw, sh, dx: i_dx, dy: i_dy, dw: i_dw, dh: i_dh });
-            }
-        };
+        // The nine patches (corners fixed, edges/center stretched), in source and destination rects.
+        const patches: DrawChunk[] = [
+            { sx: 1, sy: 1, sw: lw, sh: th, dx: x, dy: y, dw: lw, dh: th }, // Top-left corner
+            { sx: 1 + lw, sy: 1, sw: cw, sh: th, dx: x + lw, dy: y, dw: targetCW, dh: th }, // Top edge
+            { sx: sw - 1 - rw, sy: 1, sw: rw, sh: th, dx: x + drawW - rw, dy: y, dw: rw, dh: th }, // Top-right corner
+            { sx: 1, sy: 1 + th, sw: lw, sh: ch, dx: x, dy: y + th, dw: lw, dh: targetCH }, // Left edge
+            { sx: 1 + lw, sy: 1 + th, sw: cw, sh: ch, dx: x + lw, dy: y + th, dw: targetCW, dh: targetCH }, // Center
+            { sx: sw - 1 - rw, sy: 1 + th, sw: rw, sh: ch, dx: x + drawW - rw, dy: y + th, dw: rw, dh: targetCH }, // Right edge
+            { sx: 1, sy: sh - 1 - bh, sw: lw, sh: bh, dx: x, dy: y + drawH - bh, dw: lw, dh: bh }, // Bottom-left corner
+            { sx: 1 + lw, sy: sh - 1 - bh, sw: cw, sh: bh, dx: x + lw, dy: y + drawH - bh, dw: targetCW, dh: bh }, // Bottom edge
+            {
+                sx: sw - 1 - rw,
+                sy: sh - 1 - bh,
+                sw: rw,
+                sh: bh,
+                dx: x + drawW - rw,
+                dy: y + drawH - bh,
+                dw: rw,
+                dh: bh,
+            }, // Bottom-right corner
+        ];
 
         ctx.save();
         // Set context properties (alpha blending, smoothing)
         setContextGlobalAlpha(ctx, style.alpha);
-        const smoothing = bitmap.scaleMode === 1;
-        ctx.imageSmoothingEnabled = smoothing;
-        if (smoothing && "imageSmoothingQuality" in ctx) {
-            ctx.imageSmoothingQuality = "high";
+        applyScaleModeSmoothing(ctx, bitmap.scaleMode);
+
+        for (const patch of patches) {
+            drawNinePatchPart(ctx, image, patch);
         }
-
-        // Top-left corner
-        drawPart(1, 1, lw, th, x, y, lw, th);
-
-        // Top edge
-        drawPart(1 + lw, 1, cw, th, x + lw, y, targetCW, th);
-
-        // Top-right corner
-        drawPart(sw - 1 - rw, 1, rw, th, x + drawW - rw, y, rw, th);
-
-        // Left edge
-        drawPart(1, 1 + th, lw, ch, x, y + th, lw, targetCH);
-
-        // Center
-        drawPart(1 + lw, 1 + th, cw, ch, x + lw, y + th, targetCW, targetCH);
-
-        // Right edge
-        drawPart(sw - 1 - rw, 1 + th, rw, ch, x + drawW - rw, y + th, rw, targetCH);
-
-        // Bottom-left corner
-        drawPart(1, sh - 1 - bh, lw, bh, x, y + drawH - bh, lw, bh);
-
-        // Bottom edge
-        drawPart(1 + lw, sh - 1 - bh, cw, bh, x + lw, y + drawH - bh, targetCW, bh);
-
-        // Bottom-right corner
-        drawPart(sw - 1 - rw, sh - 1 - bh, rw, bh, x + drawW - rw, y + drawH - bh, rw, bh);
 
         ctx.restore();
         this.component.makeDirty();
@@ -565,8 +531,7 @@ export class IfDraw2D {
             returns: ValueKind.Boolean,
         },
         impl: (_: Interpreter, xStart: Int32, yStart: Int32, xEnd: Int32, yEnd: Int32, rgba: Int32) => {
-            const baseX = this.component.x;
-            const baseY = this.component.y;
+            const { x: baseX, y: baseY } = this.component;
             const ctx = this.component.getContext();
             ctx.beginPath();
             ctx.strokeStyle = rgbaIntToHex(rgba.getValue(), this.component.getCanvasAlpha());
@@ -590,8 +555,7 @@ export class IfDraw2D {
             returns: ValueKind.Boolean,
         },
         impl: (_: Interpreter, x: Int32, y: Int32, size: Float, rgba: Int32) => {
-            const baseX = this.component.x;
-            const baseY = this.component.y;
+            const { x: baseX, y: baseY } = this.component;
             const ctx = this.component.getContext();
             ctx.fillStyle = rgbaIntToHex(rgba.getValue(), this.component.getCanvasAlpha());
             ctx.fillRect(baseX + x.getValue(), baseY + y.getValue(), size.getValue(), size.getValue());
@@ -615,14 +579,16 @@ export class IfDraw2D {
         impl: (_: Interpreter, x: Int32, y: Int32, width: Int32, height: Int32, rgba: Int32) => {
             const baseX = this.component.x + x.getValue();
             const baseY = this.component.y + y.getValue();
+            const w = width.getValue();
+            const h = height.getValue();
             const ctx = this.component.getContext();
             if (this.component instanceof RoScreen && !this.component.getCanvasAlpha()) {
-                ctx.clearRect(baseX, baseY, width.getValue(), height.getValue());
+                ctx.clearRect(baseX, baseY, w, h);
                 ctx.fillStyle = rgbaIntToHex(rgba.getValue(), true);
             } else {
                 ctx.fillStyle = rgbaIntToHex(rgba.getValue(), this.component.getCanvasAlpha());
             }
-            ctx.fillRect(baseX, baseY, width.getValue(), height.getValue());
+            ctx.fillRect(baseX, baseY, w, h);
             this.component.makeDirty();
             return BrsBoolean.True;
         },
@@ -715,15 +681,7 @@ export class IfDraw2D {
             returns: ValueKind.Int32,
         },
         impl: (_: Interpreter, x: Int32, y: Int32, width: Int32, height: Int32) => {
-            const baseX = this.component.x;
-            const baseY = this.component.y;
-            const ctx = this.component.getCanvas().getContext("2d") as BrsCanvasContext2D;
-            const imgData = ctx.getImageData(
-                baseX + x.getValue(),
-                baseY + y.getValue(),
-                width.getValue(),
-                height.getValue()
-            );
+            const imgData = this.getImageDataRect(x.getValue(), y.getValue(), width.getValue(), height.getValue());
             const byteArray = new Uint8Array(imgData.data.buffer);
             return new RoByteArray(byteArray);
         },
@@ -741,20 +699,19 @@ export class IfDraw2D {
             returns: ValueKind.Int32,
         },
         impl: (_: Interpreter, x: Int32, y: Int32, width: Int32, height: Int32) => {
-            const baseX = this.component.x;
-            const baseY = this.component.y;
-            const ctx = this.component.getCanvas().getContext("2d") as BrsCanvasContext2D;
-            const imgData = ctx.getImageData(
-                baseX + x.getValue(),
-                baseY + y.getValue(),
-                width.getValue(),
-                height.getValue()
-            );
+            const imgData = this.getImageDataRect(x.getValue(), y.getValue(), width.getValue(), height.getValue());
             return new RoByteArray(
                 new Uint8Array(UPNG.encode([imgData.data.buffer as ArrayBuffer], imgData.width, imgData.height, 0))
             );
         },
     });
+
+    /** Reads back the RGBA pixel data for a rectangle, offset by the component's origin. */
+    private getImageDataRect(x: number, y: number, width: number, height: number): BrsImageData {
+        const { x: baseX, y: baseY } = this.component;
+        const ctx = this.component.getCanvas().getContext("2d") as BrsCanvasContext2D;
+        return ctx.getImageData(baseX + x, baseY + y, width, height);
+    }
 }
 
 export interface BrsDraw2D {
@@ -825,6 +782,15 @@ function setContextGlobalAlpha(ctx: BrsCanvasContext2D, alpha: number): boolean 
         return true;
     }
     return false;
+}
+
+/** Applies the object's `scaleMode` (1 = smooth) to the context's image smoothing settings. */
+function applyScaleModeSmoothing(ctx: BrsCanvasContext2D, scaleMode: number) {
+    const smoothing = scaleMode === 1;
+    ctx.imageSmoothingEnabled = smoothing;
+    if (smoothing && "imageSmoothingQuality" in ctx) {
+        ctx.imageSmoothingQuality = "high";
+    }
 }
 
 function getCanvasFromDraw2d(object: BrsDraw2D, rgba?: number): BrsCanvas {
@@ -956,6 +922,9 @@ function getDrawChunks(
         return chunks;
     }
 
+    const rightDx = actualDrawWidth + dx;
+    const bottomDy = actualDrawHeight + dy;
+
     if (missingHorizontal > 0) {
         // missing right chunk
         chunks.push({
@@ -963,7 +932,7 @@ function getDrawChunks(
             sy: offset.y,
             sw: missingHorizontal,
             sh: actualDrawHeight,
-            dx: actualDrawWidth + dx,
+            dx: rightDx,
             dy,
             dw: missingHorizontal,
             dh: actualDrawHeight,
@@ -977,7 +946,7 @@ function getDrawChunks(
             sw: actualDrawWidth,
             sh: missingVertical,
             dx: dx,
-            dy: actualDrawHeight + dy,
+            dy: bottomDy,
             dw: actualDrawWidth,
             dh: missingVertical,
         });
@@ -989,8 +958,8 @@ function getDrawChunks(
             sy: 0,
             sw: missingHorizontal,
             sh: missingVertical,
-            dx: actualDrawWidth + dx,
-            dy: actualDrawHeight + dy,
+            dx: rightDx,
+            dy: bottomDy,
             dw: missingHorizontal,
             dh: missingVertical,
         });
@@ -1049,11 +1018,7 @@ export function drawObjectToComponent(
     // copies the whole drawing state on every single blit, and shares its stack with `pushClip`.
     const alphaSet = setContextGlobalAlpha(ctx, blitAlpha);
     try {
-        const smoothing = (scaleMode ?? object.scaleMode) === 1;
-        ctx.imageSmoothingEnabled = smoothing;
-        if (smoothing && "imageSmoothingQuality" in ctx) {
-            ctx.imageSmoothingQuality = "high";
-        }
+        applyScaleModeSmoothing(ctx, scaleMode ?? object.scaleMode);
 
         const destOffset = getDrawOffset(component);
 
@@ -1080,11 +1045,7 @@ export function drawBitmapOnBitmap(source: RoBitmap, destiny: RoBitmap, scaleMod
     const canvas = source.getCanvas();
     const ctx = destiny.getContext();
     ctx.save();
-    const smoothing = (scaleMode ?? destiny.scaleMode) === 1;
-    ctx.imageSmoothingEnabled = smoothing;
-    if (smoothing && "imageSmoothingQuality" in ctx) {
-        ctx.imageSmoothingQuality = "high";
-    }
+    applyScaleModeSmoothing(ctx, scaleMode ?? destiny.scaleMode);
     const chunk = {
         sx: 0,
         sy: 0,
@@ -1279,6 +1240,23 @@ function drawChunk(ctx: BrsCanvasContext2D, image: BrsCanvas, chunk: DrawChunk) 
         ctx.drawImage(image, sx, sy, sw, sh, dx, dy, dw, dh);
     }
     /// #endif
+}
+
+/**
+ * Draws one nine-patch corner/edge/center piece, rounding destination coords/dims to integers to
+ * potentially avoid sub-pixel gaps/overlaps between adjoining pieces, and skipping the draw if the
+ * source or rounded destination has no area.
+ */
+function drawNinePatchPart(ctx: BrsCanvasContext2D, image: BrsCanvas, chunk: DrawChunk) {
+    const dw = Math.round(chunk.dw);
+    const dh = Math.round(chunk.dh);
+    if (chunk.sw > 0 && chunk.sh > 0 && dw > 0 && dh > 0) {
+        chunk.dx = Math.round(chunk.dx);
+        chunk.dy = Math.round(chunk.dy);
+        chunk.dw = dw;
+        chunk.dh = dh;
+        drawChunk(ctx, image, chunk);
+    }
 }
 
 /** The two independent things a blend color and a node opacity resolve to for one blit. */

--- a/test/brsTypes/interfaces/IfDraw2D.test.js
+++ b/test/brsTypes/interfaces/IfDraw2D.test.js
@@ -1,0 +1,522 @@
+const brs = require("../../../packages/node/bin/brs.node");
+const UPNG = require("@lvcabral/upng");
+const { createCanvas } = require("canvas");
+const {
+    RoBitmap,
+    RoScreen,
+    RoRegion,
+    RoAssociativeArray,
+    BrsString,
+    Int32,
+    Float,
+    BrsBoolean,
+    IfDraw2D,
+    RectRect,
+    RectCircle,
+    CircleCircle,
+    rgbaToTransparent,
+    rgbaToOpaque,
+    rgbaIntToHex,
+    getDimensions,
+    getDrawOffset,
+    Dimensions,
+    DrawOffset,
+    drawObjectToComponent,
+    drawBitmapOnBitmap,
+    drawRotatedObject,
+    createNewCanvas,
+    releaseCanvas,
+    drawImageAtPos,
+    putImageAtPos,
+    drawCanvasRegion,
+} = brs.types;
+const { Interpreter } = brs;
+
+// BrightScript &hFF0000FF literals are two's-complement Int32s, not the plain positive JS number:
+// `new Int32(0xff0000ff)` alone would clamp to Int32's max value (RBI truncation), not wrap.
+function rgba(value) {
+    return new Int32(value | 0);
+}
+
+function makeBitmap(width, height, alphaEnable) {
+    return new RoBitmap(
+        new RoAssociativeArray([
+            { name: new BrsString("width"), value: new Int32(width) },
+            { name: new BrsString("height"), value: new Int32(height) },
+            { name: new BrsString("alphaEnable"), value: alphaEnable ? BrsBoolean.True : BrsBoolean.False },
+        ])
+    );
+}
+
+function pixelAt(ctx, width, x, y) {
+    const data = ctx.getImageData(0, 0, width, ctx.canvas.height).data;
+    const i = (x + y * width) * 4;
+    return [data[i], data[i + 1], data[i + 2], data[i + 3]];
+}
+
+describe("IfDraw2D", () => {
+    let interpreter;
+
+    beforeEach(() => {
+        interpreter = new Interpreter();
+    });
+
+    describe("geometry and color helpers", () => {
+        it("RectRect detects overlap but not mere edge-touching", () => {
+            expect(RectRect({ x: 0, y: 0, width: 5, height: 5 }, { x: 4, y: 4, width: 5, height: 5 })).toBe(true);
+            expect(RectRect({ x: 0, y: 0, width: 5, height: 5 }, { x: 10, y: 10, width: 5, height: 5 })).toBe(false);
+            expect(RectRect({ x: 0, y: 0, width: 5, height: 5 }, { x: 5, y: 0, width: 5, height: 5 })).toBe(false);
+        });
+
+        it("RectCircle detects containment, corner overlap, and misses", () => {
+            const rect = { x: 0, y: 0, width: 10, height: 10 };
+            expect(RectCircle(rect, { x: 5, y: 5, r: 1 })).toBe(true);
+            expect(RectCircle(rect, { x: 100, y: 100, r: 1 })).toBe(false);
+            expect(RectCircle(rect, { x: -3, y: -3, r: 5 })).toBe(true);
+            expect(RectCircle(rect, { x: -5, y: -5, r: 5 })).toBe(false);
+        });
+
+        it("CircleCircle detects overlap and separation", () => {
+            expect(CircleCircle({ x: 0, y: 0, r: 5 }, { x: 5, y: 0, r: 5 })).toBe(true);
+            expect(CircleCircle({ x: 0, y: 0, r: 5 }, { x: 20, y: 0, r: 5 })).toBe(false);
+        });
+
+        it("rgbaToTransparent zeroes the alpha byte, rgbaToOpaque forces it to 0xff", () => {
+            expect(rgbaToTransparent(0x11223344)).toBe(0x11223300);
+            expect(rgbaToOpaque(0x11223300)).toBe(0x112233ff);
+        });
+
+        it("rgbaIntToHex packs RRGGBBAA, forcing opaque only when alpha=false", () => {
+            expect(rgbaIntToHex(0xff0000ff)).toBe("#ff0000ff");
+            expect(rgbaIntToHex(0x11223344, true)).toBe("#11223344");
+            expect(rgbaIntToHex(0x11223344, false)).toBe("#112233ff");
+        });
+
+        it("Dimensions/DrawOffset are plain value holders", () => {
+            const dims = new Dimensions(12, 34);
+            expect(dims.width).toBe(12);
+            expect(dims.height).toBe(34);
+            const offset = new DrawOffset();
+            expect(offset.x).toBe(0);
+            expect(offset.y).toBe(0);
+        });
+
+        it("getDimensions/getDrawOffset default to size/zero for a plain bitmap", () => {
+            const bmp = makeBitmap(20, 15, true);
+            expect(getDimensions(bmp)).toEqual(new Dimensions(20, 15));
+            expect(getDrawOffset(bmp)).toEqual({ x: 0, y: 0 });
+        });
+
+        it("getDimensions/getDrawOffset report a region's own rect and position", () => {
+            const bmp = makeBitmap(20, 15, true);
+            const region = new RoRegion(bmp, new Int32(3), new Int32(4), new Int32(5), new Int32(6));
+            expect(getDimensions(region)).toEqual(new Dimensions(5, 6));
+            expect(getDrawOffset(region)).toEqual({ x: 3, y: 4 });
+        });
+    });
+
+    describe("drawRect", () => {
+        it("fills only the requested rectangle with the given color", () => {
+            const bmp = makeBitmap(10, 10, true);
+            const result = bmp
+                .getMethod("drawRect")
+                .call(interpreter, new Int32(2), new Int32(2), new Int32(4), new Int32(4), rgba(0xff0000ff));
+            expect(result).toBe(BrsBoolean.True);
+            const ctx = bmp.getContext();
+            expect(pixelAt(ctx, 10, 3, 3)).toEqual([255, 0, 0, 255]);
+            expect(pixelAt(ctx, 10, 0, 0)).toEqual([0, 0, 0, 0]);
+        });
+
+        it("replaces (does not blend with) prior content on a non-alpha RoScreen", () => {
+            const screen = new RoScreen(BrsBoolean.False, new Int32(20), new Int32(20));
+            screen.getMethod("clear").call(interpreter, rgba(0x0000ffff));
+            // A semi-transparent red drawn over the opaque blue background: on a normal alpha-enabled
+            // surface this would blend toward purple. On a non-alpha RoScreen it clears first, so the
+            // result is red at the color's own alpha over a now-transparent background, not a blend.
+            screen
+                .getMethod("drawRect")
+                .call(interpreter, new Int32(2), new Int32(2), new Int32(4), new Int32(4), rgba(0xff000080));
+            const ctx = screen.getContext();
+            expect(pixelAt(ctx, 20, 3, 3)).toEqual([255, 0, 0, 128]);
+            expect(pixelAt(ctx, 20, 0, 0)).toEqual([0, 0, 255, 255]);
+        });
+    });
+
+    describe("drawLine and drawPoint", () => {
+        it("drawLine paints along the requested segment", () => {
+            const bmp = makeBitmap(10, 1, true);
+            bmp.getMethod("drawLine").call(
+                interpreter,
+                new Int32(0),
+                new Int32(0),
+                new Int32(9),
+                new Int32(0),
+                rgba(0x00ff00ff)
+            );
+            const ctx = bmp.getContext();
+            expect(pixelAt(ctx, 10, 5, 0)[1]).toBe(255);
+        });
+
+        it("drawPoint paints a size x size square at the given position", () => {
+            const bmp = makeBitmap(10, 10, true);
+            bmp.getMethod("drawPoint").call(interpreter, new Int32(4), new Int32(4), new Float(2.0), rgba(0x0000ffff));
+            const ctx = bmp.getContext();
+            expect(pixelAt(ctx, 10, 4, 4)).toEqual([0, 0, 255, 255]);
+            expect(pixelAt(ctx, 10, 4, 6)).toEqual([0, 0, 0, 0]);
+        });
+    });
+
+    describe("drawObject family", () => {
+        function greenSource() {
+            const src = makeBitmap(4, 4, true);
+            src.getMethod("clear").call(interpreter, rgba(0x00ff00ff));
+            return src;
+        }
+
+        it("drawObject blits the source at (x, y) unscaled", () => {
+            const src = greenSource();
+            const dest = makeBitmap(10, 10, true);
+            const result = dest.getMethod("drawObject").call(interpreter, new Int32(3), new Int32(3), src);
+            expect(result).toBe(BrsBoolean.True);
+            const ctx = dest.getContext();
+            expect(pixelAt(ctx, 10, 4, 4)).toEqual([0, 255, 0, 255]);
+            expect(pixelAt(ctx, 10, 0, 0)).toEqual([0, 0, 0, 0]);
+        });
+
+        it("drawScaledObject scales the source footprint", () => {
+            const src = greenSource();
+            const dest = makeBitmap(10, 10, true);
+            dest.getMethod("drawScaledObject").call(
+                interpreter,
+                new Int32(0),
+                new Int32(0),
+                new Float(2.0),
+                new Float(2.0),
+                src
+            );
+            const ctx = dest.getContext();
+            // A 4x4 source scaled 2x covers (0,0)-(8,8).
+            expect(pixelAt(ctx, 10, 7, 7)[3]).toBeGreaterThan(0);
+            expect(pixelAt(ctx, 10, 8, 8)[3]).toBe(0);
+        });
+
+        it("drawRotatedObject at theta=0 behaves like an unrotated blit", () => {
+            const src = greenSource();
+            const dest = makeBitmap(10, 10, true);
+            dest.getMethod("drawRotatedObject").call(interpreter, new Int32(3), new Int32(3), new Float(0.0), src);
+            const ctx = dest.getContext();
+            expect(pixelAt(ctx, 10, 4, 4)).toEqual([0, 255, 0, 255]);
+        });
+
+        it("drawTransformedObject composes rotation and scale without throwing", () => {
+            const src = greenSource();
+            const dest = makeBitmap(10, 10, true);
+            const result = dest
+                .getMethod("drawTransformedObject")
+                .call(interpreter, new Int32(5), new Int32(5), new Float(90.0), new Float(1.0), new Float(1.0), src);
+            expect(result).toBe(BrsBoolean.True);
+            const ctx = dest.getContext();
+            // Some pixel near the pivot should have been painted; exact footprint is rotation math,
+            // not what this test is pinning down.
+            const total = ctx.getImageData(0, 0, 10, 10).data.reduce((sum, v) => sum + v, 0);
+            expect(total).toBeGreaterThan(0);
+        });
+    });
+
+    describe("simple property Callables", () => {
+        it("getWidth/getHeight report the component's size", () => {
+            const bmp = makeBitmap(7, 9, false);
+            expect(bmp.getMethod("getWidth").call(interpreter)).toEqual(new Int32(7));
+            expect(bmp.getMethod("getHeight").call(interpreter)).toEqual(new Int32(9));
+        });
+
+        it("getAlphaEnable/setAlphaEnable round-trip", () => {
+            const bmp = makeBitmap(7, 9, false);
+            expect(bmp.getMethod("getAlphaEnable").call(interpreter)).toBe(BrsBoolean.False);
+            bmp.getMethod("setAlphaEnable").call(interpreter, BrsBoolean.True);
+            expect(bmp.getMethod("getAlphaEnable").call(interpreter)).toBe(BrsBoolean.True);
+        });
+
+        it("clear fills the whole canvas with the given color", () => {
+            const bmp = makeBitmap(4, 4, true);
+            bmp.getMethod("clear").call(interpreter, rgba(0xaabbccff));
+            const ctx = bmp.getContext();
+            expect(pixelAt(ctx, 4, 0, 0)).toEqual([170, 187, 204, 255]);
+            expect(pixelAt(ctx, 4, 3, 3)).toEqual([170, 187, 204, 255]);
+        });
+
+        it("finish is a no-op that returns invalid", () => {
+            const bmp = makeBitmap(4, 4, true);
+            const result = bmp.getMethod("finish").call(interpreter);
+            expect(result.toString()).toBe("invalid");
+        });
+    });
+
+    describe("getByteArray and getPng", () => {
+        it("getByteArray returns the raw RGBA pixel bytes", () => {
+            const bmp = makeBitmap(2, 2, true);
+            bmp.getMethod("clear").call(interpreter, rgba(0xaabbccff));
+            const byteArray = bmp
+                .getMethod("getByteArray")
+                .call(interpreter, new Int32(0), new Int32(0), new Int32(2), new Int32(2));
+            expect(Array.from(byteArray.elements.slice(0, 4))).toEqual([170, 187, 204, 255]);
+            expect(byteArray.elements.length).toBe(2 * 2 * 4);
+        });
+
+        it("getPng round-trips a solid opaque color through the PNG codec", () => {
+            const bmp = makeBitmap(4, 4, true);
+            bmp.getMethod("clear").call(interpreter, rgba(0x112233ff));
+            const png = bmp
+                .getMethod("getPng")
+                .call(interpreter, new Int32(0), new Int32(0), new Int32(4), new Int32(4));
+            const decoded = UPNG.decode(Buffer.from(png.elements));
+            expect(decoded.width).toBe(4);
+            expect(decoded.height).toBe(4);
+            const rgba8 = new Uint8Array(UPNG.toRGBA8(decoded)[0]);
+            expect(Array.from(rgba8.slice(0, 4))).toEqual([17, 34, 51, 255]);
+        });
+    });
+
+    describe("clip stack (pushClip/popClip/resetClips/getClipDepth)", () => {
+        it("clips drawing to the pushed rectangle and restores it on pop", () => {
+            const bmp = makeBitmap(10, 10, true);
+            const ifd = new IfDraw2D(bmp);
+            expect(ifd.getClipDepth()).toBe(0);
+
+            ifd.pushClip({ x: 2, y: 2, width: 4, height: 4 });
+            expect(ifd.getClipDepth()).toBe(1);
+            ifd.doDrawRotatedRect({ x: 0, y: 0, width: 10, height: 10 }, 0x00ff00ff | 0, 0);
+            ifd.popClip();
+            expect(ifd.getClipDepth()).toBe(0);
+
+            const ctx = bmp.getContext();
+            expect(pixelAt(ctx, 10, 3, 3)[3]).toBeGreaterThan(0);
+            expect(pixelAt(ctx, 10, 0, 0)[3]).toBe(0);
+            expect(pixelAt(ctx, 10, 9, 9)[3]).toBe(0);
+        });
+
+        it("resetClips unwinds an unbalanced push depth so a leaked clip cannot poison later frames", () => {
+            const bmp = makeBitmap(4, 4, true);
+            const ifd = new IfDraw2D(bmp);
+            ifd.pushClip({ x: 0, y: 0, width: 1, height: 1 });
+            ifd.pushClip({ x: 0, y: 0, width: 1, height: 1 });
+            expect(ifd.getClipDepth()).toBe(2);
+
+            ifd.resetClips();
+            expect(ifd.getClipDepth()).toBe(0);
+        });
+
+        it("popClip at depth 0 is a no-op, not an error", () => {
+            const bmp = makeBitmap(4, 4, true);
+            const ifd = new IfDraw2D(bmp);
+            expect(() => ifd.popClip()).not.toThrow();
+            expect(ifd.getClipDepth()).toBe(0);
+        });
+    });
+
+    describe("pushScale/popScale", () => {
+        it("is a no-op at scale [1,1] and reports that nothing was pushed", () => {
+            const bmp = makeBitmap(10, 10, true);
+            const ifd = new IfDraw2D(bmp);
+            expect(ifd.pushScale(0, 0, 1, 1)).toBe(false);
+        });
+
+        it("pushes a transform at any other scale and pairs cleanly with popScale", () => {
+            const bmp = makeBitmap(10, 10, true);
+            const ifd = new IfDraw2D(bmp);
+            expect(ifd.pushScale(0, 0, 2, 2)).toBe(true);
+            expect(() => ifd.popScale()).not.toThrow();
+        });
+    });
+
+    describe("do* drawing primitives", () => {
+        it("doClearCanvas fills the whole canvas", () => {
+            const bmp = makeBitmap(5, 5, true);
+            new IfDraw2D(bmp).doClearCanvas(0x00ff00ff | 0);
+            expect(pixelAt(bmp.getContext(), 5, 0, 0)).toEqual([0, 255, 0, 255]);
+        });
+
+        it("doDrawScaledObject scales the source into the destination", () => {
+            const src = makeBitmap(2, 2, true);
+            new IfDraw2D(src).doClearCanvas(0xff0000ff | 0);
+            const dest = makeBitmap(10, 10, true);
+            const ok = new IfDraw2D(dest).doDrawScaledObject(1, 1, 3, 3, src);
+            expect(ok).toBe(true);
+            const ctx = dest.getContext();
+            expect(pixelAt(ctx, 10, 3, 3)).toEqual([255, 0, 0, 255]);
+            expect(pixelAt(ctx, 10, 7, 7)[3]).toBe(0);
+        });
+
+        it("doDrawCroppedBitmap draws only the requested source sub-rect, scaled into destRect", () => {
+            const src = makeBitmap(4, 4, true);
+            new IfDraw2D(src).doClearCanvas(0x0000ffff | 0);
+            const dest = makeBitmap(10, 10, true);
+            new IfDraw2D(dest).doDrawCroppedBitmap(
+                src,
+                { x: 1, y: 1, width: 2, height: 2 },
+                { x: 3, y: 3, width: 2, height: 2 }
+            );
+            const ctx = dest.getContext();
+            expect(pixelAt(ctx, 10, 3, 3)).toEqual([0, 0, 255, 255]);
+            expect(pixelAt(ctx, 10, 2, 2)[3]).toBe(0);
+        });
+
+        it("doDrawRotatedBitmap at 180 degrees flips the draw across its pivot", () => {
+            const src = makeBitmap(2, 2, true);
+            new IfDraw2D(src).doClearCanvas(0x0000ffff | 0);
+            const dest = makeBitmap(10, 10, true);
+            new IfDraw2D(dest).doDrawRotatedBitmap(4, 4, 1, 1, Math.PI, src);
+            const ctx = dest.getContext();
+            // Unrotated, a 2x2 blit at (4,4) would occupy (4,4)-(6,6); at 180deg it lands at (2,2)-(4,4).
+            expect(pixelAt(ctx, 10, 2, 2)[3]).toBeGreaterThan(0);
+            expect(pixelAt(ctx, 10, 4, 4)[3]).toBe(0);
+        });
+
+        it("doDrawRotatedRect scales around the rect's own origin as pivot", () => {
+            const bmp = makeBitmap(10, 10, true);
+            new IfDraw2D(bmp).doDrawRotatedRect(
+                { x: 1, y: 1, width: 2, height: 2 },
+                0xff0000ff | 0,
+                0,
+                undefined,
+                1,
+                2,
+                2
+            );
+            const ctx = bmp.getContext();
+            // A 2x2 rect at (1,1) scaled 2x around its own top-left corner covers (1,1)-(5,5).
+            expect(pixelAt(ctx, 10, 1, 1)[3]).toBeGreaterThan(0);
+            expect(pixelAt(ctx, 10, 4, 4)[3]).toBeGreaterThan(0);
+            expect(pixelAt(ctx, 10, 5, 5)[3]).toBe(0);
+        });
+
+        it("doDrawClearedRect erases a rectangle back to transparent", () => {
+            const bmp = makeBitmap(6, 6, true);
+            const ifd = new IfDraw2D(bmp);
+            ifd.doClearCanvas(0xffffffff | 0);
+            ifd.doDrawClearedRect({ x: 1, y: 1, width: 2, height: 2 });
+            const ctx = bmp.getContext();
+            expect(pixelAt(ctx, 6, 1, 1)).toEqual([0, 0, 0, 0]);
+            expect(pixelAt(ctx, 6, 0, 0)).toEqual([255, 255, 255, 255]);
+        });
+
+        it("doDrawText/doDrawRotatedText no-op on empty strings without touching the font", () => {
+            const bmp = makeBitmap(5, 5, true);
+            const ifd = new IfDraw2D(bmp);
+            expect(() => ifd.doDrawText("", 0, 0, 0xffffffff | 0, 1, undefined)).not.toThrow();
+            expect(() => ifd.doDrawRotatedText("", 0, 0, 0xffffffff | 0, 1, undefined, 0)).not.toThrow();
+        });
+    });
+
+    describe("drawNinePatch", () => {
+        function makeNinePatchSource() {
+            const size = 10;
+            const canvas = createCanvas(size, size);
+            const ctx = canvas.getContext("2d");
+            ctx.fillStyle = "rgba(255, 255, 255, 1)";
+            ctx.fillRect(1, 1, size - 2, size - 2);
+            ctx.fillStyle = "rgba(0, 0, 0, 0.5)";
+            ctx.fillRect(4, 0, 2, 1); // top stretch marker
+            ctx.fillRect(0, 4, 1, 2); // left stretch marker
+            ctx.fillStyle = "rgba(0, 0, 0, 1)";
+            ctx.fillRect(0, size - 1, size, 1); // bottom padding marker through both corners
+            return new RoBitmap(canvas.toBuffer("image/png"), "pkg:/images/bar.9.png");
+        }
+
+        it("clamps the drawn size to the fixed-corner sum instead of collapsing/inverting at 0", () => {
+            const bitmap = makeNinePatchSource();
+            expect(bitmap.getPatchSizes()).toEqual({
+                left: 3,
+                right: 3,
+                top: 3,
+                bottom: 3,
+                margins: { left: 0, right: 0, top: 0, bottom: 0 },
+            });
+
+            const target = makeBitmap(20, 20, true);
+            new IfDraw2D(target).drawNinePatch(bitmap, { x: 0, y: 0, width: 0, height: 0 }, undefined, 1);
+            const ctx = target.getContext();
+            let painted = 0;
+            for (let x = 0; x < 20; x++) {
+                if (pixelAt(ctx, 20, x, 3)[3] > 8) {
+                    painted++;
+                }
+            }
+            // left(3) + right(3) fixed corners, never fewer even when the requested size is 0.
+            expect(painted).toBe(6);
+        });
+    });
+
+    describe("module-level draw helpers", () => {
+        function magentaSource() {
+            const src = makeBitmap(4, 4, true);
+            src.getMethod("clear").call(interpreter, rgba(0xff00ffff));
+            return src;
+        }
+
+        it("drawObjectToComponent short-circuits at alpha=0 without touching the destination", () => {
+            const src = magentaSource();
+            const dest = makeBitmap(10, 10, true);
+            const before = Buffer.from(dest.getContext().getImageData(0, 0, 10, 10).data);
+            const result = drawObjectToComponent(dest, src, 2, 2, 1, 1, undefined, 0);
+            expect(result).toBe(true);
+            const after = Buffer.from(dest.getContext().getImageData(0, 0, 10, 10).data);
+            expect(after.equals(before)).toBe(true);
+        });
+
+        it("drawObjectToComponent draws the source when alpha is non-zero", () => {
+            const src = magentaSource();
+            const dest = makeBitmap(10, 10, true);
+            const result = drawObjectToComponent(dest, src, 2, 2);
+            expect(result).toBe(true);
+            expect(pixelAt(dest.getContext(), 10, 3, 3)).toEqual([255, 0, 255, 255]);
+        });
+
+        it("drawBitmapOnBitmap copies one bitmap's canvas onto another's", () => {
+            const src = magentaSource();
+            const dest = makeBitmap(4, 4, true);
+            drawBitmapOnBitmap(src, dest);
+            expect(pixelAt(dest.getContext(), 4, 1, 1)).toEqual([255, 0, 255, 255]);
+        });
+
+        it("drawRotatedObject (module function) rotates the draw about (x, y)", () => {
+            const src = magentaSource();
+            const dest = makeBitmap(10, 10, true);
+            const ok = drawRotatedObject(dest, src, 4, 4, 180);
+            expect(ok).toBe(true);
+            expect(pixelAt(dest.getContext(), 10, 2, 2)[3]).toBeGreaterThan(0);
+            expect(pixelAt(dest.getContext(), 10, 4, 4)[3]).toBe(0);
+        });
+
+        it("drawImageAtPos blits a canvas at a fixed position", () => {
+            const src = magentaSource();
+            const dest = makeBitmap(10, 10, true);
+            drawImageAtPos(src.getCanvas(), dest.getContext(), 1, 1);
+            expect(pixelAt(dest.getContext(), 10, 2, 2)).toEqual([255, 0, 255, 255]);
+        });
+
+        it("putImageAtPos writes raw ImageData at a fixed position", () => {
+            const src = magentaSource();
+            const dest = makeBitmap(10, 10, true);
+            const imgData = src.getContext().getImageData(0, 0, 4, 4);
+            putImageAtPos(imgData, dest.getContext(), 3, 3);
+            expect(pixelAt(dest.getContext(), 10, 3, 3)).toEqual([255, 0, 255, 255]);
+        });
+
+        it("drawCanvasRegion blits a scaled sub-region between canvases", () => {
+            const src = magentaSource();
+            const dest = makeBitmap(10, 10, true);
+            drawCanvasRegion(dest.getContext(), src.getCanvas(), 0, 0, 4, 4, 5, 5, 4, 4);
+            expect(pixelAt(dest.getContext(), 10, 6, 6)).toEqual([255, 0, 255, 255]);
+        });
+
+        it("createNewCanvas/releaseCanvas allocate and free a canvas's backing size", () => {
+            const canvas = createNewCanvas(5, 5);
+            expect(canvas.width).toBe(5);
+            expect(canvas.height).toBe(5);
+            releaseCanvas(canvas);
+            expect(canvas.width).toBe(0);
+            expect(canvas.height).toBe(0);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Simplifies `src/core/brsTypes/interfaces/IfDraw2D.ts` (a `/simplify` code-quality pass): extracts a shared `applyScaleModeSmoothing` helper (was duplicated 4x), replaces the nine-patch draw's per-call `drawPart` closure with a data-driven `DrawChunk[]` array + `drawNinePatchPart` loop, extracts `getImageDataRect` shared by `getByteArray`/`getPng`, and hoists a few redundant recomputations (`getDrawChunks`'s repeated offset math, `drawRect`'s duplicate `getValue()` calls).
- All changes are behavior-preserving — verified line-by-line against the original nine-patch draw order, and confirmed via the full test suite plus both `ts-loader` build variants (`build:node`/`build:sg` and `build:api`, exercising both `/// #if BROWSER` branches). One earlier draft accidentally broke TypeScript's `instanceof` narrowing on a shared canvas-type guard (`TS2349`); that was caught by the build and reverted in favor of keeping the narrowing inline, since it's load-bearing, not incidental duplication.
- Adds `test/brsTypes/interfaces/IfDraw2D.test.js` — the first dedicated unit test file for this interface (43 tests). Covers geometry/color helpers, the BrightScript-facing `Callable` surface (`drawRect`, `drawLine`, `drawPoint`, `drawObject` family, `getByteArray`/`getPng` with a real PNG round-trip), the clip stack (`pushClip`/`popClip`/`resetClips`), `pushScale`/`popScale`, the `do*` drawing primitives, nine-patch clamping at zero size, and the exported module-level draw helpers (`drawObjectToComponent`, `drawBitmapOnBitmap`, `drawImageAtPos`, etc.).

## Test plan
- [x] `npm run lint` / `npx prettier --check`
- [x] `npm run build:node`, `npm run build:sg`, `npm run build:api` (both ifdef-loader branches compile clean)
- [x] `npm test` — 220 files / 2897 tests pass, including the new `IfDraw2D.test.js`
- [x] `/code-review` (forked agent) — no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UWszA9nJRkmi6sdEcteWT