### PR TITLE
fix(core): consume the callback queue exactly once in peekMessage()

### DIFF
--- a/src/core/brsTypes/components/RoMessagePort.ts
+++ b/src/core/brsTypes/components/RoMessagePort.ts
@@ -158,8 +158,8 @@ export class RoMessagePort extends BrsComponent implements BrsValue {
                 return this.messageQueue[0];
             }
             if (this.callbackQueue.length > 0) {
-                let callback = this.callbackQueue[0];
-                if (callback) {
+                const callback = this.callbackQueue.shift();
+                if (typeof callback === "function") {
                     const msg = callback();
                     if (!isInvalid(msg)) {
                         this.messageQueue.push(msg);

--- a/test/brsTypes/components/RoURLTransfer.test.js
+++ b/test/brsTypes/components/RoURLTransfer.test.js
@@ -109,4 +109,39 @@ describe("RoURLTransfer", () => {
             expect(transfer.postFromStringAsync()).toBe(BrsInvalid.Instance);
         });
     });
+
+    describe("AsyncGetToString + PeekMessage", () => {
+        // PeekMessage() used to read callbackQueue[0] without removing it, so for roUrlTransfer's
+        // callbackQueue entries (one-shot job thunks that perform a real, synchronous HTTP request)
+        // the same pending job kept firing on every PeekMessage() call once messageQueue drained —
+        // producing duplicate network requests and repeated roUrlEvent delivery in the very common
+        // PeekMessage()+GetMessage() polling idiom. Regression for that zombie-callback bug.
+        it("fires the request only once across a PeekMessage()+GetMessage() poll loop", () => {
+            const transfer = new RoURLTransfer();
+            const port = new RoMessagePort();
+            transfer.getMethod("setMessagePort").call(interpreter, port);
+
+            let callCount = 0;
+            transfer.getToStringEvent = () => {
+                callCount++;
+                return new RoURLEvent(1, "", "ok", 200, "", "");
+            };
+
+            transfer.getMethod("asyncGetToString").call(interpreter);
+
+            const peekMessage = port.getMethod("peekMessage");
+            const getMessage = port.getMethod("getMessage");
+
+            // Common app idiom: peek, then get once a message is available.
+            const peeked = peekMessage.call(interpreter);
+            expect(peeked).toBeInstanceOf(RoURLEvent);
+
+            const gotten = getMessage.call(interpreter);
+            expect(gotten).toBeInstanceOf(RoURLEvent);
+
+            // A further poll with no new async call queued must not re-fire the request.
+            expect(peekMessage.call(interpreter)).toBe(BrsInvalid.Instance);
+            expect(callCount).toBe(1);
+        });
+    });
 });

--- a/test/simulator/probes/task-url-peek-loop-probe/README.md
+++ b/test/simulator/probes/task-url-peek-loop-probe/README.md
@@ -1,0 +1,87 @@
+# Task URL PeekMessage Loop Probe
+
+Reproduces a user report: during app initialization, while downloading configuration from the
+internet, the simulator entered an infinite loop, repeatedly delivering what looked like the same
+`roUrlEvent` on the message port — even though the download itself completed fine. No app source
+was available, so this probe was built purely from tracing how the engine implements async
+`roUrlTransfer` calls and message-port delivery.
+
+## Why
+
+`AsyncGetToString`/`AsyncGetToFile`/`AsyncHead`/`AsyncPostFromString`/`AsyncPostFromFile`/
+`AsyncPostFromFileToFile` (`src/core/brsTypes/components/RoURLTransfer.ts`) don't perform the HTTP
+request immediately. Each queues a one-shot job closure onto the target `roMessagePort`'s
+`callbackQueue` (`pushCallback`); the closure performs the real, **synchronous** HTTP request the
+first time something drains the port.
+
+`RoMessagePort` (`src/core/brsTypes/components/RoMessagePort.ts`) has two consumers of
+`callbackQueue`:
+
+- `getNextMessage()` (used by `GetMessage()`/`WaitMessage()`) correctly does
+  `this.callbackQueue.shift()` before invoking the closure — consumed exactly once.
+- `peekMessage()` used to instead read `callbackQueue[0]` and invoke it **without removing it**
+  from the queue.
+
+That corrupts the extremely common Roku polling idiom:
+
+```brightscript
+while true
+    msg = port.PeekMessage()
+    if msg <> invalid then msg = port.GetMessage() : ProcessEvent(msg)
+end while
+```
+
+1. `AsyncGetToString()` queues one closure.
+2. `PeekMessage()`: `messageQueue` empty → invokes the closure (real HTTP request) → pushes the
+   event to `messageQueue`. The closure is **not** removed from `callbackQueue`.
+3. `GetMessage()`: drains the event correctly. `callbackQueue` still holds the stale closure.
+4. Next loop iteration: `PeekMessage()` sees `callbackQueue.length > 0` again and invokes the
+   **same stale closure** — a second real HTTP request fires, producing a second `roUrlEvent`.
+   This repeats indefinitely.
+
+Because the downloaded content is typically stable (e.g. a config file), every one of those
+duplicate events looks like "the same event" being redelivered forever — matching the report. Each
+"redelivery" is a genuine new network round trip, not a replayed object.
+
+**Fix**: `peekMessage()` now does `this.callbackQueue.shift()` before invoking, mirroring
+`getNextMessage()`, so a queued job is consumed exactly once regardless of which method discovers
+it first.
+
+## What this probe does
+
+A background `Task` (`ConfigDownloadTask`) — the shape a real app uses to keep an init-time
+network call off the render thread — downloads a small, stable file over HTTPS using
+`AsyncGetToString()`, then drains its own port with the `PeekMessage()` + `GetMessage()` idiom
+above instead of `wait(timeout, port)`. It counts how many `roUrlEvent` objects arrive for that
+single async call and reports a verdict. Iteration/event caps keep it safe to run even against a
+still-broken engine — it reports the bug instead of hanging forever or hammering the network.
+
+`MainScene` creates the task, observes its `report` field, prints the report, and mirrors it onto
+its own `report` field; `source/main.brs` observes that field (via the port overload of
+`ObserveField`) to know when to close the screen and exit on its own.
+
+## Run
+
+```
+node packages/node/bin/brs.cli.js --root test/simulator/probes/task-url-peek-loop-probe -c 0
+```
+
+Requires outbound internet access (it downloads
+`https://raw.githubusercontent.com/lvcabral/brs-engine/refs/heads/master/packages/browser/package.json`,
+the same fixture already used by `test/e2e/resources/components/roURLTransfer.brs`).
+
+## Results
+
+Verified by temporarily reverting the `peekMessage()` fix in `RoMessagePort.ts`, rebuilding
+(`npm run build:node && npm run build:sg`), and re-running:
+
+| Build | Events delivered for one `AsyncGetToString()` call | Verdict |
+| --- | --- | --- |
+| Before fix (`callbackQueue[0]`, no shift) | 5 (hit the probe's safety cap — real engine would keep going) | `BUG REPRODUCED` |
+| After fix (`callbackQueue.shift()`) | 1 | `OK` |
+
+## Regression coverage
+
+`test/brsTypes/components/RoURLTransfer.test.js`, `describe("AsyncGetToString + PeekMessage")` —
+a deterministic, non-Task, non-network unit test pinning the same fix with a stubbed
+`getToStringEvent`.

--- a/test/simulator/probes/task-url-peek-loop-probe/components/ConfigDownloadTask.brs
+++ b/test/simulator/probes/task-url-peek-loop-probe/components/ConfigDownloadTask.brs
@@ -1,0 +1,103 @@
+' Reproduces a reported bug: an app that downloads its config from the internet during
+' initialization saw the SAME roUrlEvent delivered over and over, in what looked like an
+' infinite loop, even though the download itself completed fine.
+'
+' Root cause (see src/core/brsTypes/components/RoMessagePort.ts, peekMessage()): AsyncGetToString/
+' AsyncGetToFile/AsyncHead/AsyncPostFromString/AsyncPostFromFile/AsyncPostFromFileToFile don't run
+' the request immediately - they queue a one-shot job closure on the port's callbackQueue, which
+' performs the real (synchronous) HTTP request the first time something drains the port.
+' GetMessage()/WaitMessage() correctly `shift()` the closure off callbackQueue before invoking it,
+' but PeekMessage() used to only read callbackQueue[0] and invoke it WITHOUT removing it. So the
+' extremely common app idiom below - peek, then only GetMessage() once something is there - left a
+' "zombie" callback in the queue: every later PeekMessage() call (once messageQueue drained again)
+' re-invoked the SAME closure, firing a brand-new real HTTP request and delivering a brand-new
+' roUrlEvent, forever. Because the config content is stable, every one of those events looks like
+' "the same event" being redelivered - which matches the report.
+'
+' Run this probe against a build with the bug: VERDICT below reports BUG REPRODUCED, and the
+' download fires multiple real HTTP requests for a single AsyncGetToString() call. Against the
+' fixed engine it reports OK: exactly one event for one call.
+sub init()
+    m.top.functionName = "downloadConfig"
+end sub
+
+sub downloadConfig()
+    ' A small, stable file this project already uses elsewhere as a network test fixture -
+    ' see test/e2e/resources/components/roURLTransfer.brs.
+    configUrl = "https://raw.githubusercontent.com/lvcabral/brs-engine/refs/heads/master/packages/browser/package.json"
+
+    port = CreateObject("roMessagePort")
+    xfer = CreateObject("roUrlTransfer")
+    xfer.SetCertificatesFile("common:/certs/ca-bundle.crt")
+    xfer.InitClientCertificates()
+    xfer.RetainBodyOnError(true)
+    xfer.SetMessagePort(port)
+    xfer.SetUrl(configUrl)
+
+    lines = []
+    lines.push("========== Task URL PeekMessage Loop Probe ==========")
+    lines.push("Simulating an init-time config download driven by the common")
+    lines.push("PeekMessage() + GetMessage() poll idiom instead of wait(timeout, port):")
+    lines.push("")
+
+    started = xfer.AsyncGetToString()
+    lines.push("AsyncGetToString() called ONCE. started=" + started.toStr())
+    lines.push("")
+
+    ' Caps keep this safe to run even against a still-broken engine: it won't hang forever or
+    ' hammer the network - it just reports the bug instead. Once the first event lands, only
+    ' keep polling for a short tail (the zombie-callback bug re-fires on the very next poll that
+    ' finds messageQueue empty, so a handful of extra iterations is enough to catch it).
+    maxIterations = 60
+    maxEvents = 5
+    tailAfterFirstEvent = 15
+    iteration = 0
+    eventCount = 0
+    firstEventIteration = -1
+
+    while iteration < maxIterations and eventCount < maxEvents
+        iteration++
+        peeked = port.PeekMessage()
+        if peeked <> invalid
+            msg = port.GetMessage()
+            if type(msg) = "roUrlEvent"
+                eventCount++
+                if firstEventIteration = -1 then firstEventIteration = iteration
+                status = str(msg.GetResponseCode()).Trim()
+                lines.push("[" + str(eventCount).Trim() + "] roUrlEvent on iteration " + str(iteration).Trim() + " - status=" + status)
+            end if
+        else
+            sleep(10)
+        end if
+        if firstEventIteration <> -1 and (iteration - firstEventIteration) >= tailAfterFirstEvent then exit while
+    end while
+
+    lines.push("")
+    lines.push("Poll iterations used: " + str(iteration).Trim() + " / " + str(maxIterations).Trim())
+    lines.push("roUrlEvent objects delivered for that single AsyncGetToString() call: " + str(eventCount).Trim())
+    lines.push("")
+
+    if eventCount = 0
+        lines.push("VERDICT: INCONCLUSIVE - no roUrlEvent received within the iteration cap (check network access).")
+    else if eventCount = 1
+        lines.push("VERDICT: OK - exactly one roUrlEvent delivered for one AsyncGetToString() call.")
+    else
+        lines.push("VERDICT: BUG REPRODUCED - " + str(eventCount).Trim() + " roUrlEvent objects delivered (that many real HTTP requests fired) for a single AsyncGetToString() call.")
+    end if
+
+    ' A clean fix leaves nothing behind: this must come back invalid, not another event.
+    extra = port.PeekMessage()
+    if extra = invalid
+        lines.push("Post-loop PeekMessage(): invalid (no zombie callback left on the port)")
+    else
+        lines.push("Post-loop PeekMessage(): " + type(extra) + " (UNEXPECTED - a stray event/callback is still queued)")
+    end if
+
+    lines.push("========== end ==========")
+
+    out = ""
+    for each line in lines
+        out = out + line + chr(10)
+    end for
+    m.top.report = out
+end sub

--- a/test/simulator/probes/task-url-peek-loop-probe/components/ConfigDownloadTask.xml
+++ b/test/simulator/probes/task-url-peek-loop-probe/components/ConfigDownloadTask.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="ConfigDownloadTask" extends="Task">
+    <interface>
+        <field id="report" type="string" />
+    </interface>
+    <script type="text/brightscript" uri="pkg:/components/ConfigDownloadTask.brs" />
+</component>

--- a/test/simulator/probes/task-url-peek-loop-probe/components/MainScene.brs
+++ b/test/simulator/probes/task-url-peek-loop-probe/components/MainScene.brs
@@ -1,0 +1,16 @@
+' Kicks off the download on a background Task (the shape a real app uses to keep init-time
+' network calls off the render thread) and prints whatever the task reports back.
+sub init()
+    m.task = CreateObject("roSGNode", "ConfigDownloadTask")
+    m.task.observeField("report", "onReport")
+    m.task.control = "RUN"
+end sub
+
+sub onReport()
+    for each line in m.task.report.Split(chr(10))
+        if line <> "" then ? "[PEEKLOOP] " + line
+    end for
+    m.top.findNode("Results").text = m.task.report
+    ' Signals source/main.brs (observing this field) that it can close the screen and exit.
+    m.top.report = m.task.report
+end sub

--- a/test/simulator/probes/task-url-peek-loop-probe/components/MainScene.xml
+++ b/test/simulator/probes/task-url-peek-loop-probe/components/MainScene.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="MainScene" extends="Scene">
+    <interface>
+        <!-- Mirrors the task's report; source/main.brs observes this to know when to close. -->
+        <field id="report" type="string" />
+    </interface>
+    <script type="text/brightscript" uri="pkg:/components/MainScene.brs" />
+    <children>
+        <Label id="Results" translation="[40,30]" width="1840" height="1020" wrap="true" font="font:MediumSystemFont" />
+    </children>
+</component>

--- a/test/simulator/probes/task-url-peek-loop-probe/manifest
+++ b/test/simulator/probes/task-url-peek-loop-probe/manifest
@@ -1,0 +1,5 @@
+title=Task URL PeekMessage Loop Probe
+major_version=1
+minor_version=0
+build_version=00001
+ui_resolutions=fhd

--- a/test/simulator/probes/task-url-peek-loop-probe/source/main.brs
+++ b/test/simulator/probes/task-url-peek-loop-probe/source/main.brs
@@ -1,0 +1,20 @@
+sub Main()
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+    scene = screen.CreateScene("MainScene")
+    screen.show()
+
+    ' The scene's "report" field flips once the task's download loop finishes, so this
+    ' probe can close itself and exit rather than waiting for Home/Ctrl+D.
+    scene.ObserveField("report", port)
+
+    while true
+        msg = wait(0, port)
+        if type(msg) = "roSGScreenEvent"
+            if msg.isScreenClosed() then return
+        else if type(msg) = "roSGNodeEvent"
+            screen.close()
+        end if
+    end while
+end sub


### PR DESCRIPTION
## Summary

- `RoMessagePort.peekMessage()` read `callbackQueue[0]` without removing it, so a pending `roUrlTransfer` async job (`AsyncGetToString`, `AsyncGetToFile`, `AsyncHead`, `AsyncPostFromString`, `AsyncPostFromFile`, `AsyncPostFromFileToFile`) left a "zombie" callback in the queue after firing.
- In the very common `PeekMessage()` + `GetMessage()` polling idiom, every later `PeekMessage()` call re-invoked the same stale callback — firing a duplicate **real** HTTP request and delivering a brand-new `roUrlEvent` each time. Since the downloaded content is typically stable, this looks like the same event being redelivered forever (reported as an infinite loop during app init while downloading config).
- `getNextMessage()` (used by `GetMessage()`/`WaitMessage()`) already did `callbackQueue.shift()` correctly; `peekMessage()` now does the same, so a queued job is consumed exactly once regardless of which method discovers it first.
- Verified against the official Roku reference (`ifMessagePort`/`ifUrlTransfer` in `external/dev-doc`): `PeekMessage()` must keep returning the *same* message on repeated calls (still true — `messageQueue` peeks are unaffected), and a single async call must produce exactly one `roUrlEvent` (now true again).

## Test plan

- [x] New regression test in `test/brsTypes/components/RoURLTransfer.test.js` (`AsyncGetToString + PeekMessage`) pins the fix with a stubbed network call.
- [x] New Task-based probe app at `test/simulator/probes/task-url-peek-loop-probe/` reproduces the bug end-to-end over a real network call; verified it reports `BUG REPRODUCED` (5 duplicate requests/events) against the pre-fix code and `OK` (exactly 1) against the fix, by temporarily reverting/rebuilding.
- [x] `npm run lint` and `npm run prettier:write` clean.
- [x] Full suite: `npm test` — 220 files / 2898 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)