### PR TITLE
fix(scenegraph): DynamicKeyGrid crashes loading a KDF with a spacer row

### DIFF
--- a/src/extensions/scenegraph/nodes/kdf/KeyDefinition.ts
+++ b/src/extensions/scenegraph/nodes/kdf/KeyDefinition.ts
@@ -29,7 +29,8 @@ export interface KeyDef {
 export interface RowDef {
     rowHeightFHD?: number;
     rowHeightHD?: number;
-    keys: KeyDef[];
+    /** Omitted (or a null Row, e.g. `{}`) renders as blank, unfocusable space. */
+    keys?: KeyDef[];
 }
 
 export interface GridDef {
@@ -192,14 +193,15 @@ export function computeLayout(
             let rowY = inset.top;
             for (let r = 0; r < grid.rows.length; r++) {
                 const row = grid.rows[r];
+                const keys = row.keys ?? [];
                 const rowHeight = rowHeights[r];
                 const keyWidths = distribute(
                     sectionWidth,
-                    row.keys.map((key) => pick(res, key.keyWidthFHD, key.keyWidthHD))
+                    keys.map((key) => pick(res, key.keyWidthFHD, key.keyWidthHD))
                 );
                 let keyX = sectionX;
-                for (let c = 0; c < row.keys.length; c++) {
-                    const key = row.keys[c];
+                for (let c = 0; c < keys.length; c++) {
+                    const key = keys[c];
                     const keyWidth = keyWidths[c];
                     const label = key.label ?? "";
                     const strOut = key.strOut ?? "";

--- a/test/extensions/scenegraph/DynamicKeyboard.test.js
+++ b/test/extensions/scenegraph/DynamicKeyboard.test.js
@@ -774,6 +774,46 @@ describe("Dynamic voice keyboards", () => {
         });
     });
 
+    describe("DynamicKeyGrid Key Definition File loading", () => {
+        afterEach(() => {
+            BrsDevice.fileSystem.clearSourceOverlay();
+        });
+
+        test("a Row with no keys (spacer row) renders as blank space instead of throwing", () => {
+            // Real-device KDFs use a Row with only rowHeight and no `keys` (or `{}`) as a
+            // spacer between rows of keys; the spec calls this a "null Row" (blank space,
+            // not focusable). computeLayout() must tolerate the missing `keys` array.
+            BrsDevice.fileSystem.setSourceOverlay({
+                "pkg:/resources/keyboards/custom.json": JSON.stringify({
+                    keyboardWidthFHD: 300,
+                    keyboardHeightFHD: 200,
+                    keyboardWidthHD: 200,
+                    keyboardHeightHD: 133,
+                    sections: [
+                        {
+                            grids: [
+                                {
+                                    rows: [
+                                        { keys: [{ label: "a" }] },
+                                        { rowHeightFHD: 4, rowHeightHD: 2 }, // spacer row, no "keys"
+                                        { keys: [{ label: "b" }] },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                }),
+            });
+            const grid = SGNodeFactory.createNode("DynamicKeyGrid");
+            expect(() =>
+                grid.setValue("keyDefinitionUri", new BrsString("pkg:/resources/keyboards/custom.json"))
+            ).not.toThrow();
+            expect(grid.getValueJS("width")).toBe(200); // default test scene resolution is HD
+            expect(grid.getValueJS("height")).toBe(133);
+            expect(grid.getValueJS("keyFocused")).toBe("a");
+        });
+    });
+
     describe("DynamicKeyGrid focus management", () => {
         test("disabling the focused key moves focus to an adjacent key", () => {
             const pad = SGNodeFactory.createNode("DynamicPinPad");


### PR DESCRIPTION
## Summary
- A Key Definition File Row with no `keys` (a documented "null Row" spacer, e.g. `{ "rowHeightFHD": 4, "rowHeightHD": 2 }` with no `keys` array) crashed `computeLayout()` with `Cannot read properties of undefined (reading 'map')`, since `RowDef.keys` was typed/used as required.
- The exception was swallowed by `DynamicKeyGrid.loadKeyDefinition()`'s try/catch and misreported as a generic "failed to load Key Definition File" warning, obscuring the real cause.
- Fixed by making `RowDef.keys` optional and defaulting to `[]` in `computeLayout()`, matching the Roku spec's documented "null Row = blank, unfocusable space" behavior (`external/dev-doc/.../key-definition-file.md`).
- Confirmed this is unrelated to field aliasing: a live BrightScript write to an aliased `keyDefinitionUri` field already correctly propagates through to `DynamicKeyGrid.setValue()`/`loadKeyDefinition()`.

## Test plan
- [x] Added a regression test in `test/extensions/scenegraph/DynamicKeyboard.test.js` loading a KDF with a keys-less spacer row; verified it fails without the fix and passes with it.
- [x] `npm run lint` and `npm run prettier:write` pass.
- [x] `npx vitest run test/extensions/scenegraph/` — 88 files, 1030 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015h2jnvL2ErArRY17LhcKBQ