### PR TITLE
chore(release): bump version to 2.5.4 with SceneGraph Task rendezvous fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+<a name="v2.5.4"></a>
+
+## [v2.5.4 - SceneGraph Task Rendezvous Fixes](https://github.com/lvcabral/brs-engine/releases/tag/v2.5.4) - 08 September 2026
+
+This patch release fixes a `callFunc` issued from the render thread onto a SceneGraph `Task`, or onto a plain `Node` genuinely owned by a Task's thread, silently running locally against an incomplete render-side reconstruction instead of rendezvousing to the real owning thread — the root cause of a reported New Relic SDK crash. Two related device-confirmed fixes ship alongside it: a field or callFunc argument publishing a `Node` reference (e.g. an `m.global` singleton) no longer gets incorrectly re-owned to the receiving thread, and a Task's outgoing field-set now acknowledges before dispatching render-side observers, closing a circular-wait deadlock reproduced against a real Jellyfin server. A related fix makes a field added to `m.global` by another task, after this task's own launch, visible through rendezvous instead of permanently reading `Invalid`. Also fixed: `DynamicKeyGrid` crashing when loading a Key Definition File containing a spacer row with no `keys`, and `roAppManager.getUpTime()` returning negative values. Read the full release notes below for more details.
+
+### Release Changes
+
+#### Core Engine
+
+* (brs) Fixed `roAppManager.getUpTime()` returning negative values by [@lvcabral](https://github.com/lvcabral) in [#1216](https://github.com/lvcabral/brs-engine/pull/1216)
+
+#### SceneGraph Extension (`brs-scenegraph` release v0.5.4)
+
+* (rsg) Fixed a render-initiated `callFunc` onto a Task or Task-owned Node running locally instead of rendezvousing to the owning thread, plus a field/argument re-ownership fix and a Task field-set acknowledgment race that could deadlock by [@lvcabral](https://github.com/lvcabral) in [#1218](https://github.com/lvcabral/brs-engine/pull/1218)
+* (rsg) Fixed `m.global` rendezvous so a field added by another task after this task's own launch is no longer permanently invisible by [@lvcabral](https://github.com/lvcabral) in [#1220](https://github.com/lvcabral/brs-engine/pull/1220)
+* (rsg) Fixed `DynamicKeyGrid` crashing when loading a Key Definition File with a spacer row (no `keys`) by [@lvcabral](https://github.com/lvcabral) in [#1217](https://github.com/lvcabral/brs-engine/pull/1217)
+
+[Full Changelog][v2.5.4]
+
 <a name="v2.5.3"></a>
 
 ## [v2.5.3 - SceneGraph Copy Semantics and Node Hierarchy Fixes](https://github.com/lvcabral/brs-engine/releases/tag/v2.5.3) - 03 September 2026
@@ -1860,6 +1880,7 @@ The following is the list of components implemented (some partially or just mock
 
 [Full Changelog][v0.1.0-emu]
 
+[v2.5.4]: https://github.com/lvcabral/brs-engine/compare/v2.5.3...v2.5.4
 [v2.5.3]: https://github.com/lvcabral/brs-engine/compare/v2.5.2...v2.5.3
 [v2.5.2]: https://github.com/lvcabral/brs-engine/compare/v2.5.1...v2.5.2
 [v2.5.1]: https://github.com/lvcabral/brs-engine/compare/v2.5.0...v2.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,17 @@ All notable changes to this project will be documented in this file.
 
 ## [v2.5.4 - SceneGraph Task Rendezvous Fixes](https://github.com/lvcabral/brs-engine/releases/tag/v2.5.4) - 08 September 2026
 
-This patch release fixes a `callFunc` issued from the render thread onto a SceneGraph `Task`, or onto a plain `Node` genuinely owned by a Task's thread, silently running locally against an incomplete render-side reconstruction instead of rendezvousing to the real owning thread — the root cause of a reported New Relic SDK crash. Two related device-confirmed fixes ship alongside it: a field or callFunc argument publishing a `Node` reference (e.g. an `m.global` singleton) no longer gets incorrectly re-owned to the receiving thread, and a Task's outgoing field-set now acknowledges before dispatching render-side observers, closing a circular-wait deadlock reproduced against a real Jellyfin server. A related fix makes a field added to `m.global` by another task, after this task's own launch, visible through rendezvous instead of permanently reading `Invalid`. Also fixed: `DynamicKeyGrid` crashing when loading a Key Definition File containing a spacer row with no `keys`, and `roAppManager.getUpTime()` returning negative values. Read the full release notes below for more details.
+This patch release fixes a `callFunc` issued from the render thread onto a SceneGraph `Task`, or onto a plain `Node` genuinely owned by a Task's thread, silently running locally against an incomplete render-side reconstruction instead of rendezvousing to the real owning thread — the root cause of a reported New Relic SDK crash. Two related device-confirmed fixes ship alongside it: a field or callFunc argument publishing a `Node` reference (e.g. an `m.global` singleton) no longer gets incorrectly re-owned to the receiving thread, and a Task's outgoing field-set now acknowledges before dispatching render-side observers, closing a circular-wait deadlock reproduced against a real Jellyfin server. A related fix makes a field added to `m.global` by another task, after this task's own launch, visible through rendezvous instead of permanently reading `Invalid`. Also fixed: `DynamicKeyGrid` crashing when loading a Key Definition File containing a spacer row with no `keys`, `roAppManager.getUpTime()` returning negative values, and the Node.js host silently dropping a Task's last `print` when it raced the Task's own teardown. Read the full release notes below for more details.
 
 ### Release Changes
 
 #### Core Engine
 
 * (brs) Fixed `roAppManager.getUpTime()` returning negative values by [@lvcabral](https://github.com/lvcabral) in [#1216](https://github.com/lvcabral/brs-engine/pull/1216)
+
+#### Node.js Library and CLI
+
+* (node) Fixed the host force-terminating a Task worker before an in-flight `print` it had already sent could reach the terminal by [@lvcabral](https://github.com/lvcabral) in [#1222](https://github.com/lvcabral/brs-engine/pull/1222)
 
 #### SceneGraph Extension (`brs-scenegraph` release v0.5.4)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brs-engine-workspace",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "brs-engine-workspace",
-      "version": "2.5.3",
+      "version": "2.5.4",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -14233,7 +14233,7 @@
     },
     "packages/browser": {
       "name": "brs-engine",
-      "version": "2.5.3",
+      "version": "2.5.4",
       "license": "MIT",
       "dependencies": {
         "@lvcabral/libwebp": "^0.2.0",
@@ -14310,7 +14310,7 @@
     },
     "packages/node": {
       "name": "brs-node",
-      "version": "2.5.3",
+      "version": "2.5.4",
       "license": "MIT",
       "dependencies": {
         "@lvcabral/libwebp": "^0.2.0",
@@ -14393,7 +14393,7 @@
     },
     "packages/scenegraph": {
       "name": "brs-scenegraph",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "MIT",
       "dependencies": {
         "p-settle": "^5.1.1",
@@ -14413,7 +14413,7 @@
         "zip-webpack-plugin": "^4.0.3"
       },
       "peerDependencies": {
-        "brs-engine": "^2.5.3"
+        "brs-engine": "^2.5.4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brs-engine-workspace",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "private": true,
   "title": "BrightScript Simulation Engine",
   "description": "BrightScript Simulation Engine - Run Roku apps on Browsers and Node.js",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brs-engine",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "title": "BrightScript Simulation Engine",
   "description": "BrightScript Simulation Engine - Run Roku apps on Browsers and Electron",
   "author": "Marcelo Lv Cabral <marcelo@lvcabral.com> (https://lvcabral.com/)",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brs-node",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "title": "BrightScript Simulation Engine",
   "description": "BrightScript Simulation Engine - Run Roku apps on Node.js or Terminal (CLI)",
   "author": "Marcelo Lv Cabral <marcelo@lvcabral.com> (https://lvcabral.com/)",

--- a/packages/scenegraph/CHANGELOG.md
+++ b/packages/scenegraph/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to `brs-scenegraph` extension will be documented in this file.
 
+<a name="v0.5.4"></a>
+
+## [v0.5.4 (beta) - Task Rendezvous Fixes](https://github.com/lvcabral/brs-engine/releases/tag/brs-sg-v0.5.4) - 08 September 2026
+
+This patch release fixes a `callFunc` issued from the render thread onto a SceneGraph `Task`, or onto a plain `Node` genuinely owned by a Task's thread, silently running locally against an incomplete render-side reconstruction instead of rendezvousing to the real owning thread — the root cause of a reported New Relic SDK crash. Two related device-confirmed fixes ship alongside it: a field or callFunc argument publishing a `Node` reference (e.g. an `m.global` singleton) no longer gets incorrectly re-owned to the receiving thread, and a Task's outgoing field-set now acknowledges before dispatching render-side observers, closing a circular-wait deadlock reproduced against a real Jellyfin server. A related fix makes a field added to `m.global` by another task, after this task's own launch, visible through rendezvous instead of permanently reading `Invalid`. Also fixed: `DynamicKeyGrid` crashing when loading a Key Definition File containing a spacer row with no `keys`. Read the full release notes below for more details.
+
+### Release Changes
+
+* (rsg) Fixed a render-initiated `callFunc` onto a Task or Task-owned Node running locally instead of rendezvousing to the owning thread, plus a field/argument re-ownership fix and a Task field-set acknowledgment race that could deadlock by [@lvcabral](https://github.com/lvcabral) in [#1218](https://github.com/lvcabral/brs-engine/pull/1218)
+* (rsg) Fixed `m.global` rendezvous so a field added by another task after this task's own launch is no longer permanently invisible by [@lvcabral](https://github.com/lvcabral) in [#1220](https://github.com/lvcabral/brs-engine/pull/1220)
+* (rsg) Fixed `DynamicKeyGrid` crashing when loading a Key Definition File with a spacer row (no `keys`) by [@lvcabral](https://github.com/lvcabral) in [#1217](https://github.com/lvcabral/brs-engine/pull/1217)
+
+[Full Changelog][v0.5.4]
+
 <a name="v0.5.3"></a>
 
 ## [v0.5.3 (beta) - Copy Semantics and Node Hierarchy Fixes](https://github.com/lvcabral/brs-engine/releases/tag/brs-sg-v0.5.3) - 03 September 2026
@@ -414,6 +428,7 @@ This first alpha delivers the **SceneGraph** runtime as a standalone extension t
   * Media + utility nodes: `Audio`, `Video`, `SoundEffect`, `Task`, `Timer`, `ChannelStore`.
 * Published merged `assets/common.zip` so SceneGraph fonts, locale data, dialogs, and imagery are available through the simulated `common:/` volume in both `brs-engine` and `brs-node` packages.
 
+[v0.5.4]: https://github.com/lvcabral/brs-engine/compare/brs-sg-v0.5.3...brs-sg-v0.5.4
 [v0.5.3]: https://github.com/lvcabral/brs-engine/compare/brs-sg-v0.5.2...brs-sg-v0.5.3
 [v0.5.2]: https://github.com/lvcabral/brs-engine/compare/brs-sg-v0.5.1...brs-sg-v0.5.2
 [v0.5.1]: https://github.com/lvcabral/brs-engine/compare/brs-sg-v0.5.0...brs-sg-v0.5.1

--- a/packages/scenegraph/package.json
+++ b/packages/scenegraph/package.json
@@ -1,6 +1,6 @@
 {
     "name": "brs-scenegraph",
-    "version": "0.5.3",
+    "version": "0.5.4",
     "description": "SceneGraph addon for BrightScript Simulation Engine",
     "author": "Marcelo Lv Cabral <marcelo@lvcabral.com> (https://lvcabral.com/)",
     "license": "MIT",
@@ -42,7 +42,7 @@
         "p-settle": "^5.1.1"
     },
     "peerDependencies": {
-        "brs-engine": "^2.5.3"
+        "brs-engine": "^2.5.4"
     },
     "devDependencies": {
         "@types/node": "^22.13.2",


### PR DESCRIPTION
## Summary
- Bump `brs-engine`/`brs-node` to `2.5.4` and `brs-scenegraph` to `0.5.4`.
- Update `CHANGELOG.md` and `packages/scenegraph/CHANGELOG.md` for the release, covering:
  - fix(scenegraph): rendezvous a render-initiated `callFunc` onto Task-owned nodes correctly (#1218)
  - fix(scenegraph): rendezvous a `m.global` field added after a task's own launch (#1220)
  - fix(scenegraph): `DynamicKeyGrid` crashes loading a KDF with a spacer row (#1217)
  - fix(core): `roAppManager.getUpTime()` was returning negative values (#1216)
- No user-facing docs needed updates; `.claude/docs/threading-and-rendezvous.md` was already updated as part of the rendezvous fixes.

## Test plan
- [x] `npm run lint`
- [x] `npm install` to regenerate `package-lock.json` (version-bump-only diff)
- [ ] Merge and tag `v2.5.4` / `brs-sg-v0.5.4`, then publish packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015h2jnvL2ErArRY17LhcKBQ