### PR TITLE
Bump to v2.5.3 (core) and v0.5.3 (rsg)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented in this file.
 
+<a name="v2.5.3"></a>
+
+## [v2.5.3 - SceneGraph Copy Semantics and Node Hierarchy Fixes](https://github.com/lvcabral/brs-engine/releases/tag/v2.5.3) - 03 September 2026
+
+This patch release fixes copying an `assocarray`/`array` containing a SceneGraph node: the node itself was being cloned rather than carried over, leaving a broken copy whose script scope read back `invalid` — the fix and its container-copy semantics (dropped uncopyable members, cycle safety, `clone()` base-type behavior) are verified against a real device across four new probes. A related fix corrects the class hierarchy so every built-in node beyond a direct `Group` child reports its full `isSubtype()`/`parentSubtype()` chain instead of collapsing to `"Node"`, and adds `RenderableNode` as a documented `Group` alias. The remaining documented `ChannelStore` node commands — Roku Pay credential storage and TVOD partner orders — are now mocked, along with several spec deviations in the commands already implemented. The core engine also gains a performance improvement that defers `roArray`/`roAssociativeArray`/`roList`/`roRegion`/`roBitmap`'s method-surface construction to first use, cutting a representative SceneGraph layout benchmark by 30%. Read the full release notes below for more details.
+
+### Release Changes
+
+#### Core Engine
+
+* (brs) Build expensive component method surfaces (`roArray`, `roAssociativeArray`, `roList`, `roRegion`, `roBitmap`) lazily, improving SceneGraph layout performance by up to 30% by [@lvcabral](https://github.com/lvcabral) in [#1208](https://github.com/lvcabral/brs-engine/pull/1208)
+* (draw2d) Simplified `IfDraw2D.ts` and added dedicated unit tests by [@lvcabral](https://github.com/lvcabral) in [#1212](https://github.com/lvcabral/brs-engine/pull/1212)
+
+#### SceneGraph Extension (`brs-scenegraph` release v0.5.3)
+
+* (rsg) Mocked the remaining documented `ChannelStore` node commands (Roku Pay credential storage and TVOD partner orders) and fixed spec deviations in existing ones by [@lvcabral](https://github.com/lvcabral) in [#1205](https://github.com/lvcabral/brs-engine/pull/1205)
+* (rsg) Aligned container and node copy semantics with the device, so copying an `assocarray`/`array` no longer clones a SceneGraph node inside it by [@lvcabral](https://github.com/lvcabral) in [#1207](https://github.com/lvcabral/brs-engine/pull/1207)
+* (rsg) Added `RenderableNode` as an alias for `Group` and fixed multi-level subtype hierarchy registration by [@lvcabral](https://github.com/lvcabral) in [#1210](https://github.com/lvcabral/brs-engine/pull/1210)
+
+#### Chores, Build and Dependencies
+
+* build(deps): bump `fflate` from 0.8.2 to 0.8.3 by @dependabot in [#1211](https://github.com/lvcabral/brs-engine/pull/1211)
+* Upgraded dependencies
+
+[Full Changelog][v2.5.3]
+
 <a name="v2.5.2"></a>
 
 ## [v2.5.2 - Text Baseline, Packaging and Stability Fixes](https://github.com/lvcabral/brs-engine/releases/tag/v2.5.2) - 29 August 2026
@@ -1833,6 +1859,7 @@ The following is the list of components implemented (some partially or just mock
 
 [Full Changelog][v0.1.0-emu]
 
+[v2.5.3]: https://github.com/lvcabral/brs-engine/compare/v2.5.2...v2.5.3
 [v2.5.2]: https://github.com/lvcabral/brs-engine/compare/v2.5.1...v2.5.2
 [v2.5.1]: https://github.com/lvcabral/brs-engine/compare/v2.5.0...v2.5.1
 [v2.5.0]: https://github.com/lvcabral/brs-engine/compare/v2.4.0...v2.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brs-engine-workspace",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "brs-engine-workspace",
-      "version": "2.5.2",
+      "version": "2.5.3",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -13309,6 +13309,24 @@
         }
       }
     },
+    "node_modules/vite-node/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/vitest": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
@@ -13531,6 +13549,24 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/watchpack": {
@@ -14197,7 +14233,7 @@
     },
     "packages/browser": {
       "name": "brs-engine",
-      "version": "2.5.2",
+      "version": "2.5.3",
       "license": "MIT",
       "dependencies": {
         "@lvcabral/libwebp": "^0.2.0",
@@ -14274,7 +14310,7 @@
     },
     "packages/node": {
       "name": "brs-node",
-      "version": "2.5.2",
+      "version": "2.5.3",
       "license": "MIT",
       "dependencies": {
         "@lvcabral/libwebp": "^0.2.0",
@@ -14357,7 +14393,7 @@
     },
     "packages/scenegraph": {
       "name": "brs-scenegraph",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
         "p-settle": "^5.1.1",
@@ -14377,7 +14413,7 @@
         "zip-webpack-plugin": "^4.0.3"
       },
       "peerDependencies": {
-        "brs-engine": "^2.5.2"
+        "brs-engine": "^2.5.3"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brs-engine-workspace",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "private": true,
   "title": "BrightScript Simulation Engine",
   "description": "BrightScript Simulation Engine - Run Roku apps on Browsers and Node.js",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brs-engine",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "title": "BrightScript Simulation Engine",
   "description": "BrightScript Simulation Engine - Run Roku apps on Browsers and Electron",
   "author": "Marcelo Lv Cabral <marcelo@lvcabral.com> (https://lvcabral.com/)",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brs-node",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "title": "BrightScript Simulation Engine",
   "description": "BrightScript Simulation Engine - Run Roku apps on Node.js or Terminal (CLI)",
   "author": "Marcelo Lv Cabral <marcelo@lvcabral.com> (https://lvcabral.com/)",

--- a/packages/scenegraph/CHANGELOG.md
+++ b/packages/scenegraph/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to `brs-scenegraph` extension will be documented in this file.
 
+<a name="v0.5.3"></a>
+
+## [v0.5.3 (beta) - Copy Semantics and Node Hierarchy Fixes](https://github.com/lvcabral/brs-engine/releases/tag/brs-sg-v0.5.3) - 03 September 2026
+
+This patch release fixes copying an `assocarray`/`array` containing a SceneGraph node: the node itself was being cloned rather than carried over, leaving a broken copy whose script scope read back `invalid` — verified against a real device across four new probes. A related fix corrects the class hierarchy so every built-in node beyond a direct `Group` child reports its full `isSubtype()`/`parentSubtype()` chain instead of collapsing to `"Node"`, and adds `RenderableNode` as a documented `Group` alias. The remaining documented `ChannelStore` node commands — Roku Pay credential storage and TVOD partner orders — are now mocked, along with several spec deviations in the commands already implemented. Read the full release notes below for more details.
+
+### Release Changes
+
+* (rsg) Mocked the remaining documented `ChannelStore` node commands (Roku Pay credential storage and TVOD partner orders) and fixed spec deviations in existing ones by [@lvcabral](https://github.com/lvcabral) in [#1205](https://github.com/lvcabral/brs-engine/pull/1205)
+* (rsg) Aligned container and node copy semantics with the device, so copying an `assocarray`/`array` no longer clones a SceneGraph node inside it by [@lvcabral](https://github.com/lvcabral) in [#1207](https://github.com/lvcabral/brs-engine/pull/1207)
+* (rsg) Added `RenderableNode` as an alias for `Group` and fixed multi-level subtype hierarchy registration by [@lvcabral](https://github.com/lvcabral) in [#1210](https://github.com/lvcabral/brs-engine/pull/1210)
+
+[Full Changelog][v0.5.3]
+
 <a name="v0.5.2"></a>
 
 ## [v0.5.2 (beta) - Poll-Loop Rendering Fix](https://github.com/lvcabral/brs-engine/releases/tag/brs-sg-v0.5.2) - 29 August 2026
@@ -400,6 +414,7 @@ This first alpha delivers the **SceneGraph** runtime as a standalone extension t
   * Media + utility nodes: `Audio`, `Video`, `SoundEffect`, `Task`, `Timer`, `ChannelStore`.
 * Published merged `assets/common.zip` so SceneGraph fonts, locale data, dialogs, and imagery are available through the simulated `common:/` volume in both `brs-engine` and `brs-node` packages.
 
+[v0.5.3]: https://github.com/lvcabral/brs-engine/compare/brs-sg-v0.5.2...brs-sg-v0.5.3
 [v0.5.2]: https://github.com/lvcabral/brs-engine/compare/brs-sg-v0.5.1...brs-sg-v0.5.2
 [v0.5.1]: https://github.com/lvcabral/brs-engine/compare/brs-sg-v0.5.0...brs-sg-v0.5.1
 [v0.5.0]: https://github.com/lvcabral/brs-engine/compare/brs-sg-v0.4.0...brs-sg-v0.5.0

--- a/packages/scenegraph/package.json
+++ b/packages/scenegraph/package.json
@@ -1,6 +1,6 @@
 {
     "name": "brs-scenegraph",
-    "version": "0.5.2",
+    "version": "0.5.3",
     "description": "SceneGraph addon for BrightScript Simulation Engine",
     "author": "Marcelo Lv Cabral <marcelo@lvcabral.com> (https://lvcabral.com/)",
     "license": "MIT",
@@ -42,7 +42,7 @@
         "p-settle": "^5.1.1"
     },
     "peerDependencies": {
-        "brs-engine": "^2.5.2"
+        "brs-engine": "^2.5.3"
     },
     "devDependencies": {
         "@types/node": "^22.13.2",


### PR DESCRIPTION
## Summary

- Bumps `brs-engine`, `brs-node`, and the root workspace to **v2.5.3**, and `brs-scenegraph` to **v0.5.3** (`peerDependencies.brs-engine` updated in lockstep).
- Adds the `v2.5.3`/`v0.5.3` sections to `CHANGELOG.md` and `packages/scenegraph/CHANGELOG.md`, covering the 6 commits merged since v2.5.2:
  - #1205 — Mocked the remaining documented `ChannelStore` node commands (Roku Pay credential storage and TVOD partner orders)
  - #1207 — Aligned container and node copy semantics with the device (assocarray/array no longer clones a SceneGraph node)
  - #1208 — Build expensive component method surfaces lazily (`roArray`, `roAssociativeArray`, `roList`, `roRegion`, `roBitmap`), ~30% SceneGraph layout perf gain
  - #1210 — Added `RenderableNode` alias for `Group`, fixed multi-level subtype hierarchy
  - #1211 — Bumped `fflate` from 0.8.2 to 0.8.3
  - Dependency lockfile upgrade

## Test plan

- [x] `npm run lint`
- [x] `npm run prettier`
- [x] Verified no stale `2.5.2`/`0.5.2` version references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UWszA9nJRkmi6sdEcteWT