### PR TITLE
fix(core): roAppManager.getUpTime() was returning negative values

### DIFF
--- a/src/core/interpreter/index.ts
+++ b/src/core/interpreter/index.ts
@@ -109,7 +109,7 @@ const MainEnvironment: Environment = new Environment(new RoAssociativeArray([]))
  */
 export class Interpreter implements Expr.Visitor<BrsType>, Stmt.Visitor<BrsType> {
     private readonly _stack = new Array<TracePoint>();
-    private readonly _startTime = Date.now();
+    private readonly _startTime = performance.now();
     private readonly _creationTime = process.env.CREATION_TIME;
     private _environment: Environment;
     private _sourceMap = new Map<string, string>();

--- a/test/brsTypes/components/RoAppManager.test.js
+++ b/test/brsTypes/components/RoAppManager.test.js
@@ -10,7 +10,11 @@ describe("RoAppManager", () => {
     let ts;
 
     beforeEach(() => {
-        clock = fakeTimer.install({ toFake: ["Date", "performance"] });
+        // Only fake `Date`, pinned to a realistic epoch (not sinon's default of 0): `getUpTime` is
+        // marked from `performance.now()`, so leaving `performance` real and `Date` at a huge,
+        // real-world-scale epoch lets the tests below actually distinguish the two clocks (see the
+        // regression test in the "getUpTime" block, which catches them being mixed up).
+        clock = fakeTimer.install({ toFake: ["Date"], now: 1700000000000 });
         ts = new RoTimespan();
         interpreter = new Interpreter();
         interpreter.manifest = new Map();
@@ -37,6 +41,14 @@ describe("RoAppManager", () => {
             expect(totalMilliseconds).toBeTruthy();
             expect(upTime).toBeTruthy();
             expect(upTime.call(interpreter)).toEqual(totalMilliseconds.call(interpreter));
+        });
+
+        it("returns a non-negative elapsed time, not a clamped Int32.MIN_VALUE", () => {
+            let appManager = new RoAppManager();
+            let getUpTime = appManager.getMethod("getUpTime");
+            let upTime = getUpTime.call(interpreter).getMethod("totalMilliseconds");
+
+            expect(upTime.call(interpreter).getValue()).toBeGreaterThanOrEqual(0);
         });
     });
 


### PR DESCRIPTION
RoAppManager.getUpTime() (src/core/brsTypes/components/RoAppManager.ts) marks its returned RoTimespan with interpreter.startTime,  which was Date.now() (a huge wall-clock epoch, ~1.7×10¹²). But RoTimespan's elapsed-time methods always compute performance.now() - markTime, where performance.now() is a small monotonic value near process start. The mismatch produced a deeply negative delta that Int32's constructor clamped to Int32.MIN_VALUE (-2147483648) — so GetUptime().TotalMilliseconds() always returned exactly that constant, regardless of real elapsed time.

Fix: One-line change in src/core/interpreter/index.ts — Interpreter._startTime now uses performance.now() instead of Date.now(), matching the clock RoTimespan actually diffs against. Confirmed via grep this field has no other consumers, so nothing else is affected.