### PR TITLE
fix(scenegraph): rendezvous a render-initiated callFunc onto Task-owned nodes correctly

### DIFF
--- a/.claude/docs/threading-and-rendezvous.md
+++ b/.claude/docs/threading-and-rendezvous.md
@@ -75,8 +75,107 @@ A node's authoritative copy lives on its owner thread, so reading/writing a node
   `rendezvousCall(interpreter, "<method>", [args])`. When `shouldRendezvous()`, it serializes args (node
   args re-owned by thread 0) and calls `task.requestMethodCall(...)`, which blocks (default 10s timeout,
   logs "Rendezvous timeout") until `resp`/`nil`. `requestFieldValue` does the same for plain reads.
-- **Crossing into a node sends ownership**: a `Node` passed from a task to the render thread is re-owned
-  (`setOwner(0)`), so later access from the task rendezvouses back.
+- **Crossing into a node sends ownership *only when the task is reporting through its own
+  field*.** `Task.syncRemoteField` re-owns a `Node` value to render (`setOwner(0)`) when the task
+  is setting **its own** interface field (`m.top.xxx = someNode`, `address === this.address` —
+  a hand-off: the task isn't going to keep using the node itself, so render becoming its
+  permanent owner is correct, and the receiver needs to run `callFunc` against its own copy).
+  It must **not** re-own when the task is merely setting a field on some *other* render-owned
+  node (`address !== this.address` — e.g. `m.global.someHandle = someNode`, the common
+  "publish a singleton for other threads/components to discover" pattern): the task keeps using
+  its own local reference to that node forever after, so its ownership must not change.
+  Device-confirmed this distinction matters (real Roku does not re-own in the second case) —
+  getting it wrong was the actual New Relic SDK crash's root cause (see
+  `test/simulator/probes/node-owned-by-task-callfunc-probe/`, whose README documents the full
+  investigation): re-owning unconditionally made every later same-thread access on the owning
+  task incorrectly evaluate `shouldRendezvous()` as `true` and rendezvous *out* to render, which
+  only had a reconstructed copy missing whatever the task's own script populated. Regression:
+  `DirectRendezvous.test.js`'s "own field" vs "FOREIGN node" pair, and
+  `task-owned-node-callfunc-app` in `test/cli/`.
+- **A `callFunc` argument is never re-owned, on either the render→Task or task→render routing
+  branch** — `Node.buildMethodCallPayload`'s `reownToRender` boolean, threaded through from both
+  `rendezvousCallFunc` call sites (`rendezvousCall(..., false)` for the fallback branch,
+  `buildMethodCallPayload(..., false)` for the Task-target branch). Same rule and same root cause
+  as the field case above, just reached via a call argument: re-owning a `Node` argument to
+  whichever thread it's passed into breaks the caller's own later same-thread use of it.
+  `rendezvousCall`'s ~69 other, non-`callFunc` call sites keep the default (`true`) — those really
+  are a task→render hand-off. **Gotcha hit while fixing this**: giving the parameter a numeric
+  default (`= 0`) let an explicit `undefined` argument silently fall back to that default (JS
+  substitutes on `undefined`, not just omission) — hence the boolean instead of a nullable thread
+  id. Regression: `RenderTaskCallFunc.test.js`'s "keeps its own ownership" pair.
+- **`callFunc` on a Task rendezvouses even from the thread that owns the node** (device-confirmed — a
+  Task's callable interface functions always run on its own worker thread, independent of `owner`, which
+  models who built the node's *fields*, typically render). `shouldRendezvous()`'s `owner` check can never
+  catch this: a Task's render-side instance is *constructed* on render, so `owner === 0` forever. `callFunc`
+  therefore has its own routing pair — `Node.callFuncThread()` (only `Task` overrides it, returning its own
+  `threadId` when `active`) and `Node.rendezvousCallFunc()` — used exclusively by `RoSGNode.callFunc`, not
+  the other ~69 `rendezvousCall()` call sites (those stay owner-based; a Task's *fields* really are
+  render-owned and already work via the field-sync path above). Three branches: not an active Task →
+  falls back to `rendezvousCall` unchanged; `callFuncThread() === sgRoot.threadId` → run locally,
+  returning `undefined` **without** falling through to `rendezvousCall` — `handleMethodCallRequest`
+  re-dispatches `"callFunc"` through the Callable a second time once the request lands on the Task's own
+  thread, so falling through there would self-rendezvous back out to render; otherwise →
+  `Task.requestTaskMethodCall()`. That method's transport differs from `requestMethodCall`'s: the request
+  travels via `fanoutQueue`/`fanoutBuffer` (the only channel a Task polls every tick, not just while
+  blocked in its own outgoing wait — `directBuffer`/broker delivery are dead paths for a fresh
+  render-initiated request in current direct/fan-out mode), and the reply arrives on a **dedicated
+  `callBackBuffer`** (can't reuse `directBuffer` — a nested task→render rendezvous served while handling
+  the call, e.g. a `m.global` read, could be in flight on it at the same time, in the opposite direction).
+  The wait loop pumps `sgRoot.processTasks()` every iteration — otherwise that nested rendezvous, or any
+  other task's unrelated in-flight request, would deadlock behind this blocking wait, since incoming
+  requests are only ever served from `processTasks()` (see the *silence* note below). Regression:
+  `test/extensions/scenegraph/RenderTaskCallFunc.test.js` and `task-render-callfunc-app` in `test/cli/`.
+- **`callFunc` on an ordinary `Node` genuinely owned by a Task thread also rendezvouses, from *any*
+  caller — not just a Task-initiated one.** This is the base-class counterpart to the Task-specific
+  routing above: `shouldRendezvous()`/`rendezvousCall()` gate on the *caller* being a task thread
+  (`sgRoot.inTaskThread()`), so they never fire for a render-initiated call, no matter what the
+  target's `owner` is. That left a real gap: a plain `Node` a Task legitimately owns and keeps using
+  itself (not a Task target, and not merely field-owned by render the way most nodes are) was
+  unreachable from render's own `callFunc` — the exact shape a Task publishing an SDK singleton via
+  `m.global` produces once the ownership bug above is fixed. `Node.callFuncThread()`'s base case
+  (previously an unconditional `return undefined`, meaning "always fall back to `rendezvousCall`")
+  now checks `this.owner`: if it points at a thread with an active, registered Task
+  (`sgRoot.getThreadTask(this.owner)`), route through the same `rendezvousCallFunc`/
+  `requestTaskMethodCall` machinery the Task-specific case already uses — no gate on
+  `sgRoot.inTaskThread()`, since it doesn't matter whether the caller is render or another task,
+  only that the *target* thread has a live Task to dispatch through. `Task`'s own override is
+  unaffected (a Task's functions run on its own `threadId`, which can differ from `owner` — the
+  thread that *built* it, typically render — so it keeps using `active`/`threadId`, not this
+  `owner`-based check). Regression: `task-owned-node-callfunc-app` in `test/cli/`.
+- **A render-initiated `callFunc` runs against a frozen snapshot of the Task's `m`, never its live,
+  currently-mutating `m`** — device-confirmed by direct probing (`callfunc-task-thread-probe` in
+  `test/simulator/probes/`, whose README documents the full experiment trail). Real Roku snapshots a
+  Task's `m` once, right after `init()` completes and before the task's own function starts running; a
+  raw script-scope member added *after* that point is invisible to any later `callFunc` dispatch — not
+  stale, **absent entirely**, not even as a key. A member that *is* captured keeps pointing at the exact
+  same live value forever after (a `Node` reference stays fully functional and reflects later mutations
+  made either through the dispatch or by the task's own unrelated code — it is the same object, not a
+  copy); a value with no meaning outside the one thread that made it (a live `roMessagePort` handle) comes
+  back present-as-key but `invalid`-as-value. Declared fields (`m.top.xxx`) are untouched by any of this —
+  they cross via the already-correct field-sync path above regardless of timing.
+  `Task.captureCallFuncSnapshot()` builds this once (`buildCallFuncSnapshot` in `nodes/Task.ts`: keep
+  `top`/`global`, `Node` values, and primitives as-is; flatten everything else — any other live
+  BrsComponent — to `invalid`), called from `execTask` in `src/extensions/scenegraph/index.ts` at exactly
+  that boundary, right before the task's function is invoked. Routing this into the actual call is not a
+  matter of passing a different `m` down through `Interpreter.call`'s dispatch of the `callFunc`
+  Callable — `Node.callFunction`'s sub-environment setup hardcodes `this.m`, ignoring whatever `m` the
+  outer call carried, so a naive parameter swap at the outer layer is a silent no-op. Instead
+  `callFunction` takes an explicit `mOverride` parameter (every other caller passes `undefined`, meaning
+  "use `this.m`" — unchanged), and a new virtual hook, `Node.consumeCallFuncMOverride()` (no-op on `Node`;
+  `Task` overrides it), is consulted right at the `callFunc` Callable's own call site in
+  `RoSGNode.callFunc`. `Task.handleMethodCallRequest` sets a one-shot `useCallFuncSnapshot` flag on the
+  target immediately before dispatching a `direct`-flagged request (clearing it in a `finally`, so a
+  resolution that never reaches the hook — or throws — can't leak it onto a later, unrelated call);
+  `consumeCallFuncMOverride()` reads and clears that same flag, returning `callFuncM` only for that one
+  dispatch. Regression: `captureCallFuncSnapshot`/`consumeCallFuncMOverride` describe blocks in
+  `test/extensions/scenegraph/RenderTaskCallFunc.test.js`, and `task-render-callfunc-app`'s
+  positive/negative pair (`m.harvestEvents`, created in `init()`, must round-trip; `m.postInitNode`,
+  created in `runTask()`, must be invisible — not merely stale) in `test/cli/`.
+  `captureCallFuncSnapshot()` skips the `m`-copy when `funcNames` is empty (no callable interface
+  functions declared) — `callFunction` can never dispatch to such a Task, so no `callFunc` will
+  ever consume the snapshot; cheap to skip for the common fields-only worker/background Task shape.
+  Unit tests exercising the snapshot directly must populate `funcNames` on their bare `Task`
+  instances or this guard makes `captureCallFuncSnapshot()` a no-op.
 - **Function values cross threads via AST rebuild** — `jsValueOf` serializes a user-defined `Callable` as
   name + source location; `restoreCallable` (`factory/Serializer.ts`) resolves it from the per-worker anon
   registry (location-verified — `$anon_N` ids collide across workers) or rebuilds it with `toCallable`

--- a/.claude/docs/threading-and-rendezvous.md
+++ b/.claude/docs/threading-and-rendezvous.md
@@ -22,35 +22,35 @@ result as a function value, and the REPL needs a same-isolate interpreter. Regre
 
 Node-host invariants (all mirror the browser API):
 
-- **Workers never write to the terminal.** `host.ts`/`task.ts` spawn every worker with
-  `{ stdout: true, stderr: true }` and surface the piped streams as host `stdout`/`stderr` events — a
-  `console.log` inside a worker (engine internals, third-party libs) inheriting the process fds would
-  land inside the frame region in `-i`/`-a` modes and flicker graphics terminals (text over image cells
-  erases them on iTerm2/Kitty).
-- **Termination is host-driven** (`terminateApp(reason = UserNav, timeoutMs = 3000)`): write
-  `DebugCommand.EXIT` for a graceful exit, then force-`terminate()` the app worker + all Task workers on
-  timeout, and report the host's `reason` on `end` (the worker unwinding via the debugger EXIT path
-  reports `EXIT_BRIGHTSCRIPT_STOP`, not `EXIT_USER_NAV`). The CLI home/poweroff key goes through this path
-  — do **not** "simplify" it back to a bare `DBG=EXIT` write: a worker idling in `wait()` can miss it (see
-  next point) and there is no backstop.
-- **EXIT must unwind `wait()` loops.** `RoMessagePort.wait` consumes the EXIT command, sets
-  `debugMode = EXIT` and *returns* (it can't throw through the callable boundary);
-  `Interpreter.checkDebugger` therefore **throws `BlockEnd("debug-exit")` when already in EXIT mode**
-  instead of returning — otherwise an app in `while true : wait(0, port)` live-locks with `wait` returning
-  instantly (the pre-fix home-key hang).
-- **`getMessage()`/`peekMessage()` must thread the live `Interpreter` through `updateMessageQueue`,
-  exactly like `wait()` does.** They dispatch through the same generic `callbackMap` as `wait()`
-  (`RoMessagePort.ts`), and `RoSGScreen`'s callback (`getNewEvents`) early-returns with no work done when
-  its `interpreter` argument is falsy — it needs a live interpreter to service timers/animations/
-  tasks/rendering. A refactor once made `getMessage`/`peekMessage` call `updateMessageQueue()` with no
-  arguments, which silently stopped SceneGraph from ever being serviced through those two calls (a real
-  app driving its main loop with `sleep()+getMessage()` instead of `wait()` never rendered a frame, with
-  no error) — nothing caught it because the only prior test only asserted `getMessage()` "doesn't crash."
-  A distinct non-blocking sentinel (`PORT_NO_WAIT`, not `0` — `0` already means "block indefinitely" by
-  this codebase's convention, see `wait()` above) marks the call as a poll rather than a wait; `Task.ts`'s
-  `getNewEvents` must treat that sentinel as "poll once, don't block" rather than converting it to an
-  infinite `Atomics.wait`. Regression: "Services SceneGraph timers/rendering through a sleep()+
-  getMessage() poll loop" in `test/cli/cli-scenegraph.test.js`.
+-   **Workers never write to the terminal.** `host.ts`/`task.ts` spawn every worker with
+    `{ stdout: true, stderr: true }` and surface the piped streams as host `stdout`/`stderr` events — a
+    `console.log` inside a worker (engine internals, third-party libs) inheriting the process fds would
+    land inside the frame region in `-i`/`-a` modes and flicker graphics terminals (text over image cells
+    erases them on iTerm2/Kitty).
+-   **Termination is host-driven** (`terminateApp(reason = UserNav, timeoutMs = 3000)`): write
+    `DebugCommand.EXIT` for a graceful exit, then force-`terminate()` the app worker + all Task workers on
+    timeout, and report the host's `reason` on `end` (the worker unwinding via the debugger EXIT path
+    reports `EXIT_BRIGHTSCRIPT_STOP`, not `EXIT_USER_NAV`). The CLI home/poweroff key goes through this path
+    — do **not** "simplify" it back to a bare `DBG=EXIT` write: a worker idling in `wait()` can miss it (see
+    next point) and there is no backstop.
+-   **EXIT must unwind `wait()` loops.** `RoMessagePort.wait` consumes the EXIT command, sets
+    `debugMode = EXIT` and _returns_ (it can't throw through the callable boundary);
+    `Interpreter.checkDebugger` therefore **throws `BlockEnd("debug-exit")` when already in EXIT mode**
+    instead of returning — otherwise an app in `while true : wait(0, port)` live-locks with `wait` returning
+    instantly (the pre-fix home-key hang).
+-   **`getMessage()`/`peekMessage()` must thread the live `Interpreter` through `updateMessageQueue`,
+    exactly like `wait()` does.** They dispatch through the same generic `callbackMap` as `wait()`
+    (`RoMessagePort.ts`), and `RoSGScreen`'s callback (`getNewEvents`) early-returns with no work done when
+    its `interpreter` argument is falsy — it needs a live interpreter to service timers/animations/
+    tasks/rendering. A refactor once made `getMessage`/`peekMessage` call `updateMessageQueue()` with no
+    arguments, which silently stopped SceneGraph from ever being serviced through those two calls (a real
+    app driving its main loop with `sleep()+getMessage()` instead of `wait()` never rendered a frame, with
+    no error) — nothing caught it because the only prior test only asserted `getMessage()` "doesn't crash."
+    A distinct non-blocking sentinel (`PORT_NO_WAIT`, not `0` — `0` already means "block indefinitely" by
+    this codebase's convention, see `wait()` above) marks the call as a poll rather than a wait; `Task.ts`'s
+    `getNewEvents` must treat that sentinel as "poll once, don't block" rather than converting it to an
+    infinite `Atomics.wait`. Regression: "Services SceneGraph timers/rendering through a sleep()+
+    getMessage() poll loop" in `test/cli/cli-scenegraph.test.js`.
 
 ## Rendezvous architecture (multi-threaded Tasks)
 
@@ -64,178 +64,191 @@ A node's authoritative copy lives on its owner thread, so reading/writing a node
 **rendezvous**: a synchronous blocking request to the owner. Implemented in `nodes/Task.ts` +
 `nodes/Node.ts`:
 
-- **Transport** — each Task owns a `SharedObject` wrapping a `SharedArrayBuffer`. `ThreadUpdate` messages
-  (`action`: `get`/`set`/`call`/`resp`/`ack`/`nil`, plus `type`, `address`, `key`, `value`) are written in;
-  the receiver wakes via `Atomics`-based `taskBuffer.waitVersion(...)`. Lifecycle/state transitions flow
-  over normal `postMessage` (`TaskData`, `TaskState`).
-- **Field writes** — `Node.setValue` → `rendezvousSet`; if `shouldRendezvous()`
-  (`inTaskThread() && owner !== threadId`) it forwards via `task.syncRemoteField`. Otherwise, on the
-  render thread, it pushes the change to any Task observing that field's port.
-- **Field reads / method calls** — `RoSGNode`/`ContentNode` methods call
-  `rendezvousCall(interpreter, "<method>", [args])`. When `shouldRendezvous()`, it serializes args (node
-  args re-owned by thread 0) and calls `task.requestMethodCall(...)`, which blocks (default 10s timeout,
-  logs "Rendezvous timeout") until `resp`/`nil`. `requestFieldValue` does the same for plain reads.
-- **Crossing into a node sends ownership *only when the task is reporting through its own
-  field*.** `Task.syncRemoteField` re-owns a `Node` value to render (`setOwner(0)`) when the task
-  is setting **its own** interface field (`m.top.xxx = someNode`, `address === this.address` —
-  a hand-off: the task isn't going to keep using the node itself, so render becoming its
-  permanent owner is correct, and the receiver needs to run `callFunc` against its own copy).
-  It must **not** re-own when the task is merely setting a field on some *other* render-owned
-  node (`address !== this.address` — e.g. `m.global.someHandle = someNode`, the common
-  "publish a singleton for other threads/components to discover" pattern): the task keeps using
-  its own local reference to that node forever after, so its ownership must not change.
-  Device-confirmed this distinction matters (real Roku does not re-own in the second case) —
-  getting it wrong was the actual New Relic SDK crash's root cause (see
-  `test/simulator/probes/node-owned-by-task-callfunc-probe/`, whose README documents the full
-  investigation): re-owning unconditionally made every later same-thread access on the owning
-  task incorrectly evaluate `shouldRendezvous()` as `true` and rendezvous *out* to render, which
-  only had a reconstructed copy missing whatever the task's own script populated. Regression:
-  `DirectRendezvous.test.js`'s "own field" vs "FOREIGN node" pair, and
-  `task-owned-node-callfunc-app` in `test/cli/`.
-- **A `callFunc` argument is never re-owned, on either the render→Task or task→render routing
-  branch** — `Node.buildMethodCallPayload`'s `reownToRender` boolean, threaded through from both
-  `rendezvousCallFunc` call sites (`rendezvousCall(..., false)` for the fallback branch,
-  `buildMethodCallPayload(..., false)` for the Task-target branch). Same rule and same root cause
-  as the field case above, just reached via a call argument: re-owning a `Node` argument to
-  whichever thread it's passed into breaks the caller's own later same-thread use of it.
-  `rendezvousCall`'s ~69 other, non-`callFunc` call sites keep the default (`true`) — those really
-  are a task→render hand-off. **Gotcha hit while fixing this**: giving the parameter a numeric
-  default (`= 0`) let an explicit `undefined` argument silently fall back to that default (JS
-  substitutes on `undefined`, not just omission) — hence the boolean instead of a nullable thread
-  id. Regression: `RenderTaskCallFunc.test.js`'s "keeps its own ownership" pair.
-- **`callFunc` on a Task rendezvouses even from the thread that owns the node** (device-confirmed — a
-  Task's callable interface functions always run on its own worker thread, independent of `owner`, which
-  models who built the node's *fields*, typically render). `shouldRendezvous()`'s `owner` check can never
-  catch this: a Task's render-side instance is *constructed* on render, so `owner === 0` forever. `callFunc`
-  therefore has its own routing pair — `Node.callFuncThread()` (only `Task` overrides it, returning its own
-  `threadId` when `active`) and `Node.rendezvousCallFunc()` — used exclusively by `RoSGNode.callFunc`, not
-  the other ~69 `rendezvousCall()` call sites (those stay owner-based; a Task's *fields* really are
-  render-owned and already work via the field-sync path above). Three branches: not an active Task →
-  falls back to `rendezvousCall` unchanged; `callFuncThread() === sgRoot.threadId` → run locally,
-  returning `undefined` **without** falling through to `rendezvousCall` — `handleMethodCallRequest`
-  re-dispatches `"callFunc"` through the Callable a second time once the request lands on the Task's own
-  thread, so falling through there would self-rendezvous back out to render; otherwise →
-  `Task.requestTaskMethodCall()`. That method's transport differs from `requestMethodCall`'s: the request
-  travels via `fanoutQueue`/`fanoutBuffer` (the only channel a Task polls every tick, not just while
-  blocked in its own outgoing wait — `directBuffer`/broker delivery are dead paths for a fresh
-  render-initiated request in current direct/fan-out mode), and the reply arrives on a **dedicated
-  `callBackBuffer`** (can't reuse `directBuffer` — a nested task→render rendezvous served while handling
-  the call, e.g. a `m.global` read, could be in flight on it at the same time, in the opposite direction).
-  The wait loop pumps `sgRoot.processTasks()` every iteration — otherwise that nested rendezvous, or any
-  other task's unrelated in-flight request, would deadlock behind this blocking wait, since incoming
-  requests are only ever served from `processTasks()` (see the *silence* note below). Regression:
-  `test/extensions/scenegraph/RenderTaskCallFunc.test.js` and `task-render-callfunc-app` in `test/cli/`.
-- **`callFunc` on an ordinary `Node` genuinely owned by a Task thread also rendezvouses, from *any*
-  caller — not just a Task-initiated one.** This is the base-class counterpart to the Task-specific
-  routing above: `shouldRendezvous()`/`rendezvousCall()` gate on the *caller* being a task thread
-  (`sgRoot.inTaskThread()`), so they never fire for a render-initiated call, no matter what the
-  target's `owner` is. That left a real gap: a plain `Node` a Task legitimately owns and keeps using
-  itself (not a Task target, and not merely field-owned by render the way most nodes are) was
-  unreachable from render's own `callFunc` — the exact shape a Task publishing an SDK singleton via
-  `m.global` produces once the ownership bug above is fixed. `Node.callFuncThread()`'s base case
-  (previously an unconditional `return undefined`, meaning "always fall back to `rendezvousCall`")
-  now checks `this.owner`: if it points at a thread with an active, registered Task
-  (`sgRoot.getThreadTask(this.owner)`), route through the same `rendezvousCallFunc`/
-  `requestTaskMethodCall` machinery the Task-specific case already uses — no gate on
-  `sgRoot.inTaskThread()`, since it doesn't matter whether the caller is render or another task,
-  only that the *target* thread has a live Task to dispatch through. `Task`'s own override is
-  unaffected (a Task's functions run on its own `threadId`, which can differ from `owner` — the
-  thread that *built* it, typically render — so it keeps using `active`/`threadId`, not this
-  `owner`-based check). Regression: `task-owned-node-callfunc-app` in `test/cli/`.
-- **A render-initiated `callFunc` runs against a frozen snapshot of the Task's `m`, never its live,
-  currently-mutating `m`** — device-confirmed by direct probing (`callfunc-task-thread-probe` in
-  `test/simulator/probes/`, whose README documents the full experiment trail). Real Roku snapshots a
-  Task's `m` once, right after `init()` completes and before the task's own function starts running; a
-  raw script-scope member added *after* that point is invisible to any later `callFunc` dispatch — not
-  stale, **absent entirely**, not even as a key. A member that *is* captured keeps pointing at the exact
-  same live value forever after (a `Node` reference stays fully functional and reflects later mutations
-  made either through the dispatch or by the task's own unrelated code — it is the same object, not a
-  copy); a value with no meaning outside the one thread that made it (a live `roMessagePort` handle) comes
-  back present-as-key but `invalid`-as-value. Declared fields (`m.top.xxx`) are untouched by any of this —
-  they cross via the already-correct field-sync path above regardless of timing.
-  `Task.captureCallFuncSnapshot()` builds this once (`buildCallFuncSnapshot` in `nodes/Task.ts`: keep
-  `top`/`global`, `Node` values, and primitives as-is; flatten everything else — any other live
-  BrsComponent — to `invalid`), called from `execTask` in `src/extensions/scenegraph/index.ts` at exactly
-  that boundary, right before the task's function is invoked. Routing this into the actual call is not a
-  matter of passing a different `m` down through `Interpreter.call`'s dispatch of the `callFunc`
-  Callable — `Node.callFunction`'s sub-environment setup hardcodes `this.m`, ignoring whatever `m` the
-  outer call carried, so a naive parameter swap at the outer layer is a silent no-op. Instead
-  `callFunction` takes an explicit `mOverride` parameter (every other caller passes `undefined`, meaning
-  "use `this.m`" — unchanged), and a new virtual hook, `Node.consumeCallFuncMOverride()` (no-op on `Node`;
-  `Task` overrides it), is consulted right at the `callFunc` Callable's own call site in
-  `RoSGNode.callFunc`. `Task.handleMethodCallRequest` sets a one-shot `useCallFuncSnapshot` flag on the
-  target immediately before dispatching a `direct`-flagged request (clearing it in a `finally`, so a
-  resolution that never reaches the hook — or throws — can't leak it onto a later, unrelated call);
-  `consumeCallFuncMOverride()` reads and clears that same flag, returning `callFuncM` only for that one
-  dispatch. Regression: `captureCallFuncSnapshot`/`consumeCallFuncMOverride` describe blocks in
-  `test/extensions/scenegraph/RenderTaskCallFunc.test.js`, and `task-render-callfunc-app`'s
-  positive/negative pair (`m.harvestEvents`, created in `init()`, must round-trip; `m.postInitNode`,
-  created in `runTask()`, must be invisible — not merely stale) in `test/cli/`.
-  `captureCallFuncSnapshot()` skips the `m`-copy when `funcNames` is empty (no callable interface
-  functions declared) — `callFunction` can never dispatch to such a Task, so no `callFunc` will
-  ever consume the snapshot; cheap to skip for the common fields-only worker/background Task shape.
-  Unit tests exercising the snapshot directly must populate `funcNames` on their bare `Task`
-  instances or this guard makes `captureCallFuncSnapshot()` a no-op.
-- **Function values cross threads via AST rebuild** — `jsValueOf` serializes a user-defined `Callable` as
-  name + source location; `restoreCallable` (`factory/Serializer.ts`) resolves it from the per-worker anon
-  registry (location-verified — `$anon_N` ids collide across workers) or rebuilds it with `toCallable`
-  from the component AST retained in `ComponentDefinition.scopeStatements` (set by
-  `setupInterpreterWithSubEnvs` — keep it retained). Sound because BrightScript has no lexical closures:
-  `m` binds to the receiver at call time. Unresolvable → stub returning `uninitialized` + one-shot
-  warning. Matches device behavior (a Task's `m` copy keeps functions callable, e.g. analytics-SDK
-  helpers). Regression: `test/extensions/scenegraph/CallableSerialization.test.js`.
-- **Task startup** — when `control` becomes `"run"`, `checkTaskRun` posts `TaskData` (shared buffer,
-  serialized `m`, render-thread id, `tmp:`/`cachefs:` volumes). The core spins up a worker → extension's
-  `execTask` → `initializeTask` rebuilds the tree and invokes the task function. The `tick` hook drains
-  incoming updates each iteration via `task.processThreadUpdate()`.
+-   **Transport** — each Task owns a `SharedObject` wrapping a `SharedArrayBuffer`. `ThreadUpdate` messages
+    (`action`: `get`/`set`/`call`/`resp`/`ack`/`nil`, plus `type`, `address`, `key`, `value`) are written in;
+    the receiver wakes via `Atomics`-based `taskBuffer.waitVersion(...)`. Lifecycle/state transitions flow
+    over normal `postMessage` (`TaskData`, `TaskState`).
+-   **Field writes** — `Node.setValue` → `rendezvousSet`; if `shouldRendezvous()`
+    (`inTaskThread() && owner !== threadId`) it forwards via `task.syncRemoteField`. Otherwise, on the
+    render thread, it pushes the change to any Task observing that field's port.
+-   **Field reads / method calls** — `RoSGNode`/`ContentNode` methods call
+    `rendezvousCall(interpreter, "<method>", [args])`. When `shouldRendezvous()`, it serializes args (node
+    args re-owned by thread 0) and calls `task.requestMethodCall(...)`, which blocks (default 10s timeout,
+    logs "Rendezvous timeout") until `resp`/`nil`. `requestFieldValue` does the same for plain reads.
+-   **Crossing into a node sends ownership _only when the task is reporting through its own
+    field_.** `Task.syncRemoteField` re-owns a `Node` value to render (`setOwner(0)`) when the task
+    is setting **its own** interface field (`m.top.xxx = someNode`, `address === this.address` —
+    a hand-off: the task isn't going to keep using the node itself, so render becoming its
+    permanent owner is correct, and the receiver needs to run `callFunc` against its own copy).
+    It must **not** re-own when the task is merely setting a field on some _other_ render-owned
+    node (`address !== this.address` — e.g. `m.global.someHandle = someNode`, the common
+    "publish a singleton for other threads/components to discover" pattern): the task keeps using
+    its own local reference to that node forever after, so its ownership must not change.
+    Device-confirmed this distinction matters (real Roku does not re-own in the second case) —
+    getting it wrong was the actual New Relic SDK crash's root cause (see
+    `test/simulator/probes/node-owned-by-task-callfunc-probe/`, whose README documents the full
+    investigation): re-owning unconditionally made every later same-thread access on the owning
+    task incorrectly evaluate `shouldRendezvous()` as `true` and rendezvous _out_ to render, which
+    only had a reconstructed copy missing whatever the task's own script populated. Regression:
+    `DirectRendezvous.test.js`'s "own field" vs "FOREIGN node" pair, and
+    `task-owned-node-callfunc-app` in `test/cli/`.
+-   **A `callFunc` argument is never re-owned, on either the render→Task or task→render routing
+    branch** — `Node.buildMethodCallPayload`'s `reownToRender` boolean, threaded through from both
+    `rendezvousCallFunc` call sites (`rendezvousCall(..., false)` for the fallback branch,
+    `buildMethodCallPayload(..., false)` for the Task-target branch). Same rule and same root cause
+    as the field case above, just reached via a call argument: re-owning a `Node` argument to
+    whichever thread it's passed into breaks the caller's own later same-thread use of it.
+    `rendezvousCall`'s ~69 other, non-`callFunc` call sites keep the default (`true`) — those really
+    are a task→render hand-off. **Gotcha hit while fixing this**: giving the parameter a numeric
+    default (`= 0`) let an explicit `undefined` argument silently fall back to that default (JS
+    substitutes on `undefined`, not just omission) — hence the boolean instead of a nullable thread
+    id. Regression: `RenderTaskCallFunc.test.js`'s "keeps its own ownership" pair.
+-   **`callFunc` on a Task rendezvouses even from the thread that owns the node** (device-confirmed — a
+    Task's callable interface functions always run on its own worker thread, independent of `owner`, which
+    models who built the node's _fields_, typically render). `shouldRendezvous()`'s `owner` check can never
+    catch this: a Task's render-side instance is _constructed_ on render, so `owner === 0` forever. `callFunc`
+    therefore has its own routing pair — `Node.callFuncThread()` (only `Task` overrides it, returning its own
+    `threadId` when `active`) and `Node.rendezvousCallFunc()` — used exclusively by `RoSGNode.callFunc`, not
+    the other ~69 `rendezvousCall()` call sites (those stay owner-based; a Task's _fields_ really are
+    render-owned and already work via the field-sync path above). Three branches: not an active Task →
+    falls back to `rendezvousCall` unchanged; `callFuncThread() === sgRoot.threadId` → run locally,
+    returning `undefined` **without** falling through to `rendezvousCall` — `handleMethodCallRequest`
+    re-dispatches `"callFunc"` through the Callable a second time once the request lands on the Task's own
+    thread, so falling through there would self-rendezvous back out to render; otherwise →
+    `Task.requestTaskMethodCall()`. That method's transport differs from `requestMethodCall`'s: the request
+    travels via `fanoutQueue`/`fanoutBuffer` (the only channel a Task polls every tick, not just while
+    blocked in its own outgoing wait — `directBuffer`/broker delivery are dead paths for a fresh
+    render-initiated request in current direct/fan-out mode), and the reply arrives on a **dedicated
+    `callBackBuffer`** (can't reuse `directBuffer` — a nested task→render rendezvous served while handling
+    the call, e.g. a `m.global` read, could be in flight on it at the same time, in the opposite direction).
+    The wait loop pumps `sgRoot.processTasks()` every iteration — otherwise that nested rendezvous, or any
+    other task's unrelated in-flight request, would deadlock behind this blocking wait, since incoming
+    requests are only ever served from `processTasks()` (see the _silence_ note below). Regression:
+    `test/extensions/scenegraph/RenderTaskCallFunc.test.js` and `task-render-callfunc-app` in `test/cli/`.
+-   **`callFunc` on an ordinary `Node` genuinely owned by a Task thread also rendezvouses, from _any_
+    caller — not just a Task-initiated one.** This is the base-class counterpart to the Task-specific
+    routing above: `shouldRendezvous()`/`rendezvousCall()` gate on the _caller_ being a task thread
+    (`sgRoot.inTaskThread()`), so they never fire for a render-initiated call, no matter what the
+    target's `owner` is. That left a real gap: a plain `Node` a Task legitimately owns and keeps using
+    itself (not a Task target, and not merely field-owned by render the way most nodes are) was
+    unreachable from render's own `callFunc` — the exact shape a Task publishing an SDK singleton via
+    `m.global` produces once the ownership bug above is fixed. `Node.callFuncThread()`'s base case
+    (previously an unconditional `return undefined`, meaning "always fall back to `rendezvousCall`")
+    now checks `this.owner`: if it points at a thread with an active, registered Task
+    (`sgRoot.getThreadTask(this.owner)`), route through the same `rendezvousCallFunc`/
+    `requestTaskMethodCall` machinery the Task-specific case already uses — no gate on
+    `sgRoot.inTaskThread()`, since it doesn't matter whether the caller is render or another task,
+    only that the _target_ thread has a live Task to dispatch through. `Task`'s own override is
+    unaffected (a Task's functions run on its own `threadId`, which can differ from `owner` — the
+    thread that _built_ it, typically render — so it keeps using `active`/`threadId`, not this
+    `owner`-based check). Regression: `task-owned-node-callfunc-app` in `test/cli/`.
+-   **A Task's incoming field-set must be ack'd before its observers run, not after** — real-app regression
+    found via jellyfin-roku (`PostTask`/`Home.bs`): `Task` field writes rendezvous (`sendThreadUpdate` →
+    `waitForFieldAck`, blocking the _writing_ task thread until render acks), and `handleSetFieldRequest`
+    used to apply the value (`node.setValue`, which synchronously fires that field's observers) **before**
+    sending the ack. A field-change observer that itself `callFunc`s straight back onto the _same_ task —
+    a normal pattern (`postFinished()` unobserves and resets `m.postTask` right after reading its
+    `responseCode`) — now blocks render waiting for that Task thread to answer, but the Task thread is
+    itself still blocked inside its own field-set, waiting for the ack render hasn't sent yet because it's
+    stuck in the observer. A genuine circular wait, timing out only after `sgRoot.rendezvousTimeout`,
+    invisible before render-initiated `callFunc` could block at all. Fixed by moving the ack in
+    `handleSetFieldRequest` to fire immediately after resolving the incoming value, before `node.setValue`/
+    observer dispatch — the ack is a transport-level receipt, independent of whatever the observer
+    subsequently does. Regression: `test/cli/resources/task-selfcall-observer-app/` and its `it(...)` in
+    `test/cli/cli-scenegraph.test.js`.
+-   **A render-initiated `callFunc` runs against a frozen snapshot of the Task's `m`, never its live,
+    currently-mutating `m`** — device-confirmed by direct probing (`callfunc-task-thread-probe` in
+    `test/simulator/probes/`, whose README documents the full experiment trail). Real Roku snapshots a
+    Task's `m` once, right after `init()` completes and before the task's own function starts running; a
+    raw script-scope member added _after_ that point is invisible to any later `callFunc` dispatch — not
+    stale, **absent entirely**, not even as a key. A member that _is_ captured keeps pointing at the exact
+    same live value forever after (a `Node` reference stays fully functional and reflects later mutations
+    made either through the dispatch or by the task's own unrelated code — it is the same object, not a
+    copy); a value with no meaning outside the one thread that made it (a live `roMessagePort` handle) comes
+    back present-as-key but `invalid`-as-value. Declared fields (`m.top.xxx`) are untouched by any of this —
+    they cross via the already-correct field-sync path above regardless of timing.
+    `Task.captureCallFuncSnapshot()` builds this once (`buildCallFuncSnapshot` in `nodes/Task.ts`: keep
+    `top`/`global`, `Node` values, and primitives as-is; flatten everything else — any other live
+    BrsComponent — to `invalid`), called from `execTask` in `src/extensions/scenegraph/index.ts` at exactly
+    that boundary, right before the task's function is invoked. Routing this into the actual call is not a
+    matter of passing a different `m` down through `Interpreter.call`'s dispatch of the `callFunc`
+    Callable — `Node.callFunction`'s sub-environment setup hardcodes `this.m`, ignoring whatever `m` the
+    outer call carried, so a naive parameter swap at the outer layer is a silent no-op. Instead
+    `callFunction` takes an explicit `mOverride` parameter (every other caller passes `undefined`, meaning
+    "use `this.m`" — unchanged), and a new virtual hook, `Node.consumeCallFuncMOverride()` (no-op on `Node`;
+    `Task` overrides it), is consulted right at the `callFunc` Callable's own call site in
+    `RoSGNode.callFunc`. `Task.handleMethodCallRequest` sets a one-shot `useCallFuncSnapshot` flag on the
+    target immediately before dispatching a `direct`-flagged request (clearing it in a `finally`, so a
+    resolution that never reaches the hook — or throws — can't leak it onto a later, unrelated call);
+    `consumeCallFuncMOverride()` reads and clears that same flag, returning `callFuncM` only for that one
+    dispatch. Regression: `captureCallFuncSnapshot`/`consumeCallFuncMOverride` describe blocks in
+    `test/extensions/scenegraph/RenderTaskCallFunc.test.js`, and `task-render-callfunc-app`'s
+    positive/negative pair (`m.harvestEvents`, created in `init()`, must round-trip; `m.postInitNode`,
+    created in `runTask()`, must be invisible — not merely stale) in `test/cli/`.
+    `captureCallFuncSnapshot()` skips the `m`-copy when `funcNames` is empty (no callable interface
+    functions declared) — `callFunction` can never dispatch to such a Task, so no `callFunc` will
+    ever consume the snapshot; cheap to skip for the common fields-only worker/background Task shape.
+    Unit tests exercising the snapshot directly must populate `funcNames` on their bare `Task`
+    instances or this guard makes `captureCallFuncSnapshot()` a no-op.
+-   **Function values cross threads via AST rebuild** — `jsValueOf` serializes a user-defined `Callable` as
+    name + source location; `restoreCallable` (`factory/Serializer.ts`) resolves it from the per-worker anon
+    registry (location-verified — `$anon_N` ids collide across workers) or rebuilds it with `toCallable`
+    from the component AST retained in `ComponentDefinition.scopeStatements` (set by
+    `setupInterpreterWithSubEnvs` — keep it retained). Sound because BrightScript has no lexical closures:
+    `m` binds to the receiver at call time. Unresolvable → stub returning `uninitialized` + one-shot
+    warning. Matches device behavior (a Task's `m` copy keeps functions callable, e.g. analytics-SDK
+    helpers). Regression: `test/extensions/scenegraph/CallableSerialization.test.js`.
+-   **Task startup** — when `control` becomes `"run"`, `checkTaskRun` posts `TaskData` (shared buffer,
+    serialized `m`, render-thread id, `tmp:`/`cachefs:` volumes). The core spins up a worker → extension's
+    `execTask` → `initializeTask` rebuilds the tree and invokes the task function. The `tick` hook drains
+    incoming updates each iteration via `task.processThreadUpdate()`.
 
-  > **Activation ≠ launch — the two delivery paths must not overlap.** `control = "run"` runs
-  > `activateTask` **synchronously** (allocating the direct buffers early and on purpose, so no write
-  > falls back to the broker), which turns render→task fan-out on; `checkTaskRun` posts the payload only
-  > on the next `processTasks` pass. A write in between is captured by *both* — queued in `fanoutQueue`
-  > **and** left as an event on the render-side copy of the port for `collectPortNodeEvents` to sweep into
-  > `TaskData.portEvents` — and the task saw it twice (#1109). `dropFanoutCoveredByReplay` discards the
-  > fan-out copies for the exact (node, field) pairs the replay will deliver. Match on the **pair, not the
-  > value**: a field written twice with the same value under `alwaysNotify` notifies twice but syncs once.
-  > Leave events the replay can't re-target (a node that is neither the task node nor global, which
-  > `replayPortNodeEvents` drops with a warning) alone — the fan-out is their only carrier. Regression:
-  > `task-prelaunch-events-app` in `test/cli/`, which asserts **both** sides of the boundary (before `run`
-  > must still arrive; after `run` exactly once).
+    > **Activation ≠ launch — the two delivery paths must not overlap.** `control = "run"` runs
+    > `activateTask` **synchronously** (allocating the direct buffers early and on purpose, so no write
+    > falls back to the broker), which turns render→task fan-out on; `checkTaskRun` posts the payload only
+    > on the next `processTasks` pass. A write in between is captured by _both_ — queued in `fanoutQueue` > **and** left as an event on the render-side copy of the port for `collectPortNodeEvents` to sweep into
+    > `TaskData.portEvents` — and the task saw it twice (#1109). `dropFanoutCoveredByReplay` discards the
+    > fan-out copies for the exact (node, field) pairs the replay will deliver. Match on the **pair, not the
+    > value**: a field written twice with the same value under `alwaysNotify` notifies twice but syncs once.
+    > Leave events the replay can't re-target (a node that is neither the task node nor global, which
+    > `replayPortNodeEvents` drops with a warning) alone — the fan-out is their only carrier. Regression:
+    > `task-prelaunch-events-app` in `test/cli/`, which asserts **both** sides of the boundary (before `run`
+    > must still arrive; after `run` exactly once).
 
-  > **A task thread's uncaught error terminates the whole app** (device-verified), exactly as it does on
-  > the app thread — the task node is *not* moved to `state = "stop"` so the app can carry on, and there
-  > is no "the thread died but the app lives" state to model. A task worker posts `end,<reason>` only when
-  > it dies (an uncaught error, or unwinding on a termination command), so the Node broker escalates that
-  > to the host's `taskNotify` → `terminateApp(reason)` instead of surfacing it as output; the browser API
-  > already had this for free, since a task worker's strings reach the same `handleStringMessage` as the
-  > app worker's. Only the **first** report acts — a termination already in flight (home key, poweroff)
-  > keeps its own `terminateReason` rather than having it overwritten by every task unwinding behind it.
-  > In developer mode the Micro Debugger still opens on the crashing task thread first; the app ends when
-  > that session exits. Regression: `task-crash-app` in `test/cli/`.
+    > **A task thread's uncaught error terminates the whole app** (device-verified), exactly as it does on
+    > the app thread — the task node is _not_ moved to `state = "stop"` so the app can carry on, and there
+    > is no "the thread died but the app lives" state to model. A task worker posts `end,<reason>` only when
+    > it dies (an uncaught error, or unwinding on a termination command), so the Node broker escalates that
+    > to the host's `taskNotify` → `terminateApp(reason)` instead of surfacing it as output; the browser API
+    > already had this for free, since a task worker's strings reach the same `handleStringMessage` as the
+    > app worker's. Only the **first** report acts — a termination already in flight (home key, poweroff)
+    > keeps its own `terminateReason` rather than having it overwritten by every task unwinding behind it.
+    > In developer mode the Micro Debugger still opens on the crashing task thread first; the app ends when
+    > that session exits. Regression: `task-crash-app` in `test/cli/`.
 
-  > Note `state` reaches `"stop"`, never `"done"`, when a task function returns normally: `threads.md`
-  > says it "will transition to the STOP state automatically when that function returns" and that
-  > re-running requires STOP. `"done"` is a legal value in the `state` field table but no Roku doc
-  > describes a transition into it — that is why apps idiomatically test `state = "done" or state = "stop"`.
-  > Don't "fix" the missing `"done"`.
+    > Note `state` reaches `"stop"`, never `"done"`, when a task function returns normally: `threads.md`
+    > says it "will transition to the STOP state automatically when that function returns" and that
+    > re-running requires STOP. `"done"` is a legal value in the `state` field table but no Roku doc
+    > describes a transition into it — that is why apps idiomatically test `state = "done" or state = "stop"`.
+    > Don't "fix" the missing `"done"`.
 
-- **Internal presentation children must not cross threads — `Node.serializesChildren()`.** A built-in
-  composite node that builds its **visible children in its constructor** and keeps **private field
-  references** to them (updated every frame) must **not** serialize those children. `fromSGNode` includes
-  a node's `_children_` only when `node.serializesChildren()` is true (default); `updateSGNode` no-ops
-  when `_children_` is absent. Why it matters: when a Task references such a node, its child list crosses
-  over, and the Task's `updateSGNode` reconciliation **replaces** the render-thread children with fresh
-  deserialized copies — but the node's private fields still point at the **originals**, so per-frame
-  updates (`showUI` on `Video`) land on nodes no longer in the render tree and the UI silently stops
-  drawing. Overridden to `false` on **`Video`** (trick-play bar, header labels, spinner, paused icon,
-  overlay, clock timer) and **`TrickPlayBar`** (its own track/fill/ticker/label posters — needed
-  separately because `Video` exposes the bar as a node-typed `trickPlayBar` **field**, serialized
-  independently of the Video's own children). A Task never renders, so it never needs these. Apply the
-  same override to any new built-in node with constructor-built, field-referenced children reachable from
-  a Task (as a child *or* a node-typed field); plain data nodes like `ProgressBar` (no internal children)
-  need nothing. Regression: `test/extensions/scenegraph/VideoCrossThreadChildren.test.js`.
+-   **Internal presentation children must not cross threads — `Node.serializesChildren()`.** A built-in
+    composite node that builds its **visible children in its constructor** and keeps **private field
+    references** to them (updated every frame) must **not** serialize those children. `fromSGNode` includes
+    a node's `_children_` only when `node.serializesChildren()` is true (default); `updateSGNode` no-ops
+    when `_children_` is absent. Why it matters: when a Task references such a node, its child list crosses
+    over, and the Task's `updateSGNode` reconciliation **replaces** the render-thread children with fresh
+    deserialized copies — but the node's private fields still point at the **originals**, so per-frame
+    updates (`showUI` on `Video`) land on nodes no longer in the render tree and the UI silently stops
+    drawing. Overridden to `false` on **`Video`** (trick-play bar, header labels, spinner, paused icon,
+    overlay, clock timer) and **`TrickPlayBar`** (its own track/fill/ticker/label posters — needed
+    separately because `Video` exposes the bar as a node-typed `trickPlayBar` **field**, serialized
+    independently of the Video's own children). A Task never renders, so it never needs these. Apply the
+    same override to any new built-in node with constructor-built, field-referenced children reachable from
+    a Task (as a child _or_ a node-typed field); plain data nodes like `ProgressBar` (no internal children)
+    need nothing. Regression: `test/extensions/scenegraph/VideoCrossThreadChildren.test.js`.
 
-## The rendezvous timeout measures render-thread *silence*, not elapsed time
+## The rendezvous timeout measures render-thread _silence_, not elapsed time
 
 Incoming requests are served only from `sgRoot.processTasks()`, i.e. when the render thread reaches its
 message loop — never from inside app code. So a callback that runs longer than
@@ -263,12 +276,12 @@ Entering the Micro Debugger (`STOP`, dev-mode crash, or `BREAK`) must freeze **a
 handshake is one shared-array slot `DataType.DBT`: `notifyDebugStarted()` writes the debugging thread's
 id, `notifyDebugEnded()` clears it, and other threads block on it via **`BrsDevice.pauseIfDebugging()`**
 (the single definition, called by both `checkBreakCommand` and the Task rendezvous waits). But `DBT` is
-only *polled*, and a Task parked mid-rendezvous is blocked in `Atomics.wait` on its own response buffer,
+only _polled_, and a Task parked mid-rendezvous is blocked in `Atomics.wait` on its own response buffer,
 which can't watch `DBT`. So every blocking loop in `nodes/Task.ts` (`requestFieldValue`,
 `requestMethodCall`, `waitForFieldAck`, `getNewEvents`) **caps each sleep to `RENDEZVOUS_POLL_MS`
 (100 ms)** and re-checks `pauseIfDebugging()` each iteration — else a Task mid-rendezvous throws a
 spurious "Rendezvous timeout" out from under the debugger. **Invariants:** check `pauseIfDebugging()`
-*before* the timeout break and **reset the deadline** on pause (debug time mustn't count); the pause path
+_before_ the timeout break and **reset the deadline** on pause (debug time mustn't count); the pause path
 **must not re-send** the request; `EXIT` calls `notifyDebugEnded()` (not only `CONT`) so `DBT` is never
 left set (deadlock). Normal latency is unaffected — a stored response wakes the waiter immediately via
 `notify`. Gap: `debugThreads` still lists only the current thread.

--- a/src/core/common.ts
+++ b/src/core/common.ts
@@ -487,6 +487,8 @@ export type TaskData = {
     directToTask?: SharedArrayBuffer;
     /** Phase 3b: dedicated buffer for direct render→task fan-out of observed-field updates. */
     fanout?: SharedArrayBuffer;
+    /** Dedicated buffer for replies to a render-initiated `callFunc` request. See `Task.requestTaskMethodCall`. */
+    callBack?: SharedArrayBuffer;
     tmp?: SharedArrayBuffer;
     cacheFS?: SharedArrayBuffer;
     m?: any;
@@ -533,6 +535,8 @@ export type ThreadUpdate = {
     key: string;
     value: any;
     requestId?: number;
+    /** Marks a request/reply that must travel over the dedicated `callBackBuffer`, not the broker. */
+    direct?: true;
 };
 
 /**

--- a/src/extensions/scenegraph/components/RoSGNode.ts
+++ b/src/extensions/scenegraph/components/RoSGNode.ts
@@ -211,7 +211,12 @@ export abstract class RoSGNode extends BrsComponent implements BrsValue, ISGNode
     ): BrsBoolean;
     protected abstract removeObserver(fieldName: string, node?: RoSGNode): void;
     protected abstract cloneNode(isDeepCopy: boolean, interpreter?: Interpreter): BrsType;
-    protected abstract callFunction(interpreter: Interpreter, funcName: BrsString, ...funcArgs: BrsType[]): BrsType;
+    protected abstract callFunction(
+        interpreter: Interpreter,
+        funcName: BrsString,
+        mOverride: RoAssociativeArray | undefined,
+        ...funcArgs: BrsType[]
+    ): BrsType;
     protected abstract setNodeFocus(focusOn: boolean): boolean;
 
     protected abstract moveObjectIntoField(fieldName: string, data: RoAssociativeArray): { code: number; msg?: string };
@@ -243,7 +248,19 @@ export abstract class RoSGNode extends BrsComponent implements BrsValue, ISGNode
     protected abstract getThreadInfo(): RoAssociativeArray;
 
     protected abstract shouldRendezvous(): boolean;
-    protected abstract rendezvousCall(interpreter: Interpreter, method: string, args?: BrsType[]): BrsType | undefined;
+    protected abstract rendezvousCall(
+        interpreter: Interpreter,
+        method: string,
+        args?: BrsType[],
+        reownToRender?: boolean
+    ): BrsType | undefined;
+    protected abstract callFuncThread(): number | undefined;
+    protected abstract rendezvousCallFunc(
+        interpreter: Interpreter,
+        functionName: BrsString,
+        args: BrsType[]
+    ): BrsType | undefined;
+    protected abstract consumeCallFuncMOverride(): RoAssociativeArray | undefined;
 
     /**
      * Calls the function specified on this node.
@@ -257,11 +274,16 @@ export abstract class RoSGNode extends BrsComponent implements BrsValue, ISGNode
                     returns: ValueKind.Dynamic,
                 },
                 impl: (interpreter: Interpreter, functionName: BrsString, ...functionArgs: BrsType[]) => {
-                    const remote = this.rendezvousCall(interpreter, "callFunc", [functionName, ...functionArgs]);
+                    const remote = this.rendezvousCallFunc(interpreter, functionName, functionArgs);
                     if (remote !== undefined) {
                         return remote;
                     }
-                    return this.callFunction(interpreter, functionName, ...functionArgs);
+                    return this.callFunction(
+                        interpreter,
+                        functionName,
+                        this.consumeCallFuncMOverride(),
+                        ...functionArgs
+                    );
                 },
             })
         );

--- a/src/extensions/scenegraph/index.ts
+++ b/src/extensions/scenegraph/index.ts
@@ -207,6 +207,9 @@ export class BrightScriptExtension implements BrsExtension {
             // Phase 3a: render thread writes rendezvous responses directly into this buffer.
             taskNode.setDirectBuffer(taskData.directToTask);
         }
+        if (taskData.callBack) {
+            taskNode.setCallBackBuffer(taskData.callBack);
+        }
         const typeDef = sgRoot.nodeDefMap.get(taskNode.nodeSubtype.toLowerCase());
         const taskEnv = typeDef?.environment;
         if (taskEnv) {
@@ -228,6 +231,7 @@ export class BrightScriptExtension implements BrsExtension {
                             callLocation: interpreter.location,
                             signature: funcToCall.signatures[0].signature,
                         });
+                        taskNode.captureCallFuncSnapshot();
                         taskNode.started = true;
                         funcToCall.call(subInterpreter);
                         BrsDevice.stdout.write(

--- a/src/extensions/scenegraph/nodes/DynamicKeyboardBase.ts
+++ b/src/extensions/scenegraph/nodes/DynamicKeyboardBase.ts
@@ -119,7 +119,12 @@ export class DynamicKeyboardBase extends Group {
      */
     private dispatchKeySelected(out: string) {
         if (this.funcNames.has("keyselected") && sgRoot.interpreter) {
-            const handled = this.callFunction(sgRoot.interpreter, new BrsString("keySelected"), new BrsString(out));
+            const handled = this.callFunction(
+                sgRoot.interpreter,
+                new BrsString("keySelected"),
+                undefined,
+                new BrsString(out)
+            );
             if (handled instanceof BrsBoolean && handled.toBoolean()) {
                 return;
             }

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -51,6 +51,7 @@ import { sgRoot } from "../SGRoot";
 import { SGNodeType } from ".";
 import { ComponentDefinition } from "../parser/ComponentDefinition";
 import { convertHexColor } from "../SGUtil";
+import type { Task } from "./Task";
 
 type ChangeOperation = "none" | "insert" | "add" | "remove" | "set" | "clear" | "move" | "setall" | "modify";
 
@@ -2099,14 +2100,22 @@ export class Node extends RoSGNode implements BrsValue {
      * Invokes a public BrightScript function defined on this component's script.
      * @param interpreter Calling interpreter.
      * @param functionName Name of the function to call.
+     * @param mOverride `m` to run the function with instead of `this.m`, or `undefined` to use
+     *   `this.m` (see `.claude/docs/threading-and-rendezvous.md`).
      * @param functionArgs Arguments provided by BrightScript.
      * @returns Function return value or invalid when not callable.
      */
-    protected callFunction(interpreter: Interpreter, functionName: BrsString, ...functionArgs: BrsType[]): BrsType {
+    protected callFunction(
+        interpreter: Interpreter,
+        functionName: BrsString,
+        mOverride: RoAssociativeArray | undefined,
+        ...functionArgs: BrsType[]
+    ): BrsType {
         // We need to search the callee's environment for this function rather than the caller's.
         // Only allow public functions (defined in the interface) to be called.
         const name = functionName.getValue();
         if (this.componentDef && this.funcNames.has(name.toLowerCase())) {
+            const m = mOverride ?? this.m;
             return interpreter.inSubEnv((subInterpreter) => {
                 let functionToCall = subInterpreter.getCallableFunction(name);
                 if (!(functionToCall instanceof Callable)) {
@@ -2115,8 +2124,8 @@ export class Node extends RoSGNode implements BrsValue {
                 }
                 const originalLocation = interpreter.location;
                 let addedToStack = false;
-                subInterpreter.environment.setM(this.m);
-                subInterpreter.environment.setRootM(this.m);
+                subInterpreter.environment.setM(m);
+                subInterpreter.environment.setRootM(m);
                 subInterpreter.environment.hostNode = this;
 
                 try {
@@ -2516,39 +2525,120 @@ export class Node extends RoSGNode implements BrsValue {
     }
 
     /**
+     * Builds the payload for a rendezvous method call, serializing arguments for cross-thread
+     * transfer and optionally re-owning any Node argument to render.
+     * @param interpreter Current BrightScript interpreter.
+     * @param task Task instance whose channel the call travels over (used to flag port-observed
+     *   fields on any Node argument via `fromSGNode`'s host parameter).
+     * @param callArgs Arguments to pass to the remote method.
+     * @param reownToRender Whether a Node argument should be re-owned to render (see
+     *   `.claude/docs/threading-and-rendezvous.md` for when this is/isn't correct).
+     * @returns The serialized call payload.
+     */
+    private buildMethodCallPayload(
+        interpreter: Interpreter,
+        task: Task,
+        callArgs: BrsType[] | undefined,
+        reownToRender: boolean
+    ): MethodCallPayload {
+        let host = this.address;
+        const hostNode = interpreter.environment.hostNode;
+        if (hostNode instanceof Node) {
+            host = hostNode.getAddress();
+        }
+        const location = interpreter.location;
+        const args = callArgs?.map((arg: BrsType) => {
+            if (arg instanceof Node) {
+                if (reownToRender) {
+                    arg.setOwner(0);
+                }
+                // Flag port-observed fields for the receiving task via fromSGNode's host param.
+                return fromSGNode(arg, true, task);
+            }
+            return jsValueOf(arg);
+        });
+        return args ? { host, args, location } : { host, location };
+    }
+
+    /**
      * Helper to perform a rendezvous method call via the current task.
      * @param interpreter Current BrightScript interpreter.
      * @param method Name of the method to call.
      * @param args Arguments to pass to the remote method.
+     * @param reownToRender Whether a Node argument should be re-owned to render (see
+     *   `buildMethodCallPayload`). Defaults to `true`.
      * @returns Result of the remote method call, or undefined if not available.
      */
-    protected rendezvousCall(interpreter: Interpreter, method: string, callArgs?: BrsType[]): BrsType | undefined {
+    protected rendezvousCall(
+        interpreter: Interpreter,
+        method: string,
+        callArgs?: BrsType[],
+        reownToRender: boolean = true
+    ): BrsType | undefined {
         if (!this.shouldRendezvous()) {
             return undefined;
         }
         const task = sgRoot.getCurrentThreadTask();
         if (task?.active) {
-            let host = this.address;
-            const hostNode = interpreter.environment.hostNode;
-            if (hostNode instanceof Node) {
-                host = hostNode.getAddress();
-            }
-            const location = interpreter.location;
-            const args = callArgs?.map((arg: BrsType) => {
-                if (arg instanceof Node) {
-                    arg.setOwner(0); // Node references sent to render thread will be owned by the render thread
-                    // Pass the task as host so port-observed fields are flagged `_observed_`. A node
-                    // built *inside* a task and observed there (the request/result node of a worker
-                    // pool) is task-owned at `observeField` time, so that call never rendezvoused and
-                    // the render thread would otherwise have no idea anyone is waiting on it.
-                    return fromSGNode(arg, true, task);
-                }
-                return jsValueOf(arg);
-            });
-            const payload: MethodCallPayload = args ? { host, args, location } : { host, location };
+            const payload = this.buildMethodCallPayload(interpreter, task, callArgs, reownToRender);
             return task.requestMethodCall(this.syncType, this.address, method, payload);
         }
         return undefined;
+    }
+
+    /**
+     * Thread this node's callable interface functions actually run on, when that differs from
+     * ordinary field-owner routing (`shouldRendezvous`'s `owner` check). `Task` overrides this
+     * with its own `threadId`; this base case routes to whichever thread owns the node, if that
+     * thread has an active, registered Task to dispatch through — see
+     * `.claude/docs/threading-and-rendezvous.md` for why this isn't gated on the caller the way
+     * `shouldRendezvous()` is.
+     * @returns The thread id, or undefined when not applicable (routes through the owner-based path).
+     */
+    protected callFuncThread(): number | undefined {
+        if (this.owner <= 0) {
+            return undefined;
+        }
+        const task = sgRoot.getThreadTask(this.owner);
+        return task?.active ? this.owner : undefined;
+    }
+
+    /**
+     * Consumes (and clears) a one-shot override for the `m` the *next* `callFunction` dispatch on
+     * this node should run with, if one is currently pending. Only `Task` overrides this — see
+     * `.claude/docs/threading-and-rendezvous.md`.
+     * @returns The `m` to use instead of `this.m` for the next dispatch, or undefined.
+     */
+    protected consumeCallFuncMOverride(): RoAssociativeArray | undefined {
+        return undefined;
+    }
+
+    /**
+     * `callFunc`-specific rendezvous entry point — see `.claude/docs/threading-and-rendezvous.md`.
+     * @param interpreter Current BrightScript interpreter.
+     * @param functionName Name of the function being called.
+     * @param callArgs Arguments to pass to the remote function.
+     * @returns Result of the remote call, or undefined when it should run locally.
+     */
+    protected rendezvousCallFunc(
+        interpreter: Interpreter,
+        functionName: BrsString,
+        callArgs: BrsType[]
+    ): BrsType | undefined {
+        const targetThread = this.callFuncThread();
+        if (targetThread === undefined) {
+            return this.rendezvousCall(interpreter, "callFunc", [functionName, ...callArgs], false);
+        }
+        if (targetThread === sgRoot.threadId) {
+            // Avoid a self-rendezvous loop when handleMethodCallRequest re-dispatches here.
+            return undefined;
+        }
+        const task = sgRoot.getThreadTask(targetThread);
+        if (!task?.active || task.inThread) {
+            return undefined;
+        }
+        const payload = this.buildMethodCallPayload(interpreter, task, [functionName, ...callArgs], false);
+        return task.requestTaskMethodCall(this.syncType, this.address, "callFunc", payload);
     }
 
     /**

--- a/src/extensions/scenegraph/nodes/Task.ts
+++ b/src/extensions/scenegraph/nodes/Task.ts
@@ -15,6 +15,8 @@ import {
     ThreadUpdate,
     SyncType,
     RoArray,
+    RoAssociativeArray,
+    PrimitiveKinds,
     isSyncAction,
     RuntimeError,
     RuntimeErrorDetail,
@@ -89,9 +91,10 @@ function nextRendezvousId(): number {
  * timeout exists to report; a busy render thread is a device-faithful wait, not a failure.
  * @param timeoutMs Milliseconds of render-thread silence tolerated before the wait fails.
  * @param label Describes the pending rendezvous for the one-shot "still waiting" warning.
+ * @param waiter Describes who is waiting, for the one-shot warning. Defaults to the render thread.
  * @returns A countdown exposing the remaining time and a restart for uncounted pauses.
  */
-export function rendezvousDeadline(timeoutMs: number, label: () => string) {
+export function rendezvousDeadline(timeoutMs: number, label: () => string, waiter: string = "the render thread") {
     const started = Date.now();
     let beat = BrsDevice.readRenderHeartbeat();
     let deadline = started + timeoutMs;
@@ -110,7 +113,7 @@ export function rendezvousDeadline(timeoutMs: number, label: () => string) {
                     warned = true;
                     BrsDevice.stderr.write(
                         `warning,[task:${sgRoot.threadId}] Rendezvous ${label()} pending for ${elapsed}ms: ` +
-                            `the render thread is busy and has not reached its message loop`
+                            `${waiter} is busy and has not reached its message loop`
                     );
                 }
             }
@@ -151,6 +154,25 @@ function describeSimpleValue(value: BrsType): string {
 }
 
 /**
+ * Builds the frozen `m` a render-initiated `callFunc` dispatch runs against — see
+ * `.claude/docs/threading-and-rendezvous.md` for the snapshot semantics.
+ * @param m The Task's own live `m`, as of the capture moment.
+ * @returns A standalone associative array snapshotting `m`'s key set at this moment.
+ */
+function buildCallFuncSnapshot(m: RoAssociativeArray): RoAssociativeArray {
+    const snapshot = new RoAssociativeArray([]);
+    for (const [key, value] of m.elements) {
+        const lowerKey = key.toLowerCase();
+        if (lowerKey === "top" || lowerKey === "global" || value instanceof Node || PrimitiveKinds.has(value.kind)) {
+            snapshot.set(new BrsString(key), value, true);
+        } else {
+            snapshot.set(new BrsString(key), BrsInvalid.Instance, true);
+        }
+    }
+    return snapshot;
+}
+
+/**
  * SceneGraph `Task` node implementation responsible for executing BrightScript in a worker thread.
  * Manages control/state fields, SharedArrayBuffer message passing, and thread synchronization.
  */
@@ -180,6 +202,22 @@ export class Task extends Node {
      * busy-waits for FPS and doesn't yield its event loop mid-frame).
      */
     private readonly fanoutQueue: ThreadUpdate[] = [];
+    /**
+     * Dedicated buffer carrying replies from this Task thread back to a `callFunc` request
+     * initiated by whichever thread manages it (typically render — see `requestTaskMethodCall`).
+     * The request itself travels over `fanoutBuffer`/`fanoutQueue` (the only channel a Task polls
+     * during normal execution, not just while blocked in its own outgoing wait); the reply can't
+     * reuse `directBuffer` because a nested task→render rendezvous served while handling the call
+     * (e.g. a `m.global` read) could be in flight on it at the same time, in the opposite direction.
+     */
+    private callBackBuffer?: SharedObject;
+    /**
+     * Frozen snapshot of this Task's own `m`, set by `captureCallFuncSnapshot()` — see
+     * `.claude/docs/threading-and-rendezvous.md`.
+     */
+    private callFuncM?: RoAssociativeArray;
+    /** One-shot signal consumed by `consumeCallFuncMOverride()`. */
+    private useCallFuncSnapshot = false;
 
     /** Thread identifier assigned by sgRoot once scheduled. */
     threadId: number;
@@ -412,8 +450,8 @@ export class Task extends Node {
 
     /**
      * Allocates the dedicated render→task rendezvous buffers (direct response + observed-field
-     * fan-out) so the render thread delivers them straight to the Task thread without a main-thread
-     * relay hop. Idempotent and render-thread only.
+     * fan-out + callFunc reply) so the render thread delivers them straight to the Task thread
+     * without a main-thread relay hop. Idempotent and render-thread only.
      */
     private ensureDirectBuffers() {
         if (this.inThread || this.fanoutBuffer) {
@@ -421,6 +459,7 @@ export class Task extends Node {
         }
         this.directBuffer = new SharedObject();
         this.fanoutBuffer = new SharedObject();
+        this.callBackBuffer = new SharedObject();
         if (sgRoot.logRendezvous) {
             BrsDevice.stdout.write(
                 `debug,[rendezvous] thread ${sgRoot.threadId} allocated direct buffers for task ${this.nodeSubtype} (thread ${this.threadId})`
@@ -506,6 +545,16 @@ export class Task extends Node {
     }
 
     /**
+     * Initializes the dedicated callFunc-reply buffer on the Task thread.
+     * @param data Buffer this thread writes `callFunc` replies into, for the managing thread
+     *   (typically render) that called `requestTaskMethodCall` to read.
+     */
+    setCallBackBuffer(data: SharedArrayBuffer) {
+        this.callBackBuffer = new SharedObject();
+        this.callBackBuffer.setBuffer(data);
+    }
+
+    /**
      * Synchronizes a field change back to the owning thread when applicable.
      * @param key Field name to synchronize.
      * @param fieldValue The new value of the field being synchronized.
@@ -516,21 +565,16 @@ export class Task extends Node {
         if (this.threadId < 0 || !this.active) {
             return;
         }
-        // A node crossing task → render changes owner (below), so the receiver runs callFunc against
-        // its own copy and needs the script-scope `m` that init() populated here. Every other path
-        // leaves the owner unchanged, and a callFunc on a node owned elsewhere rendezvouses to that
-        // owner (device-confirmed), so shipping `m` there would only bloat the payload.
+        // See .claude/docs/threading-and-rendezvous.md for the scriptScope/re-own rules below.
         const value =
             fieldValue instanceof Node
                 ? fromSGNode(fieldValue, true, undefined, undefined, { scriptScope: this.inThread })
                 : jsValueOf(fieldValue);
         if (fieldValue instanceof Node) {
-            // Re-own to the render thread only when the node actually crosses task → render (a task
-            // setting a field). On the render side this is a fan-out (render → task): the node stays
-            // render-authoritative and the task receives a serialized copy, so mutating its ownership
-            // here would corrupt the live node tree (setOwner recurses into children).
-            if (this.inThread) {
-                fieldValue.setOwner(0); // Once the Node is sent to the Render thread, it's forever owned by it
+            // Re-own to render only when reporting through this task's own field (a hand-off);
+            // never for a field on some other render-owned node the task keeps using itself.
+            if (this.inThread && address === this.address) {
+                fieldValue.setOwner(0);
             }
             fieldValue.changed = false;
         }
@@ -662,6 +706,62 @@ export class Task extends Node {
     }
 
     /**
+     * Shared blocking wait for a method-call reply, used by `requestMethodCall` and
+     * `requestTaskMethodCall`.
+     * @param rdzCtx Rendezvous tracking context from the caller's `beginRendezvous`.
+     * @param responseBuffer Buffer this thread polls for the reply.
+     * @param requestId Id the caller's request was tagged with; only a reply carrying it resolves.
+     * @param type The sync type domain (for logging/timeout messages only).
+     * @param methodName The method name that was called (for logging/timeout messages only).
+     * @param timeoutMs Timeout in milliseconds.
+     * @param waiter Describes who this thread is waiting on, for the "still waiting" warning.
+     * @param pumpTasks Whether to call `sgRoot.processTasks()` every iteration before polling.
+     * @returns The method return value, or undefined on a `nil` reply.
+     * @throws {@link rendezvousTimeoutError} if no matching reply arrives before the deadline.
+     */
+    private waitForCallReply(
+        rdzCtx: RendezvousCtx | undefined,
+        responseBuffer: SharedObject,
+        requestId: number,
+        type: SyncType,
+        methodName: string,
+        timeoutMs: number,
+        waiter: string = "the render thread",
+        pumpTasks: boolean = false
+    ): BrsType | undefined {
+        const countdown = rendezvousDeadline(timeoutMs, () => `call ${type}.${methodName}`, waiter);
+        while (true) {
+            if (pumpTasks) {
+                sgRoot.processTasks();
+            }
+            const update = this.processThreadUpdate(responseBuffer);
+            if (update?.requestId === requestId) {
+                if (update.action === "resp") {
+                    this.endRendezvous(rdzCtx, "call", type, methodName);
+                    return brsValueOf(update.value);
+                } else if (update.action === "nil") {
+                    this.endRendezvous(rdzCtx, "call", type, methodName);
+                    return undefined;
+                }
+            }
+            if (BrsDevice.pauseIfDebugging()) {
+                // Frozen for a debug session on another thread; debug time must not count toward
+                // the rendezvous timeout, and the request has already been sent (do not re-send).
+                countdown.restart();
+                continue;
+            }
+            const remaining = countdown.remaining();
+            if (remaining <= 0) {
+                break;
+            }
+            // Cap the sleep so the loop re-checks pauseIfDebugging even if the debugger activates
+            // after we entered the wait; the real timeout is enforced by the `remaining` check above.
+            responseBuffer.waitVersion(0, Math.min(remaining, RENDEZVOUS_POLL_MS));
+        }
+        throw this.rendezvousTimeoutError("call", type, methodName);
+    }
+
+    /**
      * Requests a method call on the task thread (or from task to main) using rendezvous.
      * Blocks until the return value is received or timeout occurs.
      * @param type The sync type domain.
@@ -694,35 +794,93 @@ export class Task extends Node {
         };
         const rdzCtx = this.beginRendezvous("call", type, methodName);
         this.sendThreadUpdate(request);
-        const countdown = rendezvousDeadline(timeoutMs, () => `call ${type}.${methodName}`);
         const responseBuffer = this.directBuffer ?? this.taskBuffer;
+        return this.waitForCallReply(rdzCtx, responseBuffer, requestId, type, methodName, timeoutMs);
+    }
 
-        while (true) {
-            const update = this.processThreadUpdate(responseBuffer);
-            if (update?.requestId === requestId) {
-                if (update.action === "resp") {
-                    this.endRendezvous(rdzCtx, "call", type, methodName);
-                    return brsValueOf(update.value);
-                } else if (update.action === "nil") {
-                    this.endRendezvous(rdzCtx, "call", type, methodName);
-                    return undefined;
-                }
-            }
-            if (BrsDevice.pauseIfDebugging()) {
-                // Frozen for a debug session on another thread; debug time must not count toward
-                // the rendezvous timeout, and the request has already been sent (do not re-send).
-                countdown.restart();
-                continue;
-            }
-            const remaining = countdown.remaining();
-            if (remaining <= 0) {
-                break;
-            }
-            // Cap the sleep so the loop re-checks pauseIfDebugging even if the debugger activates
-            // after we entered the wait; the real timeout is enforced by the `remaining` check above.
-            responseBuffer.waitVersion(0, Math.min(remaining, RENDEZVOUS_POLL_MS));
+    /**
+     * A Task's callable interface functions always run on its own worker thread, regardless of
+     * which thread built/owns the node's fields — see `Node.callFuncThread`.
+     * @returns This task's thread id when active and scheduled, otherwise undefined (falls back to
+     *   ordinary owner-based routing — correctly so for a reconstructed copy of a *foreign* Task
+     *   reached via `m.global`/a field, since `active`/`threadId` are never serialized cross-thread).
+     */
+    protected callFuncThread(): number | undefined {
+        return this.active && this.threadId >= 0 ? this.threadId : undefined;
+    }
+
+    /**
+     * Captures this Task's `callFuncM` snapshot. Call exactly once, on the task thread itself,
+     * right after `init()` completes and before the task function begins running — see
+     * `.claude/docs/threading-and-rendezvous.md`. No-op when this Task has no callable interface
+     * functions, since `callFunction` can never dispatch to it.
+     */
+    captureCallFuncSnapshot() {
+        if (this.funcNames.size === 0) {
+            return;
         }
-        throw this.rendezvousTimeoutError("call", type, methodName);
+        this.callFuncM = buildCallFuncSnapshot(this.m);
+    }
+
+    /**
+     * Consumes the one-shot `useCallFuncSnapshot` signal `handleMethodCallRequest` sets
+     * immediately before dispatching a render-initiated `callFunc` on this thread.
+     * @returns The frozen `callFuncM` snapshot when the signal is set, otherwise undefined (use
+     *   the live `this.m`, e.g. for a Task calling `callFunc` on itself directly).
+     */
+    protected consumeCallFuncMOverride(): RoAssociativeArray | undefined {
+        if (!this.useCallFuncSnapshot) {
+            return undefined;
+        }
+        this.useCallFuncSnapshot = false;
+        return this.callFuncM;
+    }
+
+    /**
+     * Requests a `callFunc`-class method call on this Task's own worker thread. Mirrors
+     * `requestMethodCall`'s protocol but travels via `fanoutQueue`/`fanoutBuffer` with the reply
+     * on the dedicated `callBackBuffer` — see `.claude/docs/threading-and-rendezvous.md`.
+     * @param type The sync type domain.
+     * @param address The address of the target node.
+     * @param methodName The method name to call.
+     * @param payload Optional arguments and context for the call.
+     * @param timeoutMs Timeout in milliseconds.
+     * @returns The method return value or undefined on error/timeout.
+     */
+    requestTaskMethodCall(
+        type: SyncType,
+        address: string,
+        methodName: string,
+        payload?: MethodCallPayload,
+        timeoutMs: number = sgRoot.rendezvousTimeout
+    ): BrsType | undefined {
+        if (this.inThread || !this.fanoutBuffer || !this.callBackBuffer || this.threadId < 0 || !this.active) {
+            return undefined;
+        }
+        const value = payload ?? null;
+        const requestId = this.syncRequestId++;
+        const request: ThreadUpdate = {
+            id: sgRoot.threadId,
+            action: "call",
+            type,
+            address,
+            key: methodName,
+            value,
+            requestId,
+            direct: true,
+        };
+        const rdzCtx = this.beginRendezvous("call", type, methodName);
+        this.fanoutQueue.push(request);
+        return this.waitForCallReply(
+            rdzCtx,
+            this.callBackBuffer,
+            requestId,
+            type,
+            methodName,
+            timeoutMs,
+            "the task thread",
+            true
+        );
     }
 
     /**
@@ -767,6 +925,7 @@ export class Task extends Node {
                 buffer: this.taskBuffer.getBuffer(),
                 directToTask: this.directBuffer?.getBuffer(),
                 fanout: this.fanoutBuffer?.getBuffer(),
+                callBack: this.callBackBuffer?.getBuffer(),
                 tmp: BrsDevice.getTmpVolume(),
                 cacheFS: BrsDevice.getCacheFS(),
                 m: serializeTaskM(this.m, this),
@@ -849,6 +1008,12 @@ export class Task extends Node {
         // and all task-originated traffic still go through the broker via postMessage.
         if (!this.inThread && this.directBuffer && update.requestId !== undefined) {
             this.directBuffer.store(update);
+            return;
+        }
+        // A task thread replying to a direct-flagged callFunc request — mirrors the render-side
+        // direct-buffer branch above, in the opposite direction.
+        if (this.inThread && update.direct && this.callBackBuffer && !isRequest) {
+            this.callBackBuffer.store(update);
             return;
         }
         postMessage(update);
@@ -1169,7 +1334,19 @@ export class Task extends Node {
         if (!this.inThread) {
             this.trackRemotePortObserver(target, update, payload.args);
         }
-        const result = sgRoot.interpreter.call(method, args, hostNode.m, location, hostNode);
+        // Signal the callFuncM snapshot for this one dispatch — see .claude/docs/threading-and-rendezvous.md.
+        const snapshotTarget = update.direct === true && target instanceof Task ? target : undefined;
+        if (snapshotTarget) {
+            snapshotTarget.useCallFuncSnapshot = true;
+        }
+        let result: BrsType;
+        try {
+            result = sgRoot.interpreter.call(method, args, hostNode.m, location, hostNode);
+        } finally {
+            if (snapshotTarget) {
+                snapshotTarget.useCallFuncSnapshot = false;
+            }
+        }
         update.action = "resp";
         if (result instanceof Node) {
             const deep = result instanceof ContentNode;

--- a/src/extensions/scenegraph/nodes/Task.ts
+++ b/src/extensions/scenegraph/nodes/Task.ts
@@ -744,6 +744,14 @@ export class Task extends Node {
                     return undefined;
                 }
             }
+            if (pumpTasks && !this.active) {
+                // The target task finished and tore down its worker while we were waiting (a race
+                // between its final field sync and its own control=stop relay reaching us -- see
+                // .claude/docs/threading-and-rendezvous.md). No reply can ever arrive; fall back
+                // instead of blocking for the full timeout.
+                this.endRendezvous(rdzCtx, "call", type, methodName);
+                return undefined;
+            }
             if (BrsDevice.pauseIfDebugging()) {
                 // Frozen for a debug session on another thread; debug time must not count toward
                 // the rendezvous timeout, and the request has already been sent (do not re-send).
@@ -1211,6 +1219,15 @@ export class Task extends Node {
             ? node.resolveField(update.key.toLowerCase())?.isObserved() ?? false
             : false;
         const previous = sgRoot.logRendezvous ? describeSimpleValue(oldValue) : "";
+        // Ack the sender before applying the value: applying it can synchronously fire an observer
+        // (e.g. a Task's own field-change observer calling `callFunc` right back onto this same
+        // task), which would otherwise block this thread and starve the sender's own blocking wait
+        // for this very ack -- a deadlock. The ack is a transport-level receipt, independent of
+        // whatever the observer subsequently does. See .claude/docs/threading-and-rendezvous.md.
+        if (!this.inThread && update.requestId !== undefined) {
+            const ack: ThreadUpdate = { ...update, action: "ack", value: null };
+            this.sendThreadUpdate(ack);
+        }
         // A reply to one of *our* reads only mirrors the owner's value locally — it is not a change,
         // so it must not fire this thread's observers (see `pendingReads`).
         const isReadReply = update.requestId !== undefined && this.pendingReads.has(update.requestId);
@@ -1252,12 +1269,6 @@ export class Task extends Node {
             } else {
                 node.fanOutFieldToObservingTasks(update.key, update.id);
             }
-        }
-        // Send acknowledgement back to the other thread if needed
-        if (!this.inThread && update.requestId !== undefined) {
-            update.action = "ack";
-            update.value = null;
-            this.sendThreadUpdate(update);
         }
         return update;
     }

--- a/test/cli/cli-scenegraph.test.js
+++ b/test/cli/cli-scenegraph.test.js
@@ -1124,6 +1124,45 @@ describe.concurrent("cli scenegraph", () => {
         expect(stdout).toContain("[EXIT_BRIGHTSCRIPT_CRASH]");
     }, 30000);
 
+    it("Rendezvouses a callFunc from the render thread onto a Task's own thread", async () => {
+        let command = ["node", brsCliPath, "-r task-render-callfunc-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        // `m.harvestEvents` (created in init(), see HarvestTask.xml) must round-trip through a
+        // render-initiated callFunc; `m.postInitNode` (created in runTask(), after init() returns)
+        // must be invisible to it. A nested m.global read inside the call must not deadlock. See
+        // .claude/docs/threading-and-rendezvous.md.
+        const lines = stdout.split("\n").map((line) => line.trimEnd());
+        expect(lines).toContain("=== Task Render CallFunc Repro ===");
+        expect(lines).toContain("TASK: tag=v1 duration=42");
+        expect(lines).toContain("SCENE: callFunc returned 42");
+        expect(lines).toContain("TASK: touchPostInitNode m-has-postInitNode=false");
+        expect(lines).toContain("SCENE: touchPostInitNode reports m-has-postInitNode=false");
+        expect(lines).toContain("=== Task Render CallFunc Repro Complete ===");
+        expect(stdout).not.toContain("Invalid value for left-side of expression");
+        expect(stdout).not.toContain("Dropped script-scope reference");
+    }, 30000);
+
+    it("Rendezvouses a callFunc from the render thread onto a plain Node owned by a Task thread", async () => {
+        let command = ["node", brsCliPath, "-r task-owned-node-callfunc-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        // AppTask constructs AgentNode (a plain Node, not a Task) on its own thread and publishes
+        // it via m.global, matching the real New Relic SDK shape (NRAgent.xml, a plain Node whose
+        // nrSetHarvestTime is callFunc-invoked). See .claude/docs/threading-and-rendezvous.md and
+        // test/simulator/probes/node-owned-by-task-callfunc-probe/ for the full investigation.
+        const lines = stdout.split("\n").map((line) => line.trimEnd());
+        expect(lines).toContain("=== Task Owned Node CallFunc Repro ===");
+        expect(lines).toContain("AGENT: setHarvestTime duration=42");
+        expect(lines).toContain("SCENE: callFunc returned 42");
+        expect(lines).toContain("=== Task Owned Node CallFunc Repro Complete ===");
+        expect(stdout).not.toContain("Invalid value for left-side of expression");
+    }, 30000);
+
     it("roDataGramSocket performs real UDP send/receive from inside a Task", async () => {
         let command = ["node", brsCliPath, "-r udp-loopback-app", "source/main.brs", "-c 0"].join(" ");
 

--- a/test/cli/cli-scenegraph.test.js
+++ b/test/cli/cli-scenegraph.test.js
@@ -1163,6 +1163,25 @@ describe.concurrent("cli scenegraph", () => {
         expect(stdout).not.toContain("Invalid value for left-side of expression");
     }, 30000);
 
+    it("A Task's own field-change observer can callFunc back onto that same task without deadlocking", async () => {
+        let command = ["node", brsCliPath, "-r task-selfcall-observer-app", "source/main.brs", "-c 0"].join(" ");
+
+        let { stdout } = await exec(command, {
+            cwd: path.join(__dirname, "resources"),
+        });
+        // SelfCallTask sets its own field and returns (a one-shot function, no wait() loop); render's
+        // observer of that field callFunc()s straight back onto the same task before the task's own
+        // field-set rendezvous is ack'd. Matches jellyfin-roku's PostTask/postFinished() shape. See
+        // .claude/docs/threading-and-rendezvous.md.
+        const lines = stdout.split("\n").map((line) => line.trimEnd());
+        expect(lines).toContain("=== Task Selfcall Observer Repro ===");
+        expect(lines).toContain("SCENE: onResponseCode 42");
+        expect(lines).toContain("TASK: reset called, responseCode was 42");
+        expect(lines).toContain("SCENE: reset callFunc returned true");
+        expect(lines).toContain("=== Task Selfcall Observer Repro Complete ===");
+        expect(stdout).not.toContain("Rendezvous timeout");
+    }, 30000);
+
     it("roDataGramSocket performs real UDP send/receive from inside a Task", async () => {
         let command = ["node", brsCliPath, "-r udp-loopback-app", "source/main.brs", "-c 0"].join(" ");
 

--- a/test/cli/resources/task-owned-node-callfunc-app/components/AgentNode.xml
+++ b/test/cli/resources/task-owned-node-callfunc-app/components/AgentNode.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Mirrors the real New Relic Roku video-agent SDK's NRAgent.xml structure exactly (fetched from
+    github.com/newrelic/video-agent-roku, tag 3.2.4, components/NewRelicAgent/{NRAgent.xml,.brs}):
+    a plain Node (NOT a Task) with a child Timer, whose reference is captured into a raw
+    script-scope `m` member via findNode() inside a callFunc-invoked "init" wrapper function
+    (NewRelicInit in the real SDK), not inside init() itself. The real crash line
+    (`m.nrHarvestTimerEvents.duration = seconds` in NRAgent.brs's nrSetHarvestTimeEvents, called
+    from nrSetHarvestTime) is reproduced here as setHarvestTime / harvestTimer.
+-->
+<component name="AgentNode" extends="Node">
+    <interface>
+        <function name="agentInit" />
+        <function name="setHarvestTime" />
+    </interface>
+    <children>
+        <Timer id="harvestTimer" repeat="true" />
+    </children>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        ' Real NRAgent.brs's init() is likewise trivial -- it does not touch any children.
+    end sub
+
+    ' Mirrors NewRelicInit(): a callFunc-invoked "constructor" function, not init() itself, that
+    ' captures a child node reference into a raw script-scope `m` member.
+    function agentInit() as Void
+        m.harvestTimer = m.top.findNode("harvestTimer")
+        m.harvestTimer.duration = 60
+    end function
+
+    ' Mirrors nrSetHarvestTimeEvents(): `m.nrHarvestTimerEvents.duration = seconds`.
+    function setHarvestTime(seconds as Integer) as Dynamic
+        m.harvestTimer.duration = seconds
+        print "AGENT: setHarvestTime duration=" + m.harvestTimer.duration.toStr()
+        return seconds
+    end function
+    ]]></script>
+</component>

--- a/test/cli/resources/task-owned-node-callfunc-app/components/AppTask.xml
+++ b/test/cli/resources/task-owned-node-callfunc-app/components/AppTask.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Mirrors the app's own "main"/business-logic Task creating an SDK's agent Node on its own
+    worker thread (not render) and publishing it as a m.global singleton: a very common SDK
+    integration pattern (CreateObject the agent once, store a handle other components/threads
+    reach it through). AgentNode.owner ends up being THIS task's thread, not render's: the
+    precondition for the render->callFunc bug this fixture regression-tests.
+-->
+<component name="AppTask" extends="Task">
+    <interface>
+        <field id="ready" type="boolean" value="false" />
+    </interface>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.top.functionName = "runTask"
+        m.port = CreateObject("roMessagePort")
+        m.top.observeField("control", m.port)
+    end sub
+
+    sub runTask()
+        m.agent = CreateObject("roSGNode", "AgentNode")
+        m.agent.callFunc("agentInit") ' same-thread call: this task calling its own local node.
+
+        m.global.addField("nrAgent", "node", false)
+        m.global.nrAgent = m.agent
+
+        m.top.ready = true
+        for i = 0 to 200
+            msg = wait(50, m.port)
+        end for
+    end sub
+    ]]></script>
+</component>

--- a/test/cli/resources/task-owned-node-callfunc-app/components/MainScene.xml
+++ b/test/cli/resources/task-owned-node-callfunc-app/components/MainScene.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="MainScene" extends="Scene">
+    <interface>
+        <field id="done" type="boolean" value="false" />
+        <field id="agentReady" type="boolean" value="false" />
+        <function name="doHarvestCall" />
+    </interface>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.appTask = createObject("roSGNode", "AppTask")
+        m.appTask.observeField("ready", "onAppTaskReady")
+        m.appTask.control = "run"
+    end sub
+
+    sub onAppTaskReady(event as object)
+        if event.getData() then m.top.agentReady = true
+    end sub
+
+    ' Matches the reported crash's call shape exactly: callFunc issued from the render (main)
+    ' thread's own clean loop context (source/main.brs), onto a node handle read back from
+    ' m.global -- the agent Node was constructed by AppTask (a Task), not by render.
+    function doHarvestCall() as Dynamic
+        agent = m.global.nrAgent
+        result = agent.callFunc("setHarvestTime", 42)
+        print "SCENE: callFunc returned " + result.toStr()
+        m.top.done = true
+        return result
+    end function
+    ]]></script>
+</component>

--- a/test/cli/resources/task-owned-node-callfunc-app/manifest
+++ b/test/cli/resources/task-owned-node-callfunc-app/manifest
@@ -1,0 +1,4 @@
+title=Task Owned Node CallFunc Repro
+major_version=1
+minor_version=0
+build_version=1

--- a/test/cli/resources/task-owned-node-callfunc-app/source/main.brs
+++ b/test/cli/resources/task-owned-node-callfunc-app/source/main.brs
@@ -1,0 +1,20 @@
+sub Main()
+    print "=== Task Owned Node CallFunc Repro ==="
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+    scene = screen.CreateScene("MainScene")
+    screen.show()
+    called = false
+    for i = 0 to 250
+        msg = wait(20, port)
+        if not called and scene.agentReady
+            ' callFunc onto the agent from this thread's own loop, outside any observer nesting --
+            ' matches the reported crash's call shape (main thread's own message-processing loop).
+            scene.callFunc("doHarvestCall")
+            called = true
+        end if
+        if scene.done then exit for
+    end for
+    print "=== Task Owned Node CallFunc Repro Complete ==="
+end sub

--- a/test/cli/resources/task-render-callfunc-app/components/HarvestTask.xml
+++ b/test/cli/resources/task-render-callfunc-app/components/HarvestTask.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="HarvestTask" extends="Task">
+    <interface>
+        <field id="ready" type="boolean" value="false" />
+        <function name="setHarvestTime" />
+        <function name="touchPostInitNode" />
+    </interface>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.top.functionName = "runTask"
+        ' The documented Task pattern: registered here, on the render thread, before the task
+        ' launches -- observeField's port branch is what wires this port's wait() to service
+        ' cross-thread requests (see task-globalobserve-app for the same shape). A port observed
+        ' only after the task is already running would just sleep, wired to nothing.
+        m.port = CreateObject("roMessagePort")
+        m.top.observeField("control", m.port)
+
+        ' Populated here, in init() -- this is the exact condition that used to crash a
+        ' render-initiated callFunc in brs-engine: a script-scope node reference that never
+        ' independently crossed to the render thread before, so a render-side reconstruction of
+        ' this node would be missing it.
+        '
+        ' Device testing (see .claude/docs/threading-and-rendezvous.md and the
+        ' callfunc-task-thread-probe in test/simulator/probes/) confirmed the real, precise rule:
+        ' real Roku takes a snapshot of a Task's `m` once, right after init() completes, and every
+        ' callFunc dispatch runs against that frozen snapshot forever after -- never the task's
+        ' live, currently-mutating `m`. A member that *is* in that snapshot keeps pointing at the
+        ' exact same live value (a Node stays fully functional; mutations through it persist).
+        ' That is why this node is created here, in init(), rather than in runTask() below.
+        m.harvestEvents = CreateObject("roSGNode", "Node")
+        m.harvestEvents.addField("duration", "integer", false)
+    end sub
+
+    sub runTask()
+        ' Populated AFTER init() returns, on this thread -- device-confirmed to be invisible to a
+        ' render-initiated callFunc dispatch, not merely stale: touchPostInitNode below finds
+        ' m.postInitNode absent entirely, not just an outdated copy of it. See the init() comment
+        ' above for the full story; touchPostInitNode is the negative-case regression companion to
+        ' setHarvestTime's positive case.
+        m.postInitNode = CreateObject("roSGNode", "Node")
+        m.postInitNode.addField("value", "integer", false)
+        m.top.ready = true
+        for i = 0 to 200
+            msg = wait(50, m.port)
+        end for
+    end sub
+
+    function setHarvestTime(seconds as Integer) as Dynamic
+        ' Reading a m.global field forces a nested task->render rendezvous while render is
+        ' blocked waiting on this very call -- must not deadlock.
+        tag = m.global.appTag
+        m.harvestEvents.duration = seconds
+        print "TASK: tag=" + tag + " duration=" + m.harvestEvents.duration.toStr()
+        return seconds
+    end function
+
+    ' Negative-case companion to setHarvestTime: m.postInitNode was created in runTask(), after
+    ' init() returned, so a render-initiated callFunc must not see it -- not even as a key.
+    function touchPostInitNode() as string
+        hasKey = m.doesExist("postInitNode")
+        print "TASK: touchPostInitNode m-has-postInitNode=" + hasKey.toStr()
+        return hasKey.toStr()
+    end function
+    ]]></script>
+</component>

--- a/test/cli/resources/task-render-callfunc-app/components/MainScene.xml
+++ b/test/cli/resources/task-render-callfunc-app/components/MainScene.xml
@@ -14,13 +14,10 @@
     end sub
 
     sub onTaskReady(event as object)
-        ' Only flag readiness here -- do NOT call m.task.callFunc() from this handler. This fires
-        ' synchronously while the task's own "ready" field-set rendezvous is still awaiting its ack
-        ' (handleSetFieldRequest sends it only after this observer returns), so a callFunc back into
-        ' the SAME task here would deadlock: the task blocks on that ack while render blocks on the
-        ' callFunc reply, and neither side is free to service the other. The reported crash calls
-        ' callFunc from the main thread's own independent message loop, not from a field observer of
-        ' the target task -- doHarvestCall(), below, is called from that same clean context.
+        ' Only flag readiness here; doHarvestCall() below calls back from a clean, non-nested
+        ' context (the reported crash's own shape). Calling back onto the same task from directly
+        ' inside its own field-change observer is covered separately by task-selfcall-observer-app
+        ' -- see .claude/docs/threading-and-rendezvous.md.
         if event.getData() then m.top.taskReady = true
     end sub
 

--- a/test/cli/resources/task-render-callfunc-app/components/MainScene.xml
+++ b/test/cli/resources/task-render-callfunc-app/components/MainScene.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="MainScene" extends="Scene">
+    <interface>
+        <field id="done" type="boolean" value="false" />
+        <field id="taskReady" type="boolean" value="false" />
+        <function name="doHarvestCall" />
+    </interface>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.global.addFields({ appTag: "v1" })
+        m.task = createObject("roSGNode", "HarvestTask")
+        m.task.observeField("ready", "onTaskReady")
+        m.task.control = "run"
+    end sub
+
+    sub onTaskReady(event as object)
+        ' Only flag readiness here -- do NOT call m.task.callFunc() from this handler. This fires
+        ' synchronously while the task's own "ready" field-set rendezvous is still awaiting its ack
+        ' (handleSetFieldRequest sends it only after this observer returns), so a callFunc back into
+        ' the SAME task here would deadlock: the task blocks on that ack while render blocks on the
+        ' callFunc reply, and neither side is free to service the other. The reported crash calls
+        ' callFunc from the main thread's own independent message loop, not from a field observer of
+        ' the target task -- doHarvestCall(), below, is called from that same clean context.
+        if event.getData() then m.top.taskReady = true
+    end sub
+
+    ' Called via callFunc from the main thread's own loop (source/main.brs), matching the reported
+    ' crash's call shape: callFunc onto a Task node from a clean, non-nested render-thread context.
+    function doHarvestCall() as Dynamic
+        result = m.task.callFunc("setHarvestTime", 42)
+        print "SCENE: callFunc returned " + result.toStr()
+        hasPostInit = m.task.callFunc("touchPostInitNode")
+        print "SCENE: touchPostInitNode reports m-has-postInitNode=" + hasPostInit
+        m.top.done = true
+        return result
+    end function
+    ]]></script>
+</component>

--- a/test/cli/resources/task-render-callfunc-app/manifest
+++ b/test/cli/resources/task-render-callfunc-app/manifest
@@ -1,0 +1,4 @@
+title=Task Render CallFunc Repro
+major_version=1
+minor_version=0
+build_version=1

--- a/test/cli/resources/task-render-callfunc-app/source/main.brs
+++ b/test/cli/resources/task-render-callfunc-app/source/main.brs
@@ -1,0 +1,20 @@
+sub Main()
+    print "=== Task Render CallFunc Repro ==="
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+    scene = screen.CreateScene("MainScene")
+    screen.show()
+    called = false
+    for i = 0 to 250
+        msg = wait(20, port)
+        if not called and scene.taskReady
+            ' callFunc onto the Task from this thread's own loop, outside any observer nesting --
+            ' matches the reported crash's call shape (main thread's own message-processing loop).
+            scene.callFunc("doHarvestCall")
+            called = true
+        end if
+        if scene.done then exit for
+    end for
+    print "=== Task Render CallFunc Repro Complete ==="
+end sub

--- a/test/cli/resources/task-selfcall-observer-app/components/MainScene.xml
+++ b/test/cli/resources/task-selfcall-observer-app/components/MainScene.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="MainScene" extends="Scene">
+    <interface>
+        <field id="finished" type="boolean" value="false" />
+    </interface>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.task = createObject("roSGNode", "SelfCallTask")
+        m.task.observeField("responseCode", "onResponseCode")
+        m.task.control = "run"
+    end sub
+
+    ' Fires synchronously while m.task's own "responseCode" field-set rendezvous is still awaiting
+    ' its ack (handleSetFieldRequest used to send it only after this observer returns). Calling
+    ' callFunc() on the SAME task here used to deadlock: the task blocks on that ack while render
+    ' blocks on the callFunc reply, and neither side is free to service the other. See
+    ' .claude/docs/threading-and-rendezvous.md.
+    sub onResponseCode(event as object)
+        print "SCENE: onResponseCode " + event.getData().toStr()
+        m.task.unobserveField("responseCode")
+        result = m.task.callFunc("reset")
+        print "SCENE: reset callFunc returned " + result.toStr()
+        m.top.finished = true
+    end sub
+    ]]></script>
+</component>

--- a/test/cli/resources/task-selfcall-observer-app/components/SelfCallTask.xml
+++ b/test/cli/resources/task-selfcall-observer-app/components/SelfCallTask.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="SelfCallTask" extends="Task">
+    <interface>
+        <field id="responseCode" type="integer" value="0" />
+        <function name="reset" />
+    </interface>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.top.functionName = "runTask"
+    end sub
+
+    ' Matches PostTask.bs's real-world shape: a one-shot function whose only job is to set its own
+    ' field and return -- no wait() loop. The render-side observer of that field (see MainScene's
+    ' onResponseCode) calls callFunc() straight back onto this same task before this thread's own
+    ' set-field rendezvous is ack'd.
+    sub runTask()
+        m.top.responseCode = 42
+    end sub
+
+    function reset() as Dynamic
+        print "TASK: reset called, responseCode was " + m.top.responseCode.toStr()
+        m.top.responseCode = 0
+        return true
+    end function
+    ]]></script>
+</component>

--- a/test/cli/resources/task-selfcall-observer-app/manifest
+++ b/test/cli/resources/task-selfcall-observer-app/manifest
@@ -1,0 +1,4 @@
+title=Task Selfcall Observer Repro
+major_version=1
+minor_version=0
+build_version=1

--- a/test/cli/resources/task-selfcall-observer-app/source/main.brs
+++ b/test/cli/resources/task-selfcall-observer-app/source/main.brs
@@ -1,0 +1,13 @@
+sub Main()
+    print "=== Task Selfcall Observer Repro ==="
+    screen = CreateObject("roSGScreen")
+    port = CreateObject("roMessagePort")
+    screen.setMessagePort(port)
+    scene = screen.CreateScene("MainScene")
+    screen.show()
+    for i = 0 to 250
+        msg = wait(20, port)
+        if scene.finished then exit for
+    end for
+    print "=== Task Selfcall Observer Repro Complete ==="
+end sub

--- a/test/extensions/scenegraph/DirectRendezvous.test.js
+++ b/test/extensions/scenegraph/DirectRendezvous.test.js
@@ -135,14 +135,26 @@ describe("Phase 3b direct fan-out", () => {
         expect(node.getOwner()).toBe(7); // unchanged on the render side
     });
 
-    test("a task-thread set DOES re-own the node to the render thread", () => {
+    test("a task-thread set on its OWN field DOES re-own the node to the render thread", () => {
         const task = renderSideTask();
         task.inThread = true; // simulate running on the task worker
         const node = new Task([], "Inner");
         node.setOwner(7);
-        task.syncRemoteField("foo", node, "node", "ABC123");
+        // address === task.address: setting the task's own interface field.
+        task.syncRemoteField("foo", node, "node", task.address);
 
         expect(node.getOwner()).toBe(0); // crossed task -> render, now render-owned
+    });
+
+    test("a task-thread set on a FOREIGN node's field does NOT re-own the node", () => {
+        const task = renderSideTask();
+        task.inThread = true; // simulate running on the task worker
+        const node = new Task([], "Inner");
+        node.setOwner(7);
+        // address !== task.address: setting a field on some OTHER render-owned node.
+        task.syncRemoteField("foo", node, "node", "ABC123");
+
+        expect(node.getOwner()).toBe(7); // unchanged — still owned by the task that built it
     });
 
     test("a non-serializable fan-out is dropped without throwing; the rest still flush", () => {

--- a/test/extensions/scenegraph/DynamicKeyboard.test.js
+++ b/test/extensions/scenegraph/DynamicKeyboard.test.js
@@ -207,7 +207,7 @@ describe("Dynamic voice keyboards", () => {
             kbd.funcNames.add("keyselected");
             sgRoot._interpreter = fakeInterpreter;
             const calls = [];
-            kbd.callFunction = (interpreter, name, key) => {
+            kbd.callFunction = (interpreter, name, mOverride, key) => {
                 calls.push([interpreter, name.getValue(), key.getValue()]);
                 return core.BrsBoolean.True;
             };

--- a/test/extensions/scenegraph/RenderTaskCallFunc.test.js
+++ b/test/extensions/scenegraph/RenderTaskCallFunc.test.js
@@ -1,0 +1,407 @@
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { Task, Node, sgRoot } = scenegraph;
+const { Interpreter, SharedObject, BrsString, RoMessagePort, Int32, BrsBoolean, BrsInvalid, Callable } = core;
+
+/**
+ * `callFunc` from the render thread onto a Task must rendezvous to the Task's own worker thread —
+ * a Task's callable interface functions always run there, regardless of which thread's copy of the
+ * node's *fields* is authoritative (`owner`). See `.claude/docs/threading-and-rendezvous.md` and
+ * `Node.callFuncThread`/`Node.rendezvousCallFunc`/`Task.requestTaskMethodCall`.
+ */
+describe("callFuncThread", () => {
+    test("an inactive/unscheduled task returns undefined", () => {
+        const task = new Task([], "MyTask");
+        expect(task.callFuncThread()).toBeUndefined();
+    });
+
+    test("an active, scheduled task returns its own thread id", () => {
+        const task = new Task([], "MyTask");
+        task.active = true;
+        task.threadId = 3;
+        expect(task.callFuncThread()).toBe(3);
+    });
+
+    test("a plain Node with the default (render) owner has no callFunc thread", () => {
+        const node = new Node([], "Group");
+        expect(node.callFuncThread()).toBeUndefined();
+    });
+
+    test("a plain Node owned by an active, registered task thread routes to that thread", () => {
+        const node = new Node([], "Group");
+        node.setOwner(2);
+        const task = new Task([], "OwningTask");
+        task.active = true;
+        task.threadId = 2;
+
+        const originalGetThreadTask = sgRoot.getThreadTask;
+        sgRoot.getThreadTask = vi.fn((id) => (id === 2 ? task : undefined));
+        try {
+            expect(node.callFuncThread()).toBe(2);
+            expect(sgRoot.getThreadTask).toHaveBeenCalledWith(2);
+        } finally {
+            sgRoot.getThreadTask = originalGetThreadTask;
+        }
+    });
+
+    test("a plain Node whose owner thread has no registered/active task falls back to undefined", () => {
+        const node = new Node([], "Group");
+        node.setOwner(5); // no task registered for thread 5
+
+        const originalGetThreadTask = sgRoot.getThreadTask;
+        sgRoot.getThreadTask = vi.fn(() => undefined);
+        try {
+            expect(node.callFuncThread()).toBeUndefined();
+        } finally {
+            sgRoot.getThreadTask = originalGetThreadTask;
+        }
+    });
+});
+
+describe("rendezvousCallFunc routing", () => {
+    beforeEach(() => {
+        sgRoot.setCurrentThread(0);
+    });
+    afterEach(() => {
+        sgRoot.setCurrentThread(0);
+    });
+
+    function makeInterpreter() {
+        return new Interpreter();
+    }
+
+    test("a non-Task target falls back to the existing owner-based rendezvousCall", () => {
+        const node = new Node([], "Group");
+        const interpreter = makeInterpreter();
+        const functionName = new BrsString("doThing");
+        node.rendezvousCall = vi.fn(() => new BrsString("stubbed"));
+
+        const result = node.rendezvousCallFunc(interpreter, functionName, []);
+
+        // `false`: a callFunc argument must never be silently re-owned to the callee (see
+        // buildMethodCallPayload's comment) -- unlike rendezvousCall's ~69 other, non-callFunc
+        // call sites, which omit this argument and keep the default `true`.
+        expect(node.rendezvousCall).toHaveBeenCalledWith(interpreter, "callFunc", [functionName], false);
+        expect(result.toString()).toBe("stubbed");
+    });
+
+    test("an inactive Task target falls back to running locally", () => {
+        const task = new Task([], "MyTask");
+        task.threadId = 1; // scheduled, but not active
+        const interpreter = makeInterpreter();
+        task.requestTaskMethodCall = vi.fn();
+
+        const result = task.rendezvousCallFunc(interpreter, new BrsString("doThing"), []);
+
+        expect(result).toBeUndefined();
+        expect(task.requestTaskMethodCall).not.toHaveBeenCalled();
+    });
+
+    test("calling from the thread a Task's functions already run on returns undefined (runs locally, no self-rendezvous)", () => {
+        const task = new Task([], "MyTask");
+        task.active = true;
+        task.threadId = 0; // matches sgRoot's current thread for this check
+        const interpreter = makeInterpreter();
+        task.requestTaskMethodCall = vi.fn();
+        task.rendezvousCall = vi.fn();
+
+        const result = task.rendezvousCallFunc(interpreter, new BrsString("doThing"), []);
+
+        expect(result).toBeUndefined();
+        expect(task.requestTaskMethodCall).not.toHaveBeenCalled();
+        // Must not fall back to the owner-based path either — that would be a spurious second
+        // rendezvous from the task back out to itself (handleMethodCallRequest's re-dispatch hazard).
+        expect(task.rendezvousCall).not.toHaveBeenCalled();
+    });
+
+    test("calling a different, active task thread requests a task method call on it", () => {
+        const task = new Task([], "MyTask");
+        task.active = true;
+        task.threadId = 1;
+        const interpreter = makeInterpreter();
+        task.requestTaskMethodCall = vi.fn(() => new BrsString("remote-result"));
+
+        const originalGetThreadTask = sgRoot.getThreadTask;
+        sgRoot.getThreadTask = vi.fn((id) => (id === 1 ? task : undefined));
+        try {
+            const result = task.rendezvousCallFunc(interpreter, new BrsString("doThing"), []);
+
+            expect(sgRoot.getThreadTask).toHaveBeenCalledWith(1);
+            expect(task.requestTaskMethodCall).toHaveBeenCalledTimes(1);
+            const [type, address, method, payload] = task.requestTaskMethodCall.mock.calls[0];
+            expect(type).toBe(task.syncType);
+            expect(address).toBe(task.address);
+            expect(method).toBe("callFunc");
+            expect(payload.args?.[0]).toBe("doThing");
+            expect(result.toString()).toBe("remote-result");
+        } finally {
+            sgRoot.getThreadTask = originalGetThreadTask;
+        }
+    });
+
+    test("a Node argument keeps its own ownership when calling INTO a Task -- is not reassigned to the callee thread", () => {
+        const task = new Task([], "MyTask");
+        task.active = true;
+        task.threadId = 1;
+        const interpreter = makeInterpreter();
+        task.requestTaskMethodCall = vi.fn(() => BrsInvalid.Instance);
+
+        const argNode = new Node([], "Group"); // owner defaults to render (0)
+        expect(argNode.getOwner()).toBe(0);
+
+        const originalGetThreadTask = sgRoot.getThreadTask;
+        sgRoot.getThreadTask = vi.fn((id) => (id === 1 ? task : undefined));
+        try {
+            task.rendezvousCallFunc(interpreter, new BrsString("doThing"), [argNode]);
+            expect(argNode.getOwner()).toBe(0); // unchanged -- caller keeps its own local node
+        } finally {
+            sgRoot.getThreadTask = originalGetThreadTask;
+        }
+    });
+
+    test("a Node argument keeps its own ownership when a Task calls a render-owned target -- fallback path", () => {
+        // Symmetric case to the test above, via rendezvousCallFunc's fallback branch.
+        sgRoot.setCurrentThread(1);
+        const renderOwnedTarget = new Node([], "Group"); // owner defaults to render (0)
+        const interpreter = makeInterpreter();
+
+        const currentTask = new Task([], "CallingTask");
+        currentTask.active = true;
+        currentTask.requestMethodCall = vi.fn(() => BrsInvalid.Instance);
+        const originalGetCurrentThreadTask = sgRoot.getCurrentThreadTask;
+        sgRoot.getCurrentThreadTask = vi.fn(() => currentTask);
+
+        const argNode = new Node([], "Group");
+        argNode.setOwner(1); // built by the calling task, on the calling task's own thread
+        try {
+            renderOwnedTarget.rendezvousCallFunc(interpreter, new BrsString("doThing"), [argNode]);
+            expect(argNode.getOwner()).toBe(1); // unchanged -- calling task keeps its own local node
+        } finally {
+            sgRoot.getCurrentThreadTask = originalGetCurrentThreadTask;
+        }
+    });
+});
+
+describe("callFunc reply routing (Task.sendThreadUpdate)", () => {
+    let originalPostMessage;
+    beforeEach(() => {
+        originalPostMessage = global.postMessage;
+        global.postMessage = vi.fn();
+    });
+    afterEach(() => {
+        global.postMessage = originalPostMessage;
+    });
+
+    function taskSideTask() {
+        const task = new Task([], "MyTask");
+        task.threadId = 1;
+        task.active = true;
+        task.inThread = true; // simulate running on the task worker
+        return task;
+    }
+
+    test("a direct-flagged reply is written to the callBack buffer, bypassing the broker", () => {
+        const task = taskSideTask();
+        const backing = new SharedObject();
+        task.setCallBackBuffer(backing.getBuffer());
+
+        const reply = {
+            id: 0,
+            action: "resp",
+            type: "task",
+            address: task.address,
+            key: "callFunc",
+            value: 42,
+            requestId: 5,
+            direct: true,
+        };
+        task.sendThreadUpdate(reply);
+
+        expect(global.postMessage).not.toHaveBeenCalled();
+        expect(backing.getVersion()).toBe(1);
+        const got = backing.load(true);
+        expect(got.direct).toBe(true);
+        expect(got.value).toBe(42);
+    });
+
+    test("a direct-flagged request (not a reply) is not diverted -- still goes through the broker", () => {
+        const task = taskSideTask();
+        const backing = new SharedObject();
+        task.setCallBackBuffer(backing.getBuffer());
+
+        const request = {
+            id: 0,
+            action: "call",
+            type: "task",
+            address: task.address,
+            key: "callFunc",
+            value: null,
+            requestId: 5,
+            direct: true,
+        };
+        task.sendThreadUpdate(request);
+
+        expect(global.postMessage).toHaveBeenCalledTimes(1);
+        expect(backing.getVersion()).toBe(0);
+    });
+
+    test("a non-direct reply still goes through the broker (existing behavior unchanged)", () => {
+        const task = taskSideTask();
+        const backing = new SharedObject();
+        task.setCallBackBuffer(backing.getBuffer());
+
+        const reply = { id: 0, action: "resp", type: "node", address: "ABC123", key: "count", value: 3, requestId: 5 };
+        task.sendThreadUpdate(reply);
+
+        expect(global.postMessage).toHaveBeenCalledTimes(1);
+        expect(backing.getVersion()).toBe(0);
+    });
+});
+
+describe("requestTaskMethodCall", () => {
+    test("resolves with the deserialized value when a reply is waiting on the callBack buffer", () => {
+        const task = new Task([], "MyTask");
+        task.active = true;
+        task.threadId = 1;
+        task.fanoutBuffer = new SharedObject(); // render-side write handle (TS-private; runtime-accessible)
+        const backing = new SharedObject();
+        task.setCallBackBuffer(backing.getBuffer());
+        task.syncRequestId = 9; // pin the id the call will use, so the pre-stored reply matches it
+
+        backing.store({
+            id: 1,
+            action: "resp",
+            type: task.syncType,
+            address: task.address,
+            key: "callFunc",
+            value: 42,
+            requestId: 9,
+            direct: true,
+        });
+
+        const result = task.requestTaskMethodCall(task.syncType, task.address, "callFunc", { args: [] });
+
+        expect(result.getValue()).toBe(42);
+        // The request itself must travel via the fan-out queue, not the broker/directBuffer.
+        expect(task.fanoutQueue).toHaveLength(1);
+        expect(task.fanoutQueue[0]).toMatchObject({ action: "call", key: "callFunc", direct: true, requestId: 9 });
+    });
+
+    test("throws a rendezvous timeout error when nothing replies", () => {
+        const task = new Task([], "MyTask");
+        task.active = true;
+        task.threadId = 1;
+        task.fanoutBuffer = new SharedObject();
+        task.setCallBackBuffer(new SharedObject().getBuffer());
+
+        expect(() => task.requestTaskMethodCall(task.syncType, task.address, "callFunc", { args: [] }, 50)).toThrow(
+            /Rendezvous timeout/
+        );
+    });
+
+    test("returns undefined when the buffers required for the direct path are missing", () => {
+        const task = new Task([], "MyTask");
+        task.active = true;
+        task.threadId = 1;
+        // No fanoutBuffer/callBackBuffer set up.
+        expect(task.requestTaskMethodCall(task.syncType, task.address, "callFunc", { args: [] })).toBeUndefined();
+    });
+});
+
+/**
+ * A render-initiated callFunc dispatch onto a Task runs against a snapshot of that Task's `m`,
+ * frozen once right after init() completes — see .claude/docs/threading-and-rendezvous.md.
+ */
+describe("captureCallFuncSnapshot / callFuncM", () => {
+    test("captures top/global, Nodes (live reference), and primitives as-is", () => {
+        const task = new Task([], "MyTask");
+        task.funcNames.add("dummy"); // captureCallFuncSnapshot no-ops for a Task with no callable functions
+        const child = new Node([], "Group");
+        task.m.set(new BrsString("top"), task, true);
+        task.m.set(new BrsString("global"), task, true); // stand-in; identity is all that matters here
+        task.m.set(new BrsString("childNode"), child, true);
+        task.m.set(new BrsString("count"), new Int32(7), true);
+        task.m.set(new BrsString("label"), new BrsString("hi"), true);
+        task.m.set(new BrsString("flag"), BrsBoolean.True, true);
+
+        task.captureCallFuncSnapshot();
+
+        expect(task.callFuncM.get(new BrsString("top"))).toBe(task);
+        expect(task.callFuncM.get(new BrsString("global"))).toBe(task);
+        expect(task.callFuncM.get(new BrsString("childNode"))).toBe(child); // same live reference
+        expect(task.callFuncM.get(new BrsString("count")).getValue()).toBe(7);
+        expect(task.callFuncM.get(new BrsString("label")).getValue()).toBe("hi");
+        expect(task.callFuncM.get(new BrsString("flag")).toBoolean()).toBe(true);
+    });
+
+    test("captures a live-handle value (roMessagePort) as invalid, not a fresh reconstruction", () => {
+        const task = new Task([], "MyTask");
+        task.funcNames.add("dummy"); // captureCallFuncSnapshot no-ops for a Task with no callable functions
+        task.m.set(new BrsString("port"), new RoMessagePort(), true);
+
+        task.captureCallFuncSnapshot();
+
+        const captured = task.callFuncM.get(new BrsString("port"));
+        expect(captured).toBeInstanceOf(BrsInvalid);
+    });
+
+    test("captures a function value as-is, matching PrimitiveKinds", () => {
+        const task = new Task([], "MyTask");
+        task.funcNames.add("dummy"); // captureCallFuncSnapshot no-ops for a Task with no callable functions
+        const helper = new Callable("helper");
+        task.m.set(new BrsString("helper"), helper, true);
+
+        task.captureCallFuncSnapshot();
+
+        expect(task.callFuncM.get(new BrsString("helper"))).toBe(helper);
+    });
+
+    test("a member added after the snapshot is never visible, not even as a key", () => {
+        const task = new Task([], "MyTask");
+        task.funcNames.add("dummy"); // captureCallFuncSnapshot no-ops for a Task with no callable functions
+        task.m.set(new BrsString("beforeSnapshot"), new Int32(1), true);
+        task.captureCallFuncSnapshot();
+        task.m.set(new BrsString("afterSnapshot"), new Int32(2), true);
+
+        expect(task.callFuncM.get(new BrsString("beforeSnapshot")).getValue()).toBe(1);
+        expect(task.callFuncM.elements.has("aftersnapshot")).toBe(false);
+    });
+
+    test("mutating a captured Node through the live m is reflected in the snapshot too (same object)", () => {
+        const task = new Task([], "MyTask");
+        task.funcNames.add("dummy"); // captureCallFuncSnapshot no-ops for a Task with no callable functions
+        const child = new Node([{ name: new BrsString("value"), value: new Int32(0) }], "Group");
+        task.m.set(new BrsString("childNode"), child, true);
+        task.captureCallFuncSnapshot();
+
+        child.setValue("value", new Int32(1000), false); // task's own code, not via callFunc
+
+        expect(task.callFuncM.get(new BrsString("childNode")).getValue("value").getValue()).toBe(1000);
+    });
+});
+
+describe("consumeCallFuncMOverride", () => {
+    test("returns undefined, and does nothing, when no snapshot dispatch is pending", () => {
+        const task = new Task([], "MyTask");
+        task.captureCallFuncSnapshot();
+        expect(task.consumeCallFuncMOverride()).toBeUndefined();
+    });
+
+    test("is one-shot: returns callFuncM once, then undefined again", () => {
+        const task = new Task([], "MyTask");
+        task.funcNames.add("dummy"); // captureCallFuncSnapshot no-ops for a Task with no callable
+        // functions -- populate it so callFuncM is a real snapshot, not undefined, below.
+        task.captureCallFuncSnapshot();
+        task.useCallFuncSnapshot = true;
+
+        expect(task.callFuncM).toBeDefined();
+        expect(task.consumeCallFuncMOverride()).toBe(task.callFuncM);
+        expect(task.consumeCallFuncMOverride()).toBeUndefined();
+    });
+
+    test("a plain Node never has anything to override (always live m)", () => {
+        const node = new Node([], "Group");
+        expect(node.consumeCallFuncMOverride()).toBeUndefined();
+    });
+});

--- a/test/simulator/probes/callfunc-task-thread-probe/README.md
+++ b/test/simulator/probes/callfunc-task-thread-probe/README.md
@@ -1,0 +1,255 @@
+# CallFunc / Task-Thread Probe
+
+A sideloadable Roku app that exercises `callFunc` from the render (main) thread onto a `Task`
+node's own worker thread, phase by phase.
+
+It exists to check the assumptions behind a brs-engine fix for a reported crash: a New Relic SDK
+`Task` component crashed when the app's main thread called `callFunc` into it
+(`m.nrAgent.callFunc("nrSetHarvestTime", seconds)`), because the engine ran the call locally
+against the render thread's own incomplete copy of the node instead of rendezvousing to the
+Task's actual worker thread — dropping a script-scope reference the Task had populated after
+activation. The fix (and this probe) is scoped to exactly that call shape: `callFunc` issued from
+the render thread's own, non-nested execution context onto a `Task` node.
+
+> **Finding (device-confirmed, see Results below) — RESOLVED, the engine fix has been revised to
+> match:** the render→Task rendezvous itself is real on device — a `callFunc`'d function runs on a
+> distinct thread whose backtrace chains back through the render thread's own call site. But that
+> dispatch context's `m` is **not** the Task's live, currently-mutating `m` — it's a snapshot taken
+> once, right after `init()` completes, and never refreshed. `basic-init` (a node created in
+> `init()`) and `basic-post` (a node created in `runTask()`, after `init()` returns) both report the
+> *identical* 4-key `m` (`global, initnode, port, top`): `initNode` is there and fully functional (a
+> live, working node reference — mutating it through the call really works, confirmed further by
+> `refresh`), while `postLaunchNode` never appears at all, not even as a key. `port` (also created
+> in `init()`) is present as a key but comes back `invalid` — a live `roMessagePort` apparently
+> can't survive whatever snapshot/reconstruction mechanism this is. `latefield` confirmed the
+> boundary is specific to *raw* `m` members — a declared field (`m.top.xxx`) set after `init()`
+> works regardless of timing, since it crosses via the unrelated, already-correct field-sync path.
+>
+> `refresh` was the deciding test: the task mutated `m.initNode` **itself**, outside any `callFunc`,
+> and a subsequent `callFunc`'d read saw that mutation (`1000 + 1 = 1001`) — proving the
+> callFunc-visible node reference is the task's genuine live object, not a disconnected one-time
+> copy. That turns "snapshot" into a precise, implementable rule: **freeze the *key set* of `m` at
+> `init()`-completion; for a captured key, keep pointing at the exact same live value forever
+> after.** The engine now implements exactly this (`Task.captureCallFuncSnapshot`/`callFuncM` in
+> `nodes/Task.ts`, captured once from `execTask` right after `init()` runs) — see
+> `.claude/docs/threading-and-rendezvous.md` for the full implementation writeup, and
+> `test/cli/resources/task-render-callfunc-app` for the CLI regression covering both the positive
+> (`init()`-time state) and negative (post-`init()` state, now correctly invisible) cases.
+
+### Why `basic-init`'s readback isn't what it looks like
+
+An earlier version of this probe claimed `basic-init`'s readback of `m.initNode.value` (via
+`checkInitNode`/`taskSideInitValue`) *proved* the render→Task rendezvous is genuine — reasoning
+that a buggy engine, running `callFunc` locally against render's own copy of the Task node, could
+never make the *Task's own later code* see the mutation. That reasoning has a hole: a Task's
+`init()` runs synchronously on render too, at construction time, so render's own copy also has an
+`m.initNode` — succeeding by accident is possible, and a real user (running this probe both against
+a known-buggy engine build and against the fix, with the two producing indistinguishable output)
+caught exactly that.
+
+Digging in by instrumenting the engine directly (temporary `fs.appendFileSync` markers inside
+`rendezvousCall`/`callFunction`/the `callFunc` dispatch itself, bypassing `console.log`/`print` —
+both can be silently dropped depending on which thread emits them) confirmed the mutation really
+does run locally on render in the buggy build (0 ms elapsed, `this` bound to render's own node,
+never touching the Task thread at all) — and yet `checkInitNode`'s readback still reported `MATCH`.
+The reason: the Task thread's own `m.initNode` key, by the time `checkInitNode` runs, resolves
+through a **live, address-based cross-thread proxy back to render's own node** — a separate,
+pre-existing mechanism unrelated to this callFunc fix (any Node value present in a Task's initial
+cross-thread `m` seed can end up proxied like this). Reading `.value` through that proxy genuinely
+rendezvouses back to render and fetches render's *current* value — so the readback agrees with
+render's local mutation regardless of whether the `callFunc` call itself ever rendezvoused. A
+Node-field readback proves nothing either way.
+
+Swapping the readback to a **raw `m` primitive** (`m.rawInitMirror`, mutated by `touchInitNode`
+alongside `m.initNode.value`) doesn't fix this either, just for the opposite reason: per the device-
+confirmed snapshot model above, a raw primitive touched from inside a `callFunc`'d function is
+captured *by value* into the snapshot and never propagates back to the Task's real `m` — so this
+readback shows `MISMATCH` even against a **correctly fixed** engine. Verified directly: both the
+known-buggy build and the fixed build report `taskSideInitValue=0` against `expected=42`.
+
+The signal that actually survived direct verification against both builds is **timing**:
+`elapsed-ms` on the `callFunc` call itself. A call that never leaves render's own thread returns
+near-instantly (0 ms, confirmed repeatedly against the known-buggy build); a call that genuinely
+rendezvouses to the Task's own thread cannot return before that round trip completes (~520 ms,
+confirmed repeatedly against the fixed build — the gap is roughly two orders of magnitude, not
+sensitive to normal timing noise). `runBasicInit()` now prints an explicit verdict from this
+(`elapsed-ms >= 20` → "genuine cross-thread round trip occurred"; otherwise "SUSPICIOUS ... likely
+ran locally on render"). The two readback fields (`taskSideInitValue`/`taskSideNodeValue`) are kept
+in the probe as documented diagnostics — each one's handler explains why it isn't a pass/fail
+signal — not because they're useless, but because their *expected* result (mismatch for the
+primitive, match-regardless-of-correctness for the Node field) is itself worth knowing.
+
+Questions this probe answers against real hardware:
+
+1. Does `callFunc` from the render thread onto a `Task` **rendezvous to the Task's own worker
+   thread** (the render thread blocks until the Task services it), or does the device simply run
+   it wherever it was called from? — **Confirmed: yes, it rendezvouses** (see finding above).
+2. Is a script-scope `m` value visible and mutable from a function invoked this way, and does it
+   matter **when** that value was created — in `init()` (`basic-init`) vs. after activation, inside
+   the task function itself (`basic-post`, the exact shape that crashed brs-engine)? —
+   **Confirmed: yes, it matters, and the boundary is exactly `init()` completion** (see finding
+   above). `basic-post` crashes on device (dot-operator on invalid); `basic-init` succeeds.
+3. Can a callFunc'd function read **render-owned data** (`m.global`) *during* the call — i.e. does
+   a nested, reverse-direction rendezvous back into the render thread work while the render thread
+   is itself blocked waiting for the callFunc to return? Or does this deadlock / time out?
+4. Does the render thread genuinely **block** (UI frozen, no timers firing) for the duration of the
+   call, confirming a true synchronous rendezvous rather than something async/fire-and-forget?
+5. Is there a practical bound on how long the render thread will wait for a Task's `callFunc` to
+   return, and what happens if that bound is exceeded (error, crash, or does it just hang)?
+6. If the Task is executing a **tight, non-yielding loop** (no `wait()`/message-port poll), does
+   the render thread's `callFunc` block until the Task reaches a `wait()` safepoint, or can the
+   device service it earlier, mid-statement?
+7. If a render-side observer of one of the Task's **own** fields calls `callFunc` back into that
+   same Task — synchronously, before that field-set's own acknowledgment has been sent — does the
+   device **deadlock**, or does it resolve safely? (brs-engine's own render-side wait loop
+   deadlocks here; this is a fixture-design hazard the shipped fix doesn't need to handle, since
+   the real crash never calls `callFunc` from a field observer of its own target — but it's worth
+   knowing whether a device handles a pattern our engine currently can't.)
+8. Do all common return-value types (integer, string, boolean, `invalid`, `roAssociativeArray`, an
+   `roSGNode`) round-trip correctly through the callFunc return value?
+9. Is the node reference a callFunc dispatch resolves for an `init()`-time key genuinely **live and
+   shared** with the Task's own copy, or a one-time, disconnected reconstruction? (`refresh`: the
+   Task mutates `m.initNode` itself, outside any callFunc, then a callFunc'd read checks whether it
+   sees that mutation.)
+10. Is the `init()`-completion boundary specific to **raw script-scope `m` members**, or does it
+    also apply to a **declared field** (`m.top.xxx`, synced via the field-sync path that already
+    works today) set after `init()`? (`latefield`.)
+
+## Build and sideload
+
+```bash
+./pack.sh                                       # produces callfunc-task-thread-probe.zip
+```
+
+Sideload `callfunc-task-thread-probe.zip` at `http://$ROKU/` with the device in developer mode.
+
+## Phases
+
+Each phase is triggered by one remote key. Wait for a phase's `### PHASE <name> END` print before
+starting the next one — `busy` in particular keeps the Task spinning for a full 3 s, and firing
+another phase into the middle of that spin queues it behind `busy`'s own callFunc rather than
+testing what you think it's testing (harmless, just confusing output — this happened during this
+probe's own engine verification and was purely a rapid-fire testing artifact, not a probe bug).
+
+Watch the on-screen **heartbeat** counter (updates every ~100 ms via a render-thread `Timer`) — it
+visibly stalls whenever the render thread is blocked inside a `callFunc` wait, which is the most
+direct evidence for question 4 without needing a stopwatch.
+
+| Key | Phase | What it does | Answers |
+| --- | --- | --- | --- |
+| `rewind` | `basic-init` | `callFunc` touches `m.initNode`, a node the Task created **in `init()`**, before activation | 1, 2 |
+| `up` | `basic-post` | `callFunc` touches `m.postLaunchNode`, a node the Task created **after** `control=RUN`, inside the task function itself — the exact shape that crashed brs-engine | 1, 2 |
+| `down` | `nested` | Called function reads `m.global.probeValue` (render-owned) *during* the call | 3, 4 |
+| `left` | `types` | `callFunc` round-trips 6 return types: `int`, `str`, `bool`, `invalid`, `roAssociativeArray`, `roSGNode` | 8 |
+| `right` | `busy` | Task starts a 3 s non-yielding spin (`startSpin`); 500 ms later, render calls `callFunc` into it | 4, 5, 6 |
+| `fastforward` | `refresh` | Task bumps its own `m.initNode.value` by 1000, outside any callFunc; 300 ms later, render calls `callFunc` to read it | 9 |
+| `replay` | `latefield` | `callFunc` touches `m.top.lateValue`, a **declared field** the Task set (to 100) *after* `init()` returned — same timing as `basic-post`'s node, but via the field-sync path instead of a raw `m` member | 10 |
+| `options` | *(arms)* | Arms the self-deadlock phase — prints/shows a warning, does nothing else | — |
+| `OK` | `selfdeadlock` | **Only after `options`.** Sets the Task's own `trigger` field; the Task writes its own `pulse` field in response; render's `onPulse` observer (firing *inside* that field-set's processing) calls `callFunc` straight back into the same Task | 4, 5, 7 |
+| `back` | — | exits the app | |
+
+`basic-post` is expected to break into the Micro Debugger on a device in developer mode
+(`'Dot' Operator attempted with invalid BrightScript Component...`) — that break *is* the finding
+for question 2, not a probe bug. While suspended, `thread <n>` + `print m` on both the Task's own
+thread and the crashed one is worth capturing (see Results row 2b) before `cont`-ing past it or
+letting it crash and reloading the channel to continue with the remaining phases.
+
+### ⚠️ Before running `selfdeadlock`
+
+This phase deliberately reproduces a shape brs-engine's own implementation deadlocks on. If the
+device behaves the same way, **the app may become permanently unresponsive** (heartbeat frozen,
+remote presses ignored) — the render thread would be genuinely blocked, not just busy, so there is
+no in-app escape. Run every other phase first. If it hangs:
+
+- Wait at least the length of whatever timeout you'd expect a rendezvous to have (there is no
+  documented one — this is itself part of what question 5 is trying to pin down).
+- If it never recovers, remove/relaunch the channel from the Developer Application Installer
+  (`http://$ROKU/plugin_install`) or power-cycle the device.
+- Record whatever happened (froze forever / recovered after N seconds / device or channel crashed
+  with an error) in the Results table below — that outcome **is** the finding.
+
+## Reading the output
+
+Connect to the debug console to see the `print` lines:
+
+```bash
+telnet $ROKU 8085
+```
+
+Every phase brackets itself with `### PHASE <name> BEGIN` / `END`, and each `TASK ...` line comes
+from the Task thread while each `RENDER`/`PHASE` line (outside `TASK`) comes from the render
+thread — interleaving (or its absence) is itself informative for question 1: if `basic-post` never
+prints a `TASK touchPostLaunchNode` line at all, the call did not reach the Task thread.
+`basic-init`, `basic-post`, and `latefield` each print an `ENTER m-keys=...` line
+(`m.keys().join(",")`) **before** touching the node/field under test, so even a crash still tells
+you exactly which keys `m` held in that dispatch context — that list is the direct answer to
+question 2, no debugger session required. `refresh` prints the Task's own before/after values for
+its direct mutation (`TASK bumpInitNode before=... after=...`) so you can compare against what the
+subsequent `callFunc`'d read reports.
+
+## Engine baseline
+
+The same probe runs against brs-engine via the CLI:
+
+```bash
+npm run build:cli   # from the repo root, if not already built
+brs-cli -z --log probe-cli.log callfunc-task-thread-probe.zip
+```
+
+Terminal keys map directly to remote keys for `up`/`down`/`left`/`right`/`OK` (Enter)/`back`
+(Escape)/`rewind` (Page Up)/`fastforward` (Page Down)/`replay` (Backspace) — see
+`src/cli/keyboard.ts`. The CLI's terminal keyboard has no mapping for `options`; use the ECP server
+instead to reach the `arm`/`selfdeadlock` pair. Note the engine's own ECP key name for that button
+is `info`, not `options` (it still delivers `key = "options"` to `onKeyEvent`, matching the real
+device's documented vocabulary — only the ECP endpoint name differs):
+
+```bash
+brs-cli --ecp -z --log probe-cli.log callfunc-task-thread-probe.zip &
+curl -d '' http://localhost:8060/keypress/info      # arm (engine ECP name for the Options button)
+curl -d '' http://localhost:8060/keypress/select     # fire selfdeadlock
+```
+
+Already verified against brs-engine as of this writing, **after** the fix was revised to implement
+the `callFuncM` snapshot (`Task.captureCallFuncSnapshot`/`buildCallFuncSnapshot` in `nodes/Task.ts`
+— see `.claude/docs/threading-and-rendezvous.md`): `basic-init` now reports the same 4-key
+`m` (`global, initnode, port, top`) the device does, and `basic-post` now **crashes identically to
+the device** — `'Dot' Operator attempted with invalid BrightScript Component...` on
+`m.postLaunchNode.value = ...`, `m-keys` at entry showing only the same 4 keys, `postLaunchNode`
+absent. That crash is the *correct*, device-matching result, not a regression — see the Finding
+above. `refresh` returns `1001` (the task's own `+1000` bump, then the call's own `+1`), matching
+the device exactly and for the same reason: a captured Node reference stays genuinely live.
+`latefield` still succeeds regardless of timing (`107`), matching the device — the field-sync path
+this goes through was never part of this fix and was never expected to change. `nested` and `types`
+are unaffected by any of this (unchanged from before). `busy` still shows the engine servicing
+`callFunc` **mid-spin** (`spinRunning=true`), which real hardware may or may not match — see
+question 6; its diagnostic fields moved into a small Node (`m.spinState`) created in `init()`
+specifically so this callFunc'd read stays meaningful post-fix — a *raw* `m` member holding a
+primitive is captured into the snapshot **by value**, so it would otherwise always read back
+whatever it held at `init()`-time, never a live, currently-updating count. `selfdeadlock` still
+reproduces the engine's own known deadlock and cleanly times out after `sgRoot.rendezvousTimeout`
+(~10 s), throwing `ExecutionTimeout` on the render thread rather than hanging forever — that
+remains the one phase where engine and device are *expected* to potentially disagree.
+
+## Results
+
+Fill in as you go. "Device" = real Roku hardware; "Engine" = brs-engine via the CLI baseline above.
+
+| # | Question | Device | Engine |
+| --- | --- | --- | --- |
+| 1 | `basic-post`: does `TASK touchPostLaunchNode` print at all (call reached the Task thread)? | Yes | Yes (prints `ENTER`, then crashes on the next line — see row 2) |
+| 1b | Backtrace on a crash chains through the render thread's own call site (`onkeyevent`→`runbasicpost`→`touchpostlaunchnode`), confirming a real rendezvous, not a fire-and-forget dispatch? | Yes | Yes — `#1 touchPostLaunchNode ... #0 runTask` (engine backtraces don't currently include the render-side frames, but the crash itself is on the Task's own thread, at the right line) |
+| 2 | `basic-post`: returned value reflects the Task's own live `m.postLaunchNode` (not stale/missing)? | **Crashes** — `'Dot' Operator attempted with invalid BrightScript Component...` on `m.postLaunchNode.value = ...` | **Crashes identically** (post-fix) — same error, same line shape, on `m.postLaunchNode.value = ...` |
+| 2a | `basic-post` `ENTER m-keys=` — what keys does `m` actually hold in the callFunc dispatch context? | `global, initnode, port, top` (4 keys — confirmed twice: debugger `count:4`/`print m`, and the `ENTER` print) | `global, initnode, port, top` (4 keys — matches the device exactly, post-fix) |
+| 2b | `basic-init`: does `TASK touchInitNode` succeed, and does its `ENTER m-keys=` match `basic-post`'s? Confirms (or refutes) "only init()-time `m` state survives" as the exact rule. | **Confirmed.** Succeeds, result=42; `ENTER m-keys=global,initnode,port,top` — identical to `basic-post`'s. `initNode` (created in `init()`) is a live, working node reference; `postLaunchNode` (created in `runTask()`, after `init()` returns) never appears at all, not even as a key. **Rule: real Roku snapshots the Task's `m` once, right after `init()` completes, and every `callFunc` dispatch runs against that frozen snapshot — never the task's live, currently-mutating `m`.** | Succeeds, result=42; `m-keys=global,initnode,port,top` — matches the device exactly (post-fix; the engine now implements this same rule via `Task.callFuncM`) |
+| 2c | `basic-init`: **timing verdict** — is `elapsed-ms` consistent with a genuine cross-thread round trip, or near-instant (never left render's thread)? This is the discriminator that actually distinguishes the fix from the original bug — see "Why `basic-init`'s readback isn't what it looks like" above. | Not yet run against real hardware — worth capturing `elapsed-ms` here to compare against the engine's ~520 ms. | Verified directly against both builds: **known-buggy engine (via `git stash` of the fix) → `elapsed-ms=0`, "SUSPICIOUS"**; **fixed engine → `elapsed-ms≈520-527`, "genuine cross-thread round trip occurred"** — repeatable across multiple runs each. |
+| 3 | `nested`: does `TASK readGlobalDuringCall ... END` print (no deadlock reading m.global mid-call)? | | Yes |
+| 4 | `nested`: `nested-read-ms` and outer `elapsed-ms` values | | nested-read-ms=105, elapsed-ms=106 |
+| 5 | `basic`/`nested`: heartbeat counter visibly stalls during the call? | | Not checked (no display in CLI run) |
+| 6 | `types`: any kind whose round-tripped `type()`/value differs from what was sent? | | None — all 6 matched |
+| 7 | `busy`: does `duringSpin` print `spinRunning= true` (serviced mid-spin) or `false` (serviced only after)? | | `true` — serviced mid-spin |
+| 8 | `busy`: `spinCounter` value and outer `elapsed-ms` — does it match "waited for the spin to reach a safepoint"? | | spinCounter=15, elapsed-ms≈420 (post-fix, using `m.spinState`'s Node fields — see the engine-baseline note on why a raw `m` primitive can't show live progress here) — serviced mid-spin, not at a `wait()` boundary |
+| 9 | `selfdeadlock`: does the app hang? For how long, if it ever recovers? | | Does not hang — throws `ExecutionTimeout` after ~10s (`sgRoot.rendezvousTimeout`) |
+| 10 | `selfdeadlock`: if it does NOT hang, what does `respondToPulse` return, and what's `elapsed-ms`? | | N/A — times out instead of returning |
+| 11 | Any error/crash output on the device console during any phase | `basic-post` breaks into the Micro Debugger as expected (see row 2); nothing else tested yet | `basic-post` throws the matching error (post-fix); otherwise only the expected timeout error during `selfdeadlock` |
+| 12 | `refresh`: does the callFunc'd `touchInitNode` read reflect the task's own `+1000` bump (live/shared reference), or does it see the pre-bump value (disconnected reconstruction)? | **Confirmed live/shared.** `TASK bumpInitNode before=0 after=1000`, then `touchInitNode addend=1 value now=1001` — the callFunc dispatch sees the task's own direct mutation. The callFunc-visible node reference is the task's genuine live object, not a one-time copy. | Reflects it — result=1001, same reasoning, now for the correct reason: the engine's `callFuncM` snapshot also keeps a live reference for a captured key (post-fix; matches device). |
+| 13 | `latefield`: does `callFunc` see `m.top.lateValue` (a declared field set after `init()`) despite the `init()`-boundary rule found in row 2b, confirming that rule is specific to raw `m` members? | **Confirmed.** `touchLateField` succeeds, `lateValue=100` then `value now=107` — the `init()`-boundary rule is specific to raw script-scope `m` members; a declared field crosses regardless of timing. | Succeeds — result=107 (post-fix: the engine's field-sync path was never touched by this fix, so this was never expected to change). |

--- a/test/simulator/probes/callfunc-task-thread-probe/components/ProbeScene.brs
+++ b/test/simulator/probes/callfunc-task-thread-probe/components/ProbeScene.brs
@@ -1,0 +1,257 @@
+' Render-thread side of the probe. Maps remote keys to phases, calls callFunc on the Task from a
+' clean, non-nested context in each (matching how the reported crash actually calls it), times each
+' call, and drives a heartbeat counter so a stalled render thread is visible on screen.
+
+sub init()
+    m.top.backgroundURI = ""
+    m.top.backgroundColor = "0x101020FF"
+
+    ' Render-owned global value the task reads *during* a callFunc it is blocked on (PHASE nested).
+    m.global.addFields({ probeValue: "render-owned-global-value" })
+
+    m.keymap = m.top.findNode("keymap")
+    m.status = m.top.findNode("status")
+    m.heartbeat = m.top.findNode("heartbeat")
+    m.heartbeatTimer = m.top.findNode("heartbeatTimer")
+    m.spinCallTimer = m.top.findNode("spinCallTimer")
+    m.refreshCallTimer = m.top.findNode("refreshCallTimer")
+
+    m.beatCount = 0
+    m.armed = false
+    m.taskReady = false
+
+    m.heartbeatTimer.observeField("fire", "onHeartbeat")
+    m.heartbeatTimer.control = "start"
+    m.spinCallTimer.observeField("fire", "onSpinCallTimer")
+    m.refreshCallTimer.observeField("fire", "onRefreshCallTimer")
+
+    m.keymap.text = [
+        "CALLFUNC / TASK-THREAD PROBE"
+        ""
+        "REWIND    basic-init    callFunc touches an init()-time task node"
+        "UP        basic-post    callFunc touches a post-launch task node"
+        "DOWN      nested        callFunc reads m.global mid-call (no deadlock?)"
+        "LEFT      types         callFunc return-value round trip, several types"
+        "RIGHT     busy          callFunc while the task spins without wait()"
+        "FFWD      refresh       task bumps its own initNode, then callFunc reads it"
+        "REPLAY    latefield     callFunc touches a field set after init() (m.top.xxx)"
+        "OPTIONS   arm           arms the self-deadlock phase (see README first!)"
+        "OK        selfdeadlock  fires it (task->render->task nested callFunc)"
+        "BACK                    exit"
+        ""
+        "Watch the heartbeat counter below -- it stalls whenever the render"
+        "thread is blocked waiting on a callFunc to return."
+    ].join(chr(10))
+
+    m.task = CreateObject("roSGNode", "ProbeTask")
+    m.task.observeField("ready", "onTaskReady")
+    m.task.observeField("pulse", "onPulse")
+    m.task.observeField("taskSideInitValue", "onTaskSideInitValue")
+    m.task.observeField("taskSideNodeValue", "onTaskSideNodeValue")
+    m.task.control = "run"
+
+    m.top.setFocus(true)
+end sub
+
+sub onHeartbeat(event as object)
+    m.beatCount = m.beatCount + 1
+    m.heartbeat.text = "heartbeat: " + m.beatCount.toStr()
+    m.heartbeatTimer.control = "start"
+end sub
+
+sub onTaskReady(event as object)
+    if event.getData()
+        m.taskReady = true
+        print "### RENDER task ready"
+        m.status.text = "task ready -- press a phase key"
+    end if
+end sub
+
+function onKeyEvent(key as string, press as boolean) as boolean
+    if not press then return false
+
+    ' Every phase below assumes the Task has already created m.postLaunchNode and reached its own
+    ' wait() loop -- a callFunc that lands before then would just find an incomplete `m`, which is
+    ' a race in this probe's own startup timing, not something the questions above are about.
+    if not m.taskReady and key <> "back"
+        print "### RENDER task not ready yet -- wait for '### RENDER task ready' before pressing phase keys"
+        return true
+    end if
+
+    if key = "rewind"
+        runBasicInit()
+    else if key = "up"
+        runBasicPost()
+    else if key = "down"
+        runNested()
+    else if key = "left"
+        runTypes()
+    else if key = "right"
+        print "### PHASE busy BEGIN: starting a 3s non-yielding task spin, calling in 500ms"
+        m.status.text = "busy: starting 3s task spin, calling in 500ms..."
+        m.task.startSpin = true
+        m.spinCallTimer.control = "start"
+    else if key = "fastforward"
+        print "### PHASE refresh BEGIN: task will bump its own initNode by 1000, calling in 300ms"
+        m.status.text = "refresh: bumping task-side initNode, calling in 300ms..."
+        m.task.bumpInitNode = true
+        m.refreshCallTimer.control = "start"
+    else if key = "replay"
+        runLateField()
+    else if key = "options"
+        m.armed = true
+        print "### RENDER selfdeadlock ARMED -- press OK to fire. Risk of app freeze -- see README."
+        m.status.text = "selfdeadlock ARMED -- press OK to fire (may freeze the app, see README)"
+    else if key = "OK"
+        if m.armed
+            m.armed = false
+            print "### PHASE selfdeadlock BEGIN: setting m.task.trigger"
+            m.status.text = "selfdeadlock firing..."
+            m.task.trigger = true
+        else
+            print "### RENDER press OPTIONS first to arm the self-deadlock phase"
+        end if
+    else
+        return false
+    end if
+
+    return true
+end function
+
+' --- PHASE basic-init --------------------------------------------------------------------------
+' The callFunc succeeding is NOT proof it ran on the task's own thread against the task's own real
+' node -- see the header comment in ProbeTask.brs for the full story (an earlier version of this
+' probe used a Node-field readback as "proof" and it produced a false MATCH against the
+' known-buggy engine, discovered by instrumenting the engine directly). The trustworthy,
+' BrightScript-observable signal that survived that investigation is TIMING: a callFunc that
+' silently ran locally on render (the original bug) returns near-instantly, because no thread
+' boundary was ever actually crossed; a callFunc that genuinely rendezvouses to the task's own
+' thread cannot return before that round trip completes. Verified directly against both a
+' known-buggy build and the fixed build: consistently ~0ms local vs. several hundred ms genuine
+' round trip. The two readback fields below (taskSideInitValue/taskSideNodeValue) are kept as
+' documented diagnostics, NOT as the pass/fail signal -- see their handlers for why each one is
+' unreliable on its own.
+sub runBasicInit()
+    print "### PHASE basic-init BEGIN"
+    span = CreateObject("roTimespan")
+    span.mark()
+    result = m.task.callFunc("touchInitNode", 42)
+    elapsed = span.totalMilliseconds()
+    verdict = "SUSPICIOUS -- near-instant return; callFunc likely ran locally on render, never reaching the task's own thread"
+    if elapsed >= 20 then verdict = "genuine cross-thread round trip occurred"
+    print "### PHASE basic-init END result="; result; " elapsed-ms="; elapsed; " -> "; verdict
+    m.status.text = "basic-init: result=" + result.toStr() + " elapsed=" + elapsed.toStr() + "ms (" + verdict + ")"
+
+    m.expectedInitValue = result
+    print "### PHASE basic-init requesting task-side readback (diagnostics, not the verdict -- see comments)"
+    m.task.checkInitNode = true
+end sub
+
+' DIAGNOSTIC, NOT the verdict: reports the task's own read of m.rawInitMirror (a raw `m` primitive,
+' set by touchInitNode alongside its Node-field mutation). Per real-device testing done earlier for
+' this fix, a raw script-scope primitive touched from inside a callFunc'd function is captured BY
+' VALUE into a snapshot of the task's `m` and never propagates back to the task's own regular `m` --
+' this is the SAME lack of cross-thread visibility for raw `m` members that caused the original
+' crash this fix addresses, and it is device-accurate, so expect MISMATCH here even against a
+' correctly fixed engine. It is included to document that nuance, not as a pass/fail check.
+sub onTaskSideInitValue(event as object)
+    taskSide = event.getData()
+    print "### DIAGNOSTIC m.rawInitMirror task-side readback="; taskSide; " expected="; m.expectedInitValue; " (MISMATCH here is expected even when callFunc genuinely rendezvoused -- see comment above)"
+end sub
+
+' DIAGNOSTIC, NOT the verdict: reports the task's own read of m.initNode.value (a Node field). This
+' one is UNRELIABLE as a rendezvous proof: instrumenting the engine directly showed the task's own
+' "m.initNode" key resolves through a live, address-based cross-thread proxy back to render's own
+' copy of the node -- a separate, pre-existing mechanism unrelated to this callFunc fix (it exists
+' even in the known-buggy build). That proxy makes this readback agree with render's local mutation
+' regardless of whether callFunc itself ever rendezvoused, so a MATCH here proves nothing either way.
+sub onTaskSideNodeValue(event as object)
+    taskSide = event.getData()
+    print "### DIAGNOSTIC m.initNode.value task-side readback="; taskSide; " expected="; m.expectedInitValue; " (not a reliable signal -- see comment above)"
+end sub
+
+' --- PHASE basic-post ----------------------------------------------------------------------------
+sub runBasicPost()
+    print "### PHASE basic-post BEGIN"
+    span = CreateObject("roTimespan")
+    span.mark()
+    result = m.task.callFunc("touchPostLaunchNode", 42)
+    elapsed = span.totalMilliseconds()
+    print "### PHASE basic-post END result="; result; " elapsed-ms="; elapsed
+    m.status.text = "basic-post: result=" + result.toStr() + " elapsed=" + elapsed.toStr() + "ms"
+end sub
+
+' --- PHASE refresh (deferred call) --------------------------------------------------------------
+' Checks whether the node reference a callFunc dispatch resolves is genuinely live/shared with the
+' task's own copy: the task just mutated m.initNode ITSELF (bumpInitNode, above), so if this read
+' does NOT reflect that +1000 bump, the callFunc-visible reference is a disconnected reconstruction
+' rather than the same live object.
+sub onRefreshCallTimer(event as object)
+    print "### PHASE refresh calling touchInitNode after the task's own bump"
+    span = CreateObject("roTimespan")
+    span.mark()
+    result = m.task.callFunc("touchInitNode", 1)
+    elapsed = span.totalMilliseconds()
+    print "### PHASE refresh END result="; result; " elapsed-ms="; elapsed
+    m.status.text = "refresh: result=" + result.toStr() + " elapsed=" + elapsed.toStr() + "ms"
+end sub
+
+' --- PHASE latefield -----------------------------------------------------------------------------
+sub runLateField()
+    print "### PHASE latefield BEGIN"
+    span = CreateObject("roTimespan")
+    span.mark()
+    result = m.task.callFunc("touchLateField", 7)
+    elapsed = span.totalMilliseconds()
+    print "### PHASE latefield END result="; result; " elapsed-ms="; elapsed
+    m.status.text = "latefield: result=" + result.toStr() + " elapsed=" + elapsed.toStr() + "ms"
+end sub
+
+' --- PHASE nested ------------------------------------------------------------------------------
+sub runNested()
+    print "### PHASE nested BEGIN"
+    span = CreateObject("roTimespan")
+    span.mark()
+    result = m.task.callFunc("readGlobalDuringCall", "probe1")
+    elapsed = span.totalMilliseconds()
+    print "### PHASE nested END result="; result; " elapsed-ms="; elapsed
+    m.status.text = "nested: result=" + result + " elapsed=" + elapsed.toStr() + "ms"
+end sub
+
+' --- PHASE types -------------------------------------------------------------------------------
+sub runTypes()
+    print "### PHASE types BEGIN"
+    kinds = ["int", "str", "bool", "invalid", "aa", "node"]
+    for each kind in kinds
+        result = m.task.callFunc("returnTypesCheck", kind)
+        print "### PHASE types kind="; kind; " type="; type(result); " value="; result
+    end for
+    print "### PHASE types END"
+    m.status.text = "types: see console for per-kind results"
+end sub
+
+' --- PHASE busy (deferred call) -----------------------------------------------------------------
+sub onSpinCallTimer(event as object)
+    print "### PHASE busy calling duringSpin while the task should still be spinning"
+    span = CreateObject("roTimespan")
+    span.mark()
+    result = m.task.callFunc("duringSpin", "probe")
+    elapsed = span.totalMilliseconds()
+    print "### PHASE busy END result="; result; " elapsed-ms="; elapsed
+    m.status.text = "busy: result=" + result + " elapsed=" + elapsed.toStr() + "ms"
+end sub
+
+' --- PHASE selfdeadlock --------------------------------------------------------------------------
+' Fires synchronously from inside the observer of the task's OWN field ("pulse"), i.e. while the
+' render thread is still inside the code path that applies that field's set and is not yet free to
+' send its acknowledgment back to the task. See the README before running this phase.
+sub onPulse(event as object)
+    print "### RENDER onPulse pulse="; event.getData()
+    print "### PHASE selfdeadlock calling back into the task NOW (deadlock risk)"
+    span = CreateObject("roTimespan")
+    span.mark()
+    result = m.task.callFunc("respondToPulse", "fromPulse")
+    elapsed = span.totalMilliseconds()
+    print "### PHASE selfdeadlock END result="; result; " elapsed-ms="; elapsed
+    m.status.text = "selfdeadlock: result=" + result + " elapsed=" + elapsed.toStr() + "ms"
+end sub

--- a/test/simulator/probes/callfunc-task-thread-probe/components/ProbeScene.xml
+++ b/test/simulator/probes/callfunc-task-thread-probe/components/ProbeScene.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="ProbeScene" extends="Scene">
+    <children>
+        <Label
+            id="keymap"
+            translation="[80,60]"
+            width="1760"
+            height="900"
+            wrap="true" />
+        <Label
+            id="status"
+            translation="[80,960]"
+            width="1760" />
+        <!-- A visible, continuously-incrementing counter driven by the render thread's own message
+             loop. It stalls whenever the render thread is blocked waiting on a callFunc: the
+             most direct, no-instrumentation-needed evidence of whether a phase actually blocks. -->
+        <Label
+            id="heartbeat"
+            translation="[80,1000]"
+            width="1760" />
+        <Timer
+            id="heartbeatTimer"
+            duration="0.1"
+            repeat="false" />
+        <!-- Deferred so PHASE busy's callFunc lands *after* the task's spin has actually started
+             (control=RUN/field sync round trips before runBusySpin() begins), not before it. -->
+        <Timer
+            id="spinCallTimer"
+            duration="0.5"
+            repeat="false" />
+        <!-- Deferred so PHASE refresh's callFunc lands *after* the task's own bumpInitNode mutation
+             has actually applied, not before it. -->
+        <Timer
+            id="refreshCallTimer"
+            duration="0.3"
+            repeat="false" />
+    </children>
+    <script type="text/brightscript" uri="pkg:/components/ProbeScene.brs" />
+</component>

--- a/test/simulator/probes/callfunc-task-thread-probe/components/ProbeTask.brs
+++ b/test/simulator/probes/callfunc-task-thread-probe/components/ProbeTask.brs
@@ -1,0 +1,222 @@
+' Task-thread side of the callFunc/Task-thread probe.
+'
+' Verifies the assumptions behind brs-engine's render->Task callFunc rendezvous fix (see
+' .claude/docs/threading-and-rendezvous.md):
+'   - callFunc issued by the render thread actually runs ON this task's own thread, not locally
+'     against a stale render-side reconstruction. This is NOT provable by basic-init succeeding
+'     alone: a Task's init() runs synchronously on render too, at construction time, so a buggy
+'     engine that never rendezvouses at all and just falls back to running callFunc locally,
+'     against render's OWN copy of this node, would *also* find m.initNode there (it was render's
+'     own init() that created it) and "succeed" by accident, against the wrong node entirely.
+'
+'     The readback proof must use a RAW PRIMITIVE (m.rawInitMirror), NOT a Node field
+'     (m.initNode.value) -- an earlier version of this probe used the Node field and produced a
+'     false MATCH against the known-buggy engine (confirmed by instrumenting the engine directly:
+'     the callFunc genuinely ran locally on render's own m.initNode, never touching the task's
+'     thread at all). The false MATCH happened because a Node *reference* that has been part of a
+'     Task's initial cross-thread `m` seed can resolve through a live address-based proxy back to
+'     the render-owned original -- so a plain "does the task's own read see the mutation" check
+'     over a Node field can pass by rendezvousing on the READ, independent of whether the callFunc
+'     itself ever rendezvoused. A raw primitive has no such proxy: a script-scope `m` primitive
+'     never crosses threads by any path (that lack of cross-thread visibility for raw `m` members
+'     is the exact root cause of the original crash this fix addresses), so the ONLY way the task's
+'     own read of m.rawInitMirror can see render's write is if the callFunc call that set it
+'     actually executed on the task's own thread, against the task's own real `m`. m.top.checkInitNode
+'     asks THIS TASK's OWN code (not another callFunc, not render) to read m.rawInitMirror back and
+'     report it. Only a genuine rendezvous, executing the callFunc against the task's real thread,
+'     makes the task's own readback agree with what the callFunc call just set.
+'   - whether a script-scope `m` value's visibility from a callFunc-invoked function depends on
+'     WHEN it was created: in init() (PHASE basic-init) vs. after activation, inside runTask()
+'     itself (PHASE basic-post) -- this distinction is the exact condition that used to crash
+'     brs-engine (a New Relic SDK Task calling m.nrHarvestTimerEvents.duration = x from a callFunc
+'     issued by the main thread). A first device run showed PHASE basic-post crashing with `m`
+'     missing every key runTask() added after init() returned (postLaunchNode/spinCounter/
+'     spinRunning gone entirely; only global/port/top survived, and port itself came back
+'     `invalid`, presumably because a live roMessagePort can't cross whatever boundary this is) --
+'     basic-init exists to confirm whether init()-time state is exactly the boundary.
+'   - whether a callFunc-visible node reference is genuinely LIVE/shared with the task's own copy,
+'     or a disconnected reconstruction: PHASE refresh has the task mutate m.initNode ITSELF (not
+'     via callFunc) and then reports whether a callFunc'd read sees that mutation.
+'   - whether a DECLARED field (m.top.xxx, synced via the already-proven-working field-sync path)
+'     set after init() is visible via callFunc regardless of timing, unlike a raw m member (PHASE
+'     latefield) -- if so, the init()-boundary restriction is specific to raw script-scope `m`,
+'     not to "state added after activation" in general.
+'   - a nested, reverse-direction access to render-owned data (m.global) works *during* a call the
+'     render thread is blocked waiting on, without deadlocking (PHASE nested).
+'   - callFunc on a task that is mid-way through a tight, non-yielding loop (PHASE busy).
+'   - a render-side observer of this task's OWN field calling back into this task before that
+'     field-set's own acknowledgment has been sent (PHASE selfdeadlock) -- brs-engine's own
+'     render-side wait loop deadlocks here. That is a fixture-design hazard, not something the
+'     shipped fix needs to handle: the real crash always calls callFunc from the main loop's own
+'     context, never from a field observer of the target task. This phase finds out whether a real
+'     device deadlocks too, or resolves it safely -- see the README before running it.
+
+sub init()
+    m.top.functionName = "runTask"
+    ' Registered here (render thread, before launch) so wait()'s port keeps servicing this thread
+    ' while runTask() loops -- see .claude/docs/threading-and-rendezvous.md.
+    m.port = CreateObject("roMessagePort")
+    m.top.observeField("control", m.port)
+    m.top.observeField("trigger", m.port)
+    m.top.observeField("startSpin", m.port)
+    m.top.observeField("bumpInitNode", m.port)
+    m.top.observeField("checkInitNode", m.port)
+
+    ' Created HERE, before activation -- the comparison point for PHASE basic-post's node, which
+    ' is created after activation instead (in runTask()). See PHASE basic-init/basic-post below.
+    m.initNode = CreateObject("roSGNode", "Node")
+    m.initNode.addField("value", "integer", false)
+    m.initNode.value = 0
+    ' Raw-primitive mirror of m.initNode.value, updated alongside it by touchInitNode -- see the
+    ' header comment above for why the readback proof (checkInitNode, below) must use this instead
+    ' of m.initNode.value.
+    m.rawInitMirror = 0
+
+    ' Also created here (not in runBusySpin()/runTask()) so PHASE busy's callFunc'd read stays
+    ' meaningful post-fix: a *raw* `m` member holding a primitive is captured into callFuncM by
+    ' value at snapshot time and never updates again, even if the member itself existed at
+    ' snapshot time -- only a Node's OWN field mutations (not reassigning the `m` key) stay live.
+    ' Using a small Node here, mutated via setValue in runBusySpin() rather than by reassigning
+    ' m.spinCounter/m.spinRunning directly, keeps the reads live for the same reason m.initNode's
+    ' `value` field does.
+    m.spinState = CreateObject("roSGNode", "Node")
+    m.spinState.addField("counter", "integer", false)
+    m.spinState.addField("running", "boolean", false)
+end sub
+
+sub runTask()
+    ' Created AFTER activation, on this thread -- the exact condition that used to crash a
+    ' render-initiated callFunc in brs-engine (a script-scope node reference that never
+    ' independently crossed to the render thread before).
+    m.postLaunchNode = CreateObject("roSGNode", "Node")
+    m.postLaunchNode.addField("value", "integer", false)
+    m.postLaunchNode.value = 0
+    ' A DECLARED field set after init(), same timing as postLaunchNode above but going through the
+    ' field-sync path (m.top.xxx) instead of a raw m member -- comparison point for PHASE latefield.
+    m.top.lateValue = 100
+    m.top.ready = true
+
+    print "### TASK ready"
+    while true
+        msg = wait(0, m.port)
+        if type(msg) = "roSGNodeEvent"
+            field = msg.getField()
+            if field = "trigger" and msg.getData()
+                ' A task-owned field write, observed by the render thread's onPulse -- the setup
+                ' for PHASE selfdeadlock.
+                m.top.pulse = m.top.pulse + 1
+            else if field = "startSpin" and msg.getData()
+                runBusySpin(3000)
+            else if field = "bumpInitNode" and msg.getData()
+                ' The task mutating m.initNode ITSELF (not via callFunc) -- PHASE refresh checks
+                ' whether a later callFunc'd read reflects this, i.e. whether the reference a
+                ' callFunc dispatch resolves is genuinely live/shared, not a one-time disconnected
+                ' reconstruction.
+                before = m.initNode.value
+                m.initNode.value = m.initNode.value + 1000
+                print "### TASK bumpInitNode before="; before; " after="; m.initNode.value
+            else if field = "checkInitNode" and msg.getData()
+                ' The definitive rendezvous proof: reads m.rawInitMirror (a raw primitive, immune
+                ' to the Node cross-thread proxy that made an earlier version of this check pass
+                ' even against the known-buggy engine -- see the header comment) from THIS task's
+                ' own code (not a callFunc, not render) and reports it back. A callFunc that
+                ' actually ran on this thread, against this thread's real `m`, made a mutation THIS
+                ' read will see. A callFunc that silently ran locally on render's own disconnected
+                ' copy of this node (the original bug) never touched this thread's `m` at all --
+                ' this read would report whatever this thread's own code last set, not render's call.
+                print "### TASK checkInitNode reports m.rawInitMirror="; m.rawInitMirror; " m.initNode.value="; m.initNode.value
+                m.top.taskSideInitValue = m.rawInitMirror
+                m.top.taskSideNodeValue = m.initNode.value
+            end if
+        end if
+    end while
+end sub
+
+' --- PHASE basic-init: touch the init()-time node from a callFunc issued by the render thread's
+' own top-level loop. Comparison point for PHASE basic-post below. --------------------------------
+function touchInitNode(addend as integer) as integer
+    print "### TASK touchInitNode ENTER m-keys="; m.keys().join(",")
+    m.initNode.value = m.initNode.value + addend
+    m.rawInitMirror = m.initNode.value
+    print "### TASK touchInitNode addend="; addend; " value now="; m.initNode.value
+    return m.initNode.value
+end function
+
+' --- PHASE basic-post: touch the post-launch node from a callFunc issued by the render thread's
+' own top-level loop (matches the reported crash's call shape). -----------------------------------
+function touchPostLaunchNode(addend as integer) as integer
+    print "### TASK touchPostLaunchNode ENTER m-keys="; m.keys().join(",")
+    m.postLaunchNode.value = m.postLaunchNode.value + addend
+    print "### TASK touchPostLaunchNode addend="; addend; " value now="; m.postLaunchNode.value
+    return m.postLaunchNode.value
+end function
+
+' --- PHASE latefield: touch a DECLARED field (m.top.lateValue) that was set after init(), the same
+' timing as m.postLaunchNode but through the field-sync path instead of a raw m member. -----------
+function touchLateField(addend as integer) as integer
+    print "### TASK touchLateField ENTER m-keys="; m.keys().join(",") ; " lateValue="; m.top.lateValue
+    m.top.lateValue = m.top.lateValue + addend
+    print "### TASK touchLateField addend="; addend; " value now="; m.top.lateValue
+    return m.top.lateValue
+end function
+
+' --- PHASE nested: read m.global (render-owned) *during* a call the render thread is blocked
+' waiting on. If this deadlocks/times out, the render thread never sees the "END" print at all. ---
+function readGlobalDuringCall(tag as string) as string
+    span = CreateObject("roTimespan")
+    span.mark()
+    value = m.global.probeValue ' nested rendezvous back into render, mid-callFunc
+    elapsed = span.totalMilliseconds()
+    print "### TASK readGlobalDuringCall tag="; tag; " m.global.probeValue="; value; " nested-read-ms="; elapsed
+    return tag + ":" + value + ":" + elapsed.toStr() + "ms"
+end function
+
+' --- PHASE types: round-trips several BrightScript types through the callFunc return value. -------
+function returnTypesCheck(which as string) as dynamic
+    print "### TASK returnTypesCheck which="; which
+    if which = "int" then return 12345
+    if which = "str" then return "hello-from-task"
+    if which = "bool" then return true
+    if which = "invalid" then return invalid
+    if which = "aa"
+        return { a: 1, b: "two", c: [3, 4, 5] }
+    end if
+    if which = "node"
+        n = CreateObject("roSGNode", "Node")
+        n.addField("marker", "string", false)
+        n.marker = "node-from-task"
+        return n
+    end if
+    return "unknown:" + which
+end function
+
+' --- PHASE busy: called while this task is executing a tight, non-yielding loop (no wait()). Does
+' the render thread's callFunc block until the loop ends and this thread reaches wait() again, or
+' can the runtime service it earlier, mid-statement? m.spinState's fields (mutated via setValue in
+' runBusySpin(), not by reassigning an m member -- see the init() comment) let the render thread
+' see how far along the spin was when this actually got serviced. ----------------------------------
+function duringSpin(tag as string) as string
+    print "### TASK duringSpin CALLED tag="; tag; " spinCounter="; m.spinState.counter; " spinRunning="; m.spinState.running
+    return tag + ":spinCounter=" + m.spinState.counter.toStr() + ":spinRunning=" + m.spinState.running.toStr()
+end function
+
+sub runBusySpin(ms as integer)
+    m.spinState.running = true
+    m.spinState.counter = 0
+    span = CreateObject("roTimespan")
+    span.mark()
+    while span.totalMilliseconds() < ms
+        m.spinState.counter = m.spinState.counter + 1
+    end while
+    m.spinState.running = false
+    print "### TASK runBusySpin END spinCounter="; m.spinState.counter
+end sub
+
+' --- PHASE selfdeadlock: the render thread calls this back into this SAME task from inside the
+' observer of "pulse" (this task's own field), synchronously, before the render thread has finished
+' processing the field-set that fired that observer (and so before this task's pending ack for it
+' has been sent). See the README before running this phase. ----------------------------------------
+function respondToPulse(tag as string) as string
+    print "### TASK respondToPulse tag="; tag; " pulse="; m.top.pulse
+    return tag + ":pulse=" + m.top.pulse.toStr()
+end function

--- a/test/simulator/probes/callfunc-task-thread-probe/components/ProbeTask.xml
+++ b/test/simulator/probes/callfunc-task-thread-probe/components/ProbeTask.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="ProbeTask" extends="Task">
+    <interface>
+        <field id="ready" type="boolean" value="false" />
+        <field id="trigger" type="boolean" value="false" alwaysNotify="true" />
+        <field id="startSpin" type="boolean" value="false" alwaysNotify="true" />
+        <field id="pulse" type="integer" value="0" alwaysNotify="true" />
+        <field id="bumpInitNode" type="boolean" value="false" alwaysNotify="true" />
+        <field id="checkInitNode" type="boolean" value="false" alwaysNotify="true" />
+        <field id="taskSideInitValue" type="integer" value="0" alwaysNotify="true" />
+        <field id="taskSideNodeValue" type="integer" value="0" alwaysNotify="true" />
+        <field id="lateValue" type="integer" value="0" />
+        <function name="touchInitNode" />
+        <function name="touchPostLaunchNode" />
+        <function name="touchLateField" />
+        <function name="readGlobalDuringCall" />
+        <function name="returnTypesCheck" />
+        <function name="duringSpin" />
+        <function name="respondToPulse" />
+    </interface>
+    <script type="text/brightscript" uri="pkg:/components/ProbeTask.brs" />
+</component>

--- a/test/simulator/probes/callfunc-task-thread-probe/manifest
+++ b/test/simulator/probes/callfunc-task-thread-probe/manifest
@@ -1,0 +1,4 @@
+title=CallFunc Task Thread Probe
+major_version=1
+minor_version=0
+build_version=0

--- a/test/simulator/probes/callfunc-task-thread-probe/pack.sh
+++ b/test/simulator/probes/callfunc-task-thread-probe/pack.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Packs the probe into a sideloadable zip.
+set -euo pipefail
+cd "$(dirname "$0")"
+rm -f callfunc-task-thread-probe.zip
+zip -r callfunc-task-thread-probe.zip manifest source components -x '*.DS_Store'
+echo "Created $(pwd)/callfunc-task-thread-probe.zip"

--- a/test/simulator/probes/callfunc-task-thread-probe/source/main.brs
+++ b/test/simulator/probes/callfunc-task-thread-probe/source/main.brs
@@ -1,0 +1,19 @@
+sub Main()
+    screen = CreateObject("roSGScreen")
+    m.port = CreateObject("roMessagePort")
+    screen.setMessagePort(m.port)
+    screen.CreateScene("ProbeScene")
+    screen.show()
+
+    print "### PROBE app started"
+
+    while true
+        msg = wait(0, m.port)
+        if type(msg) = "roSGScreenEvent"
+            if msg.isScreenClosed()
+                print "### PROBE app exiting"
+                return
+            end if
+        end if
+    end while
+end sub

--- a/test/simulator/probes/node-owned-by-task-callfunc-probe/README.md
+++ b/test/simulator/probes/node-owned-by-task-callfunc-probe/README.md
@@ -1,6 +1,6 @@
 # Node-Owned-By-Task CallFunc Probe
 
-A sideloadable Roku app built to verify the *actual* New Relic Roku SDK crash shape against real
+A sideloadable Roku app built to verify the _actual_ New Relic Roku SDK crash shape against real
 hardware, using the SDK's real source structure (fetched from
 [newrelic/video-agent-roku](https://github.com/newrelic/video-agent-roku), tag `3.2.4`,
 `components/NewRelicAgent/{NRAgent.xml,.brs}`) rather than a guessed one.
@@ -10,18 +10,18 @@ hardware, using the SDK's real source structure (fetched from
 The engine's render→Task `callFunc` rendezvous fix (see
 [`.claude/docs/threading-and-rendezvous.md`](../../../.claude/docs/threading-and-rendezvous.md) and
 the sibling probe `test/simulator/probes/callfunc-task-thread-probe/`) was built against an
-*assumed* repro shape: the app directly `CreateObject()`s a `Task` on render and calls `callFunc`
+_assumed_ repro shape: the app directly `CreateObject()`s a `Task` on render and calls `callFunc`
 on it. That assumption turned out to be **wrong** for the actual reported crash. Reading the real
 SDK source revealed:
 
-- `com.newrelic.NRAgent` (`NRAgent.xml`) is a **plain `Node`**, not a `Task`. `nrSetHarvestTime` is
-  one of its `callFunc`-invoked wrapped functions.
-- `m.nrHarvestTimerEvents = m.top.findNode("nrHarvestTimerEvents")` (the reference that crashed:
-  `m.nrHarvestTimerEvents.duration = seconds`) happens inside `NewRelicInit()` — itself a
-  `callFunc`-invoked function — **not** `init()`.
-- The actual `Task` in the SDK is a *child* of `NRAgent` (`com.newrelic.NRTask`, id `NRTaskEvents`),
-  used for background HTTP posting — `bgTaskEvents` in the crash report's dropped-reference warning
-  is this child.
+-   `com.newrelic.NRAgent` (`NRAgent.xml`) is a **plain `Node`**, not a `Task`. `nrSetHarvestTime` is
+    one of its `callFunc`-invoked wrapped functions.
+-   `m.nrHarvestTimerEvents = m.top.findNode("nrHarvestTimerEvents")` (the reference that crashed:
+    `m.nrHarvestTimerEvents.duration = seconds`) happens inside `NewRelicInit()` — itself a
+    `callFunc`-invoked function — **not** `init()`.
+-   The actual `Task` in the SDK is a _child_ of `NRAgent` (`com.newrelic.NRTask`, id `NRTaskEvents`),
+    used for background HTTP posting — `bgTaskEvents` in the crash report's dropped-reference warning
+    is this child.
 
 None of this matches "render calls `callFunc` on a `Task` it directly constructed." The plausible
 real shape — and the one this probe builds — is: **the app's own business-logic `Task` constructs
@@ -41,22 +41,22 @@ verified this end to end:
    a crash that real hardware does not, confirming this was a genuine engine bug rather than
    device-accurate behavior an app would need to work around.
 2. **Found two distinct root causes, both in `Task.ts`/`Node.ts`, both fixed:**
-   - `Task.syncRemoteField` unconditionally re-owned any `Node` value synced from a task thread to
-     render to render (`fieldValue.setOwner(0)`) — correct for a task reporting/handing off a
-     result through its **own** interface field (`m.top.xxx = someNode`, the receiver needs to run
-     `callFunc` against its own copy), but wrong for a task merely **publishing a reference** to a
-     node it keeps using itself (`m.global.someHandle = someNode`). The node's true owning thread
-     never changes in that case, so re-owning it broke every later same-thread access on the
-     owning task — confirmed via same-thread isolation (STEP1/STEP2 below) and, decisively, absent
-     on the real device. Fixed by gating the re-own on `address === this.address` (the task setting
-     *its own* field) rather than firing unconditionally.
-   - `Node.callFuncThread()`'s base unconditionally returned `undefined`, so even with the above
-     fixed, a render-initiated `callFunc` onto a correctly task-owned plain `Node` (not itself a
-     `Task`) never rendezvoused: `shouldRendezvous()`/`rendezvousCall()` only ever fire for a
-     **task**-initiated caller (`sgRoot.inTaskThread()`), never a render-initiated one, regardless
-     of the target's owner. Fixed by generalizing the base case to check `this.owner` against
-     `sgRoot.getThreadTask()` and route through the same `rendezvousCallFunc`/
-     `requestTaskMethodCall` machinery the Task-specific fix already used.
+    - `Task.syncRemoteField` unconditionally re-owned any `Node` value synced from a task thread to
+      render to render (`fieldValue.setOwner(0)`) — correct for a task reporting/handing off a
+      result through its **own** interface field (`m.top.xxx = someNode`, the receiver needs to run
+      `callFunc` against its own copy), but wrong for a task merely **publishing a reference** to a
+      node it keeps using itself (`m.global.someHandle = someNode`). The node's true owning thread
+      never changes in that case, so re-owning it broke every later same-thread access on the
+      owning task — confirmed via same-thread isolation (STEP1/STEP2 below) and, decisively, absent
+      on the real device. Fixed by gating the re-own on `address === this.address` (the task setting
+      _its own_ field) rather than firing unconditionally.
+    - `Node.callFuncThread()`'s base unconditionally returned `undefined`, so even with the above
+      fixed, a render-initiated `callFunc` onto a correctly task-owned plain `Node` (not itself a
+      `Task`) never rendezvoused: `shouldRendezvous()`/`rendezvousCall()` only ever fire for a
+      **task**-initiated caller (`sgRoot.inTaskThread()`), never a render-initiated one, regardless
+      of the target's owner. Fixed by generalizing the base case to check `this.owner` against
+      `sgRoot.getThreadTask()` and route through the same `rendezvousCallFunc`/
+      `requestTaskMethodCall` machinery the Task-specific fix already used.
 3. **Re-verified the full repro end to end with both fixes applied**: STEP1/STEP2 isolation both
    succeed, and the actual `render-call` phase (the reported bug shape) returns `42` with no crash.
    `npm test` (full suite, 221 files / 2929 tests) and `npm run lint` both pass.
@@ -81,12 +81,12 @@ Sideload at `http://$ROKU/` with the device in developer mode.
 (`telnet $ROKU 8085`) or the on-screen status label. With the fix applied, both succeed
 (`STEP2 (post-publish) result=22 -> OK`) and the app proceeds to the phase keys:
 
-| Key | Phase | What it does |
-| --- | --- | --- |
-| `rewind` | `task-call` | `AppTask` calls `callFunc` on its own local agent again, later, from its normal wait loop |
-| `up` | `foreign-call` | A *different* Task (`ForeignTask`) reads the agent back from `m.global` and calls `callFunc` on it — Task-to-Node, not render-to-Node. **Still fails** (a separate, pre-existing, explicitly out-of-scope limitation: `callFunc` from one Task onto a node/Task it doesn't itself own or manage — see `.claude/docs/threading-and-rendezvous.md`'s scope notes). This kills the app (uncaught Task error), so run `down` before `up` if you want to see `render-call` succeed in the same session. |
-| `down` | `render-call` | **The actual reported bug shape**: render reads the agent back from `m.global` and calls `callFunc` on it, matching `m.nrAgent.callFunc("nrSetHarvestTime", seconds)` from the main thread exactly. With the fix: succeeds, `result=42`. |
-| `back` | — | exit |
+| Key      | Phase          | What it does                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| -------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rewind` | `task-call`    | `AppTask` calls `callFunc` on its own local agent again, later, from its normal wait loop                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| `up`     | `foreign-call` | A _different_ Task (`ForeignTask`) reads the agent back from `m.global` and calls `callFunc` on it — Task-to-Node, not render-to-Node. **Fails, but not for a `callFunc` reason**: `m.global.nrAgent` itself reads back `Invalid` on `ForeignTask`, before `callFunc` is ever reached — see [issue #1219](https://github.com/lvcabral/brs-engine/issues/1219), a confirmed simulator bug (not device-accurate — real Roku succeeds here) where a field another task adds to `m.global` _after_ this task's own launch is invisible to it. Unrelated to this PR's own fix (reproduces identically on `master` in isolation, no `callFunc`/ownership involved). This kills the app (uncaught Task error), so run `down` before `up` if you want to see `render-call` succeed in the same session. |
+| `down`   | `render-call`  | **The actual reported bug shape**: render reads the agent back from `m.global` and calls `callFunc` on it, matching `m.nrAgent.callFunc("nrSetHarvestTime", seconds)` from the main thread exactly. With the fix: succeeds, `result=42`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `back`   | —              | exit                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 
 The `[sg] Dropped script-scope reference "harvesttimer"` warning still fires once, harmlessly —
 it's render's own, unused reconstructed copy of the agent failing to resolve a reference it never
@@ -95,9 +95,11 @@ indicate a problem.
 
 ## Real-device verification
 
-Confirmed on a real Roku: **the probe runs without crashing**, both the STEP1/STEP2 isolation and
-(with the engine fix applied) the `render-call` phase. The engine crashed identically to the
-original New Relic report before the fix; it no longer does, and now matches the device.
+Confirmed on a real Roku, pressing `rewind`, `down`, then `up` in sequence: STEP1/STEP2 isolation,
+`task-call`, and `render-call` (the actual reported bug shape, this PR's fix) all succeed with no
+crash — matching the simulator with the fix applied. `foreign-call` also succeeds on device; the
+simulator still crashes there, but for the separate, unrelated `m.global` bug tracked in
+[issue #1219](https://github.com/lvcabral/brs-engine/issues/1219), not this PR's fix.
 
 ## Engine baseline
 

--- a/test/simulator/probes/node-owned-by-task-callfunc-probe/README.md
+++ b/test/simulator/probes/node-owned-by-task-callfunc-probe/README.md
@@ -1,0 +1,113 @@
+# Node-Owned-By-Task CallFunc Probe
+
+A sideloadable Roku app built to verify the *actual* New Relic Roku SDK crash shape against real
+hardware, using the SDK's real source structure (fetched from
+[newrelic/video-agent-roku](https://github.com/newrelic/video-agent-roku), tag `3.2.4`,
+`components/NewRelicAgent/{NRAgent.xml,.brs}`) rather than a guessed one.
+
+## Why this probe exists
+
+The engine's render→Task `callFunc` rendezvous fix (see
+[`.claude/docs/threading-and-rendezvous.md`](../../../.claude/docs/threading-and-rendezvous.md) and
+the sibling probe `test/simulator/probes/callfunc-task-thread-probe/`) was built against an
+*assumed* repro shape: the app directly `CreateObject()`s a `Task` on render and calls `callFunc`
+on it. That assumption turned out to be **wrong** for the actual reported crash. Reading the real
+SDK source revealed:
+
+- `com.newrelic.NRAgent` (`NRAgent.xml`) is a **plain `Node`**, not a `Task`. `nrSetHarvestTime` is
+  one of its `callFunc`-invoked wrapped functions.
+- `m.nrHarvestTimerEvents = m.top.findNode("nrHarvestTimerEvents")` (the reference that crashed:
+  `m.nrHarvestTimerEvents.duration = seconds`) happens inside `NewRelicInit()` — itself a
+  `callFunc`-invoked function — **not** `init()`.
+- The actual `Task` in the SDK is a *child* of `NRAgent` (`com.newrelic.NRTask`, id `NRTaskEvents`),
+  used for background HTTP posting — `bgTaskEvents` in the crash report's dropped-reference warning
+  is this child.
+
+None of this matches "render calls `callFunc` on a `Task` it directly constructed." The plausible
+real shape — and the one this probe builds — is: **the app's own business-logic `Task` constructs
+the agent `Node` on its own worker thread (not render) and publishes it as a `m.global` singleton**
+(`CreateObject` once, store a handle other components/threads reach it through — a very common SDK
+integration pattern), and **render** later reads that handle back out of `m.global` and calls
+`callFunc` on it.
+
+## Status: RESOLVED — root cause found, fixed, and confirmed against a real Roku device
+
+Built the exact shape (`AppTask`, a `Task`, constructs `AgentNode`, a plain `Node` with a child
+`<Timer id="harvestTimer">` found via `findNode()`, then publishes it via `m.global.nrAgent`) and
+verified this end to end:
+
+1. **Reproduced the exact crash on `master`, and confirmed on a real Roku device it does NOT
+   crash there** — this was the deciding piece of evidence: the engine's `master` build produced
+   a crash that real hardware does not, confirming this was a genuine engine bug rather than
+   device-accurate behavior an app would need to work around.
+2. **Found two distinct root causes, both in `Task.ts`/`Node.ts`, both fixed:**
+   - `Task.syncRemoteField` unconditionally re-owned any `Node` value synced from a task thread to
+     render to render (`fieldValue.setOwner(0)`) — correct for a task reporting/handing off a
+     result through its **own** interface field (`m.top.xxx = someNode`, the receiver needs to run
+     `callFunc` against its own copy), but wrong for a task merely **publishing a reference** to a
+     node it keeps using itself (`m.global.someHandle = someNode`). The node's true owning thread
+     never changes in that case, so re-owning it broke every later same-thread access on the
+     owning task — confirmed via same-thread isolation (STEP1/STEP2 below) and, decisively, absent
+     on the real device. Fixed by gating the re-own on `address === this.address` (the task setting
+     *its own* field) rather than firing unconditionally.
+   - `Node.callFuncThread()`'s base unconditionally returned `undefined`, so even with the above
+     fixed, a render-initiated `callFunc` onto a correctly task-owned plain `Node` (not itself a
+     `Task`) never rendezvoused: `shouldRendezvous()`/`rendezvousCall()` only ever fire for a
+     **task**-initiated caller (`sgRoot.inTaskThread()`), never a render-initiated one, regardless
+     of the target's owner. Fixed by generalizing the base case to check `this.owner` against
+     `sgRoot.getThreadTask()` and route through the same `rendezvousCallFunc`/
+     `requestTaskMethodCall` machinery the Task-specific fix already used.
+3. **Re-verified the full repro end to end with both fixes applied**: STEP1/STEP2 isolation both
+   succeed, and the actual `render-call` phase (the reported bug shape) returns `42` with no crash.
+   `npm test` (full suite, 221 files / 2929 tests) and `npm run lint` both pass.
+
+See `test/cli/resources/task-owned-node-callfunc-app/` and the corresponding
+`it("Rendezvouses a callFunc from the render thread onto a plain Node owned by a Task thread", ...)`
+in `test/cli/cli-scenegraph.test.js` for the automated CLI regression — verified with `git
+stash`/rebuild cycles isolating `src/` to fail on `master` and pass with the fix, the same rigor
+applied throughout this investigation.
+
+## Build and sideload
+
+```bash
+./pack.sh                                          # produces node-owned-by-task-callfunc-probe.zip
+```
+
+Sideload at `http://$ROKU/` with the device in developer mode.
+
+## What to expect / how to read it
+
+**STEP1/STEP2 fire automatically at startup, no key press needed.** Watch the debug console
+(`telnet $ROKU 8085`) or the on-screen status label. With the fix applied, both succeed
+(`STEP2 (post-publish) result=22 -> OK`) and the app proceeds to the phase keys:
+
+| Key | Phase | What it does |
+| --- | --- | --- |
+| `rewind` | `task-call` | `AppTask` calls `callFunc` on its own local agent again, later, from its normal wait loop |
+| `up` | `foreign-call` | A *different* Task (`ForeignTask`) reads the agent back from `m.global` and calls `callFunc` on it — Task-to-Node, not render-to-Node. **Still fails** (a separate, pre-existing, explicitly out-of-scope limitation: `callFunc` from one Task onto a node/Task it doesn't itself own or manage — see `.claude/docs/threading-and-rendezvous.md`'s scope notes). This kills the app (uncaught Task error), so run `down` before `up` if you want to see `render-call` succeed in the same session. |
+| `down` | `render-call` | **The actual reported bug shape**: render reads the agent back from `m.global` and calls `callFunc` on it, matching `m.nrAgent.callFunc("nrSetHarvestTime", seconds)` from the main thread exactly. With the fix: succeeds, `result=42`. |
+| `back` | — | exit |
+
+The `[sg] Dropped script-scope reference "harvesttimer"` warning still fires once, harmlessly —
+it's render's own, unused reconstructed copy of the agent failing to resolve a reference it never
+needs, since the fixed dispatch correctly routes to the real, task-owned copy instead. It does not
+indicate a problem.
+
+## Real-device verification
+
+Confirmed on a real Roku: **the probe runs without crashing**, both the STEP1/STEP2 isolation and
+(with the engine fix applied) the `render-call` phase. The engine crashed identically to the
+original New Relic report before the fix; it no longer does, and now matches the device.
+
+## Engine baseline
+
+```bash
+npm run build:cli   # from the repo root, if not already built
+brs-cli --ecp -z --log probe-cli.log node-owned-by-task-callfunc-probe.zip
+```
+
+With the fix (current `src/`): STEP1 succeeds (`11`), STEP2 succeeds (`22`, "OK"), `render-call`
+succeeds (`42`). Reverting `src/` to `master` (`git stash push -- src/`) and rebuilding reproduces
+the original crash exactly: STEP2 throws `Invalid value for left-side of expression` (preceded by
+the `Dropped script-scope reference "harvesttimer"` warning) and terminates the app before
+`render-call` is ever reachable.

--- a/test/simulator/probes/node-owned-by-task-callfunc-probe/components/AgentNode.xml
+++ b/test/simulator/probes/node-owned-by-task-callfunc-probe/components/AgentNode.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Mirrors the real New Relic Roku video-agent SDK's NRAgent.xml structure exactly (fetched from
+    github.com/newrelic/video-agent-roku, tag 3.2.4, components/NewRelicAgent/{NRAgent.xml,.brs}):
+    a plain Node (NOT a Task) with a child Timer, whose reference is captured into a raw
+    script-scope `m` member via findNode() inside a callFunc-invoked "init" wrapper function
+    (NewRelicInit in the real SDK), not inside init() itself. The real crash line
+    (`m.nrHarvestTimerEvents.duration = seconds` in NRAgent.brs's nrSetHarvestTimeEvents, called
+    from nrSetHarvestTime) is reproduced here as setHarvestTime / harvestTimer.
+-->
+<component name="AgentNode" extends="Node">
+    <interface>
+        <function name="agentInit" />
+        <function name="setHarvestTime" />
+    </interface>
+    <children>
+        <Timer id="harvestTimer" repeat="true" />
+    </children>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        ' Real NRAgent.brs's init() is likewise trivial -- it does not touch any children.
+    end sub
+
+    ' Mirrors NewRelicInit(): a callFunc-invoked "constructor" function, not init() itself, that
+    ' captures a child node reference into a raw script-scope `m` member.
+    function agentInit() as Void
+        m.harvestTimer = m.top.findNode("harvestTimer")
+        m.harvestTimer.duration = 60
+        print "AGENT: agentInit m.harvestTimer.duration=" + m.harvestTimer.duration.toStr()
+    end function
+
+    ' Mirrors nrSetHarvestTimeEvents(): `m.nrHarvestTimerEvents.duration = seconds`.
+    function setHarvestTime(seconds as Integer) as Dynamic
+        m.harvestTimer.duration = seconds
+        print "AGENT: setHarvestTime duration=" + m.harvestTimer.duration.toStr()
+        return seconds
+    end function
+    ]]></script>
+</component>

--- a/test/simulator/probes/node-owned-by-task-callfunc-probe/components/AppTask.xml
+++ b/test/simulator/probes/node-owned-by-task-callfunc-probe/components/AppTask.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Mirrors the app's own "main"/business-logic Task creating an SDK's agent Node on its own
+    worker thread (not render) and publishing it as a m.global singleton: a very common SDK
+    integration pattern (CreateObject the agent once, store a handle other components/threads
+    reach it through). AgentNode.owner ends up being THIS task's thread, not render's: the
+    precondition for the render->callFunc bug this probe tests.
+-->
+<component name="AppTask" extends="Task">
+    <interface>
+        <field id="ready" type="boolean" value="false" />
+        <field id="preCallFuncResult" type="integer" value="-1" alwaysNotify="true" />
+        <field id="postPublishResult" type="integer" value="-1" alwaysNotify="true" />
+        <field id="triggerTaskCall" type="boolean" value="false" alwaysNotify="true" />
+        <field id="taskCallResult" type="integer" value="-1" alwaysNotify="true" />
+    </interface>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.top.functionName = "runTask"
+        m.port = CreateObject("roMessagePort")
+        m.top.observeField("control", m.port)
+        m.top.observeField("triggerTaskCall", m.port)
+    end sub
+
+    sub runTask()
+        m.agent = CreateObject("roSGNode", "AgentNode")
+        m.agent.callFunc("agentInit") ' same-thread call: this task calling its own local node.
+
+        ' ISOLATION STEP 1: same-thread callFunc BEFORE the agent is ever published anywhere.
+        ' Always expected to succeed -- pure sanity baseline.
+        m.top.preCallFuncResult = m.agent.callFunc("setHarvestTime", 11)
+        print "APPTASK: STEP1 (pre-publish, same-thread) result=" + m.top.preCallFuncResult.toStr()
+
+        ' Publish into m.global (a render-owned node) -- the SDK-singleton pattern.
+        m.global.addField("nrAgent", "node", false)
+        m.global.nrAgent = m.agent
+
+        ' ISOLATION STEP 2: the SAME same-thread callFunc call, immediately AFTER the publish
+        ' above, before render (or anyone else) has touched the agent at all. If this ALSO fails,
+        ' the corruption is caused by the ownership-changing publish itself, independent of who
+        ' later calls callFunc or from which thread -- not specific to render's dispatch routing.
+        '
+        ' NOTE: try/catch here does NOT protect against the engine bug this isolates. Publishing
+        ' to m.global reassigns this node's owner to render even though it physically stays on
+        ' this task's own thread, so this "same-thread" call now incorrectly rendezvouses OUT to
+        ' render -- and if it crashes, the crashing statement executes on render's own call stack
+        ' while servicing that rendezvous request, entirely outside this task's try block. That
+        ' crash terminates the whole app (uncaught error on a Task thread), so `ready` below and
+        ' every later phase become unreachable whenever this isolation step fails. That is itself
+        ' part of the finding, not a probe bug -- see the README.
+        try
+            m.top.postPublishResult = m.agent.callFunc("setHarvestTime", 22)
+            print "APPTASK: STEP2 (post-publish, same-thread) result=" + m.top.postPublishResult.toStr()
+        catch e
+            print "APPTASK: STEP2 (post-publish, same-thread) THREW: " + e.message
+            m.top.postPublishResult = -1
+        end try
+
+        m.top.ready = true
+        while true
+            msg = wait(0, m.port)
+            if type(msg) = "roSGNodeEvent" and msg.getField() = "triggerTaskCall" and msg.getData()
+                ' PHASE task-call: this task calling callFunc on its OWN local node again, later,
+                ' from inside its normal wait() loop -- same question as STEP2 but at a later,
+                ' more "normal" point in the task's lifecycle.
+                try
+                    result = m.agent.callFunc("setHarvestTime", 99)
+                    print "APPTASK: taskCall result=" + result.toStr()
+                    m.top.taskCallResult = result
+                catch e
+                    print "APPTASK: taskCall THREW: " + e.message
+                    m.top.taskCallResult = -1
+                end try
+            end if
+        end while
+    end sub
+    ]]></script>
+</component>

--- a/test/simulator/probes/node-owned-by-task-callfunc-probe/components/ForeignTask.xml
+++ b/test/simulator/probes/node-owned-by-task-callfunc-probe/components/ForeignTask.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    A second, unrelated Task that reaches the agent Node through m.global: a cross-thread
+    Task-to-Node callFunc, NOT render-to-Node. This exercises the pre-existing, already-working
+    owner-based rendezvous (Node.shouldRendezvous()/rendezvousCall(), untouched by the render-
+    thread callFunc fix), to confirm the bug is specific to render-initiated calls.
+-->
+<component name="ForeignTask" extends="Task">
+    <interface>
+        <field id="ready" type="boolean" value="false" />
+        <field id="triggerForeignCall" type="boolean" value="false" alwaysNotify="true" />
+        <field id="foreignCallResult" type="integer" value="0" alwaysNotify="true" />
+    </interface>
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.top.functionName = "runTask"
+        m.port = CreateObject("roMessagePort")
+        m.top.observeField("control", m.port)
+        m.top.observeField("triggerForeignCall", m.port)
+    end sub
+
+    sub runTask()
+        m.top.ready = true
+        while true
+            msg = wait(0, m.port)
+            if type(msg) = "roSGNodeEvent" and msg.getField() = "triggerForeignCall" and msg.getData()
+                ' PHASE foreign-task-call: a DIFFERENT task (not the one that created/owns the
+                ' agent) reads it back from m.global and calls callFunc -- cross-thread, but
+                ' Task-to-Node, not render-to-Node.
+                agent = m.global.nrAgent
+                result = agent.callFunc("setHarvestTime", 77)
+                print "FOREIGNTASK: foreignCall result=" + result.toStr()
+                m.top.foreignCallResult = result
+            end if
+        end while
+    end sub
+    ]]></script>
+</component>

--- a/test/simulator/probes/node-owned-by-task-callfunc-probe/components/ForeignTask.xml
+++ b/test/simulator/probes/node-owned-by-task-callfunc-probe/components/ForeignTask.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!--
     A second, unrelated Task that reaches the agent Node through m.global: a cross-thread
-    Task-to-Node callFunc, NOT render-to-Node. This exercises the pre-existing, already-working
+    Task-to-Node callFunc, NOT render-to-Node. On a real Roku this succeeds via the pre-existing
     owner-based rendezvous (Node.shouldRendezvous()/rendezvousCall(), untouched by the render-
-    thread callFunc fix), to confirm the bug is specific to render-initiated calls.
+    thread callFunc fix). On the simulator it currently fails earlier than that -- m.global.nrAgent
+    itself reads back Invalid here, a separate simulator-only bug tracked as issue #1219.
 -->
 <component name="ForeignTask" extends="Task">
     <interface>

--- a/test/simulator/probes/node-owned-by-task-callfunc-probe/components/MainScene.xml
+++ b/test/simulator/probes/node-owned-by-task-callfunc-probe/components/MainScene.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<component name="MainScene" extends="Scene">
+    <script type="text/brightscript"><![CDATA[
+    sub init()
+        m.top.backgroundURI = ""
+        m.top.backgroundColor = "0x101020FF"
+
+        m.status = CreateObject("roSGNode", "Label")
+        m.status.translation = [40, 40]
+        m.status.width = 1200
+        m.status.text = [
+            "NODE-OWNED-BY-TASK CALLFUNC PROBE"
+            ""
+            "Watch for STEP1/STEP2 results below as soon as the app starts (automatic, no key"
+            "needed) -- that isolation is the key diagnostic. Then:"
+            ""
+            "REWIND    task-call      baseline: AppTask calls callFunc on its own local agent"
+            "UP        foreign-call   baseline: a DIFFERENT task reaches the agent via m.global"
+            "DOWN      render-call    THE REPORTED BUG SHAPE: render calls callFunc on the"
+            "                         agent Node via m.global -- expect a crash on an unfixed"
+            "                         engine (matches the New Relic report); run this LAST, it"
+            "                         may end the app"
+            "BACK                     exit"
+        ].join(chr(10))
+        m.top.appendChild(m.status)
+
+        m.appReady = false
+        m.foreignReady = false
+        m.taskReady = false
+
+        m.appTask = CreateObject("roSGNode", "AppTask")
+        m.appTask.observeField("ready", "onAppTaskReady")
+        m.appTask.observeField("preCallFuncResult", "onPreCallFuncResult")
+        m.appTask.observeField("postPublishResult", "onPostPublishResult")
+        m.appTask.observeField("taskCallResult", "onTaskCallResult")
+        m.appTask.control = "run"
+
+        m.foreignTask = CreateObject("roSGNode", "ForeignTask")
+        m.foreignTask.observeField("ready", "onForeignTaskReady")
+        m.foreignTask.observeField("foreignCallResult", "onForeignCallResult")
+        m.foreignTask.control = "run"
+
+        m.top.setFocus(true)
+    end sub
+
+    sub onAppTaskReady(event as object)
+        if event.getData()
+            m.appReady = true
+            print "### RENDER AppTask ready"
+            checkAllReady()
+        end if
+    end sub
+
+    sub onForeignTaskReady(event as object)
+        if event.getData()
+            m.foreignReady = true
+            print "### RENDER ForeignTask ready"
+            checkAllReady()
+        end if
+    end sub
+
+    sub checkAllReady()
+        if m.appReady and m.foreignReady
+            m.taskReady = true
+            print "### RENDER all tasks ready -- press a phase key"
+            m.status.text = m.status.text + chr(10) + chr(10) + "ready -- press a phase key"
+        end if
+    end sub
+
+    ' KEY DIAGNOSTIC: isolates whether the corruption is caused by the ownership-changing
+    ' m.global publish itself (STEP2 fails while STEP1, the identical call made just before the
+    ' publish, succeeds), independent of any later callFunc routing/caller-thread question.
+    sub onPreCallFuncResult(event as object)
+        print "### ISOLATION STEP1 (pre-publish, same-thread) result="; event.getData()
+        m.status.text = m.status.text + chr(10) + "STEP1 (pre-publish) result=" + event.getData().toStr()
+    end sub
+
+    sub onPostPublishResult(event as object)
+        print "### ISOLATION STEP2 (post-publish, same-thread) result="; event.getData()
+        verdict = "FAILED -- publishing to m.global corrupted the agent's own script scope"
+        if event.getData() = 22 then verdict = "OK -- publish did not corrupt the agent"
+        print "### ISOLATION verdict: "; verdict
+        m.status.text = m.status.text + chr(10) + "STEP2 (post-publish) result=" + event.getData().toStr() + " -> " + verdict
+    end sub
+
+    sub onTaskCallResult(event as object)
+        print "### PHASE task-call READBACK result="; event.getData()
+    end sub
+
+    sub onForeignCallResult(event as object)
+        print "### PHASE foreign-call READBACK result="; event.getData()
+    end sub
+
+    function onKeyEvent(key as string, press as boolean) as boolean
+        if not press then return false
+        if not m.taskReady and key <> "back"
+            print "### RENDER not ready yet -- wait for '### RENDER all tasks ready'"
+            return true
+        end if
+
+        if key = "rewind"
+            print "### PHASE task-call BEGIN"
+            m.appTask.triggerTaskCall = true
+        else if key = "up"
+            print "### PHASE foreign-call BEGIN"
+            m.foreignTask.triggerForeignCall = true
+        else if key = "down"
+            runRenderCall()
+        else
+            return false
+        end if
+        return true
+    end function
+
+    ' THE REPORTED BUG SHAPE: callFunc issued from the render thread's own clean loop context
+    ' (onKeyEvent, not a field observer of the target), onto a node handle read back from
+    ' m.global -- the agent Node was constructed by AppTask (a Task), not by render. This is the
+    ' New Relic crash's exact shape: m.nrAgent.callFunc("nrSetHarvestTime", seconds) from the main
+    ' thread, where m.nrHarvestTimerEvents was captured via findNode() inside a callFunc-invoked
+    ' init wrapper, not the agent's own init().
+    sub runRenderCall()
+        print "### PHASE render-call BEGIN"
+        agent = m.global.nrAgent
+        span = CreateObject("roTimespan")
+        span.mark()
+        result = agent.callFunc("setHarvestTime", 42)
+        elapsed = span.totalMilliseconds()
+        print "### PHASE render-call END result="; result; " elapsed-ms="; elapsed
+        m.status.text = "render-call: result=" + result.toStr() + " elapsed=" + elapsed.toStr() + "ms"
+    end sub
+    ]]></script>
+</component>

--- a/test/simulator/probes/node-owned-by-task-callfunc-probe/manifest
+++ b/test/simulator/probes/node-owned-by-task-callfunc-probe/manifest
@@ -1,0 +1,4 @@
+title=Node Owned By Task CallFunc Probe
+major_version=1
+minor_version=0
+build_version=0

--- a/test/simulator/probes/node-owned-by-task-callfunc-probe/pack.sh
+++ b/test/simulator/probes/node-owned-by-task-callfunc-probe/pack.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Packs the probe into a sideloadable zip.
+set -euo pipefail
+cd "$(dirname "$0")"
+rm -f node-owned-by-task-callfunc-probe.zip
+zip -r node-owned-by-task-callfunc-probe.zip manifest source components -x '*.DS_Store'
+echo "Created $(pwd)/node-owned-by-task-callfunc-probe.zip"

--- a/test/simulator/probes/node-owned-by-task-callfunc-probe/source/main.brs
+++ b/test/simulator/probes/node-owned-by-task-callfunc-probe/source/main.brs
@@ -1,0 +1,18 @@
+sub Main()
+    print "### PROBE app started"
+    screen = CreateObject("roSGScreen")
+    m.port = CreateObject("roMessagePort")
+    screen.setMessagePort(m.port)
+    screen.CreateScene("MainScene")
+    screen.show()
+
+    while true
+        msg = wait(0, m.port)
+        if type(msg) = "roSGScreenEvent"
+            if msg.isScreenClosed()
+                print "### PROBE app exiting"
+                return
+            end if
+        end if
+    end while
+end sub


### PR DESCRIPTION
## Summary

- A `callFunc` issued from the render thread onto a SceneGraph `Task`, or onto a plain `Node` genuinely owned by a Task's own thread, used to silently run **locally** against an incomplete render-side reconstruction instead of rendezvousing to the real owning thread — the root cause of a reported New Relic SDK crash (`m.nrHarvestTimerEvents.duration = seconds` throwing `Invalid value for left-side of expression`).
- `Node.callFuncThread()`/`rendezvousCallFunc()` now route the dispatch to the Task's own worker thread for both a `Task` target and an ordinary `Node` owned by one — `shouldRendezvous()`/`rendezvousCall()` only ever fired for a task-initiated caller, never a render-initiated one.
- `Task.syncRemoteField` no longer unconditionally re-owns a `Node` value synced to a render-owned field. Re-owning is correct when a task reports a result through its **own** interface field, but wrong when it's merely publishing a reference to a node it keeps using itself (e.g. an `m.global` singleton) — confirmed on a real Roku device that the previous unconditional re-own crashed where the device does not.
- `buildMethodCallPayload` no longer re-owns a `callFunc` **argument** to the callee thread — the same failure class, reached via an argument instead of a field.

## Test plan

- [x] `npm run lint` and `npm run prettier:write` clean
- [x] Full suite green: 221 test files / 2934 tests (`npm test`)
- [x] New unit coverage: `test/extensions/scenegraph/RenderTaskCallFunc.test.js` (owner-based `callFunc` routing, argument-ownership in both directions, `callFuncM` snapshot semantics), `DirectRendezvous.test.js` (own-field vs. foreign-node re-own rule)
- [x] New CLI regression: `test/cli/resources/task-owned-node-callfunc-app` — mirrors the actual New Relic SDK shape (fetched and read from `newrelic/video-agent-roku@3.2.4`: `NRAgent` is a plain `Node`, not a `Task`); verified to crash identically to the original report on `master` and pass with this fix (`git stash`/rebuild cycle)
- [x] `test/simulator/probes/{callfunc-task-thread-probe,node-owned-by-task-callfunc-probe}/` — device-diffing probes, **verified against real Roku hardware**: the probe crashes on the simulator pre-fix and does not crash on a real device, confirming this was a genuine engine bug rather than device-accurate behavior apps need to work around
- [x] `.claude/docs/threading-and-rendezvous.md` updated with the full mechanism writeup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015h2jnvL2ErArRY17LhcKBQ