### PR TITLE
fix(node): drain a task worker's in-flight print before force-terminating it

### DIFF
--- a/src/node/host.ts
+++ b/src/node/host.ts
@@ -192,7 +192,7 @@ function taskNotify(event: string, data?: any) {
  * Stops all task workers and the app worker, releasing host state.
  */
 async function cleanupApp() {
-    resetTasks();
+    await resetTasks();
     const worker = appWorker;
     appWorker = undefined;
     currentPayload = undefined;

--- a/src/node/task.ts
+++ b/src/node/task.ts
@@ -162,10 +162,60 @@ function runTask(taskData: TaskData, currentPayload: AppPayload) {
 }
 
 /**
+ * Waits for a task worker to go quiet before it is force-terminated.
+ *
+ * `worker.terminate()` races the delivery of a message the worker already sent: a BrightScript
+ * `print` reaches the host via `OutputProxy`'s `postMessage(str)` (see `src/core/device/
+ * OutputProxy.ts`), a channel entirely independent of whatever unrelated signal (another thread
+ * setting `control = "stop"`, or the app itself ending) triggered this termination. A print issued
+ * moments earlier can still be in flight when the kill lands, silently dropping it -- unlike a
+ * worker's own trailing print before its own "stop"/"end" message, which shares that same channel
+ * and is reliably ordered ahead of it. Confirmed with a standalone worker_threads repro:
+ * terminating immediately after an unrelated worker's message loses the target's last postMessage
+ * a meaningful fraction of the time (worse under CPU load); a short quiet window after its last
+ * message eliminates the loss. The caller must keep the worker's real "message" listener attached
+ * during the wait -- this only tracks activity, it never substitutes for it -- and remove it
+ * afterward, once quiet.
+ *
+ * `quietMs` must comfortably cover a freshly spawned worker's own startup latency, not just
+ * message-delivery jitter: a worker that hasn't even started running yet has produced no
+ * activity to reset the timer, so a too-short window mistakes "hasn't started" for "already
+ * done" and can lose 100% of its first message. A standalone repro racing termination against a
+ * worker's very first tick (the tightest case) needed >=50ms even under heavy CPU contention.
+ * @param worker Task worker about to be terminated
+ * @param quietMs How long the worker must be silent before considering it drained
+ * @param maxWaitMs Upper bound so a worker that keeps producing output can't stall shutdown
+ */
+async function drainWorkerOutput(worker: Worker, quietMs = 50, maxWaitMs = 500): Promise<void> {
+    return new Promise((resolve) => {
+        let quietTimer: NodeJS.Timeout;
+        const onActivity = () => {
+            clearTimeout(quietTimer);
+            quietTimer = setTimeout(finish, quietMs).unref();
+        };
+        const maxTimer = setTimeout(finish, maxWaitMs).unref();
+        function finish() {
+            clearTimeout(maxTimer);
+            clearTimeout(quietTimer);
+            worker.off("message", onActivity);
+            worker.stdout.off("data", onActivity);
+            worker.stderr.off("data", onActivity);
+            resolve();
+        }
+        // "message" is the real print/debug/warning transport; stdout/stderr only catch a stray
+        // write that bypassed OutputProxy (engine internals, third-party libraries).
+        worker.on("message", onActivity);
+        worker.stdout.on("data", onActivity);
+        worker.stderr.on("data", onActivity);
+        quietTimer = setTimeout(finish, quietMs).unref();
+    });
+}
+
+/**
  * Terminates a running task worker and cleans up resources.
  * @param taskId ID of the task to terminate
  */
-function endTask(taskId: number) {
+async function endTask(taskId: number) {
     // A task stopped before its queued launch got a slot must not start afterwards.
     const queued = pendingTasks.findIndex((pending) => pending.taskData.id === taskId);
     if (queued >= 0) {
@@ -173,6 +223,9 @@ function endTask(taskId: number) {
     }
     const taskWorker = tasks.get(taskId);
     if (taskWorker) {
+        // Drain before detaching the real "message" listener: a print in flight when this was
+        // called must still reach taskCallback/notifyHost, not just be waited on.
+        await drainWorkerOutput(taskWorker);
         taskWorker.removeAllListeners("message");
         taskWorker.terminate().catch(() => {});
         tasks.delete(taskId);
@@ -199,8 +252,13 @@ function startPendingTasks() {
 /**
  * Resets all tasks by terminating workers and clearing state.
  */
-export function resetTasks() {
-    for (const [_id, worker] of tasks) {
+export async function resetTasks() {
+    const workers = [...tasks.values()];
+    // Drain every worker concurrently, real "message" listener still attached, before tearing any
+    // of them down -- sequential draining would multiply the (usually negligible) quiet-window
+    // wait by the number of still-running tasks.
+    await Promise.all(workers.map(async (worker) => drainWorkerOutput(worker)));
+    for (const worker of workers) {
         worker.removeAllListeners("message");
         worker.terminate().catch(() => {});
     }

--- a/test/node/resources/print-then-idle-worker.js
+++ b/test/node/resources/print-then-idle-worker.js
@@ -1,0 +1,10 @@
+// Minimal stand-in for a SceneGraph Task worker: mirrors what `OutputProxy.write()` does for a
+// real BrightScript `print` (postMessage a "print,<text>" string, see src/core/device/
+// OutputProxy.ts), then idles like a Task parked in a `wait()` loop until force-terminated.
+// Used to drive `src/node/task.ts`'s real runTask/endTask/resetTasks against a controlled worker
+// without needing a full BrightScript payload.
+const { parentPort } = require("worker_threads");
+
+parentPort.postMessage("print,TASK_PRINT_MARKER");
+parentPort.on("message", () => {});
+setInterval(() => {}, 1000);

--- a/test/node/task.test.js
+++ b/test/node/task.test.js
@@ -1,0 +1,55 @@
+// Exercises `src/node/task.ts` directly (not a compiled bundle), driving a real worker_threads
+// worker through the same functions the Node host uses (initTaskModule/handleTaskData/
+// resetTasks), instead of a full BrightScript payload. This lets the test control the exact race
+// this suite regresses: a task's `print` (delivered via `postMessage`, see OutputProxy.write() in
+// src/core/device/OutputProxy.ts) racing an unrelated thread's decision to tear the task down.
+import path from "node:path";
+import { initTaskModule, handleTaskData, resetTasks } from "../../src/node/task.ts";
+import { TaskState } from "../../src/core/common.ts";
+
+const workerEntry = path.join(__dirname, "resources", "print-then-idle-worker.js");
+
+function makeAppPayload() {
+    return {
+        device: {},
+        launchTime: 0,
+        manifest: new Map(),
+        deepLink: new Map(),
+        paths: [],
+        source: [],
+    };
+}
+
+function startTask(id, notify) {
+    initTaskModule(new SharedArrayBuffer(4), workerEntry, notify);
+    handleTaskData(
+        { id, name: "PrintThenIdleTask", state: TaskState.RUN, m: { top: { functionname: "run" } } },
+        makeAppPayload()
+    );
+}
+
+describe("task worker teardown does not drop an in-flight print", () => {
+    it("captures a task's print when another thread stops it with zero elapsed time (STOP)", async () => {
+        const events = [];
+        startTask(1, (event, data) => events.push({ event, data }));
+        // Mirrors a different thread's `task.control = "stop"` landing the instant the task
+        // launched, with no guaranteed gap after its print -- the regression this suite covers.
+        handleTaskData({ id: 1, name: "PrintThenIdleTask", state: TaskState.STOP }, makeAppPayload());
+        // endTask() is async (it awaits the drain); give its microtask/timer chain a turn.
+        await new Promise((resolve) => setTimeout(resolve, 750));
+
+        const printed = events.some((e) => e.event === "message" && String(e.data).includes("TASK_PRINT_MARKER"));
+        expect(printed).toBe(true);
+    });
+
+    it("captures a task's print when the app ends and tears down all tasks (resetTasks)", async () => {
+        const events = [];
+        startTask(2, (event, data) => events.push({ event, data }));
+        // Mirrors the app worker's "end" landing the instant the task launched -- resetTasks()
+        // is what host.ts's cleanupApp() calls on every app termination.
+        await resetTasks();
+
+        const printed = events.some((e) => e.event === "message" && String(e.data).includes("TASK_PRINT_MARKER"));
+        expect(printed).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary

Root-causes the CI flake seen on PR #1221: `test/cli/cli-scenegraph.test.js > Rendezvouses a callFunc from the render thread onto a plain Node owned by a Task thread` intermittently failed with the Task-owned `AgentNode`'s `AGENT: setHarvestTime duration=42` print missing from stdout.

- A BrightScript `print` inside a worker reaches the host via `OutputProxy`'s `postMessage(str)` (see `src/core/device/OutputProxy.ts`), a channel entirely independent of whatever unrelated signal (another thread setting `control = "stop"`, or the app itself ending) triggers a task's teardown.
- `endTask()`/`resetTasks()` (`src/node/task.ts`) called `worker.terminate()` the instant that unrelated signal arrived, racing the delivery of any message the task worker had already sent. Confirmed with a standalone `worker_threads` repro: terminating immediately after an unrelated worker's message loses the target's last `postMessage` a meaningful fraction of the time, worse under CPU load (matching a shared CI runner).
- Both teardown paths now wait for the worker to go quiet (its real `"message"` listener stays attached throughout, so anything still arriving keeps reaching `notifyHost` normally) before detaching listeners and terminating. The quiet window (50ms, capped at 500ms) must comfortably cover a freshly spawned worker's own startup latency, not just delivery jitter -- a too-short window mistakes "hasn't started yet" for "already done" and can lose the message entirely.
- `host.ts`'s `cleanupApp()` now awaits the now-async `resetTasks()`.

## Test plan
- [x] New `test/node/task.test.js` drives the real `runTask`/`endTask`/`resetTasks` functions (via a minimal worker fixture) against both teardown paths, regressing at the tightest possible race window; fails without the fix, passes with it.
- [x] `npm run lint`
- [x] `npx vitest run` (full suite, 222 files / 2932 tests passed)
- [x] `test/cli/cli-scenegraph.test.js` (all 61 tests) re-run repeatedly under heavy artificial CPU load (12 busy-loop processes on a 10-core machine) with no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015h2jnvL2ErArRY17LhcKBQ