### PR TITLE
fix(scenegraph): honor a focus re-grab raised while the competing focus is still detached

### DIFF
--- a/.claude/docs/scenegraph-invariants.md
+++ b/.claude/docs/scenegraph-invariants.md
@@ -1331,6 +1331,21 @@ because an app that re-grabs focus from its own `focusedChild` observer (sgRoute
      the scene's `dialog` (parented to the Scene via `setNodeParent`, never into the owner). Checked last —
      it costs an unbounded walk to the scene root, so it only runs once the cheap subtree walk has already
      failed to place `target` under `owner`.
+   - The mirror case, checked **first**: the *currently-focused* node can be the one that is unparented,
+     not the target. A component's `init()` focusing one of its own not-yet-attached children still runs
+     the ordinary `setNodeFocus` LCA walk, which unsets *every* non-common ancestor of the previously
+     focused chain as a side effect — including ancestors with no relationship whatsoever to the new
+     (detached) subtree. That fires their `focusedChild`-loss observers while nothing has actually left
+     their tree yet: a router outlet observing its own `focusedChild` and re-grabbing focus into its
+     routed content (sgRouter + a `JRDialog`-style overlay that focuses its own button from a field
+     observer *before* `presentOverlayDialog` appends it to the scene) is a real, device-confirmed
+     instance. Testing only "is `owner` still an ancestor of `focused`" reads this as a permanent
+     cross-tree steal and drops it — corrupting the chain exactly the way this whole mechanism exists to
+     prevent: `sgRoot.focused` is left on a node outside the visible tree, and the scene's own
+     `focusedChild` is left cleared instead of re-threaded to the re-grabbed node. Guard: if `owner` and
+     `focused` don't share the same root (`createPath()[0]`), there is no steal to classify yet — honor
+     the request. It resolves itself once the detached subtree is eventually mounted, via
+     `restoreFocusChainOnAttach`.
 
    **The classification must survive the deferral, not defeat it.** A grid's focus-gain settle is an
    engine emission, so raised inside another observer it defers — by which point the transaction has left
@@ -1362,4 +1377,5 @@ because an app that re-grabs focus from its own `focusedChild` observer (sgRoute
    Regression: `focus-steal-app` and `container-redirect-focus-app` in `test/cli/` (the latter drives all
    four rules plus the deferral through a real app; the `Focus.test.js` unit tests use port observers,
    which never defer), which must stay green alongside `dialog-buttongroup-focus-app`,
-   `deferred-observer-app` and `init-focus-observer-app`.
+   `deferred-observer-app` and `init-focus-observer-app`. The disconnected-tree carve-out: "honors a
+   re-grab when the competing focus lives in a still-detached subtree" in `Focus.test.js`.

--- a/src/extensions/scenegraph/nodes/Dialog.ts
+++ b/src/extensions/scenegraph/nodes/Dialog.ts
@@ -158,7 +158,7 @@ export class Dialog extends Group {
             this.setValue("visible", BrsBoolean.False);
             sgRoot.removeDialog(this);
             if (this.lastFocus instanceof Group) {
-                sgRoot.setFocused(this.lastFocus);
+                this.lastFocus.setNodeFocus(true);
                 this.lastFocus.isDirty = true;
                 this.lastFocus = undefined;
             }

--- a/src/extensions/scenegraph/nodes/Node.ts
+++ b/src/extensions/scenegraph/nodes/Node.ts
@@ -1493,6 +1493,11 @@ export class Node extends RoSGNode implements BrsValue {
         if (!owner || !(focused instanceof Node)) {
             return false;
         }
+        // Owner and focused must belong to the same tree for the ancestor comparison below to mean
+        // anything — see the disconnected-tree carve-out in scenegraph-invariants.md.
+        if (Node.rootOf(owner) !== Node.rootOf(focused)) {
+            return false;
+        }
         // Owner must still be in the focus chain.
         if (!Node.isAncestorOrSelf(owner, focused)) {
             return true;
@@ -1526,6 +1531,19 @@ export class Node extends RoSGNode implements BrsValue {
             current = current.parent;
         }
         return false;
+    }
+
+    /**
+     * Walks `node`'s raw `.parent` chain to its top-most ancestor.
+     * @param node Node to walk up from.
+     * @returns The root-most ancestor (which is `node` itself if it has no parent).
+     */
+    private static rootOf(node: Node): Node {
+        let current = node;
+        while (current.parent instanceof Node) {
+            current = current.parent;
+        }
+        return current;
     }
 
     /**

--- a/test/extensions/scenegraph/Dialog.test.js
+++ b/test/extensions/scenegraph/Dialog.test.js
@@ -1,0 +1,54 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, sgRoot } = scenegraph;
+const { BrsDevice, BrsString, BrsBoolean, RoArray } = core;
+
+/** Wraps a JS string array as an RoArray of BrsString (the stringarray field shape). */
+function stringArray(values) {
+    return new RoArray(values.map((v) => new BrsString(v)));
+}
+
+/** Minimal interpreter accepted by renderNode → renderChildren (never dereferenced when draw2D is absent). */
+const fakeInterpreter = {};
+
+describe("Dialog", () => {
+    beforeAll(() => {
+        // The dialog's default fonts need the common: fonts; mount the common volume once.
+        const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+        BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+    });
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    test("closing restores focus through the real focus-chain commit, not just the live pointer", () => {
+        const scene = SGNodeFactory.createNode("Group");
+        const list = SGNodeFactory.createNode("Group");
+        list.setValue("focusable", BrsBoolean.True);
+        scene.appendChildToParent(list);
+        list.setNodeFocus(true);
+        expect(sgRoot.focused).toBe(list);
+
+        const dialog = SGNodeFactory.createNode("Dialog");
+        dialog.setValue("buttons", stringArray(["OK", "Cancel"]));
+        scene.appendChildToParent(dialog);
+
+        // Rendering lays the dialog out and grabs focus into its button row.
+        dialog.renderNode(fakeInterpreter, [0, 0], 0, 1);
+        expect(sgRoot.focused).not.toBe(list);
+
+        dialog.setValue("close", BrsBoolean.True);
+
+        expect(dialog.getValueJS("wasClosed")).toBe(true);
+        expect(sgRoot.focused).toBe(list);
+        // The chain must be properly committed (ancestor focusedChild pointers rewritten), not just
+        // the raw sgRoot.focused pointer moved. getValue (not getValueJS, which unwraps nodes into
+        // plain JS objects) preserves node identity for this comparison.
+        expect(scene.getValue("focusedChild")).toBe(list);
+        expect(list.getValue("focusedChild")).toBe(list);
+    });
+});

--- a/test/extensions/scenegraph/Focus.test.js
+++ b/test/extensions/scenegraph/Focus.test.js
@@ -109,6 +109,55 @@ describe("SceneGraph focus management", () => {
         expect(sibling.getValueJS("focusable")).toBe(true);
     });
 
+    test("honors a re-grab when the competing focus lives in a still-detached subtree", () => {
+        // Real-world shape (JellyRock's sgRouter + JRDialog): an outlet observes its own
+        // focusedChild and re-grabs focus into its routed content whenever it loses focus. A
+        // dialog overlay focuses its OWN button from a field observer (JRDialog.onButtonsChanged)
+        // BEFORE the dialog is ever appended to the scene — the same "focus set before attach"
+        // case restoreFocusChainOnAttach exists for. Staging that focus change still clears the
+        // outlet's focusedChild as a side effect (the LCA walk in setNodeFocus unsets every
+        // non-common ancestor of the previously-focused chain), firing the outlet's loss observer
+        // while the node that "stole" focus isn't even part of the same tree yet.
+        //
+        // Device-measured (real Roku): the outlet's re-grab succeeds here. Dropping it — as a
+        // same-tree "backwards steal" classifier would — corrupts the SceneGraph's focusedChild
+        // chain: the scene's own focusedChild is left cleared (pointing at nothing) instead of
+        // being re-threaded down to the re-grabbed node, because sgRoot.focused is left on a node
+        // outside the visible tree until the detached subtree is eventually mounted.
+        const scene = focusableNode();
+        const outlet = focusableNode();
+        const page = focusableNode();
+        scene.appendChildToParent(outlet);
+        outlet.appendChildToParent(page);
+
+        page.setNodeFocus(true);
+
+        const port = new RoMessagePort();
+        const originalPush = port.pushMessage.bind(port);
+        port.pushMessage = (event) => {
+            if (sgRoot.focused !== outlet && !outlet.isChildrenFocused()) {
+                // Mirrors sgrouter_onFocusChildChanged -> Home.handleFocus -> restoreHomeFocus:
+                // re-grab focus into the routed content whenever the outlet loses it.
+                page.setNodeFocus(true);
+            }
+            originalPush(event);
+        };
+        outlet.fields.get("focusedchild").addObserver("permanent", fakeInterpreter, port, outlet, focusedChildFieldArg);
+
+        // A dialog button focuses itself while the dialog is still completely unattached — never
+        // appended anywhere, unlike the "still in the same tree" steal scenario above.
+        const dialog = focusableNode();
+        const dialogButton = focusableNode();
+        dialog.appendChildToParent(dialogButton);
+
+        dialogButton.setNodeFocus(true);
+
+        // The re-grab is honored: nothing has legitimately left the outlet's tree yet.
+        expect(sgRoot.focused).toBe(page);
+        expect(scene.getValue("focusedChild")).toBe(outlet);
+        expect(outlet.getValue("focusedChild")).toBe(page);
+    });
+
     test("still honors a forward focus onto a sibling of the focused child", () => {
         // The mirror case that must keep working: a container hands focus from its first child to
         // another of its own children (how a dialog highlights a specific button). The target is a


### PR DESCRIPTION
## Summary
- `Node.isFocusRequestDropped` classified a focus request raised from a `focusedChild`-loss observer as a permanent cross-tree "backwards steal" whenever the notifying owner was no longer an ancestor of the live focus. That check breaks down when the live-focused node's own subtree isn't attached to the scene yet — e.g. a dialog focusing its own button from a field observer (`onButtonsChanged` → `focusButton`) before the dialog itself is appended to the scene. Staging that focus change still clears *unrelated* ancestors' `focusedChild` as a side effect of the normal LCA walk, firing their loss observers while nothing has actually settled elsewhere — and the classifier dropped their re-grab, stranding `sgRoot.focused` outside the visible tree with the scene's own `focusedChild` left cleared and nothing to re-thread it.
- Real-world repro: a `sgRouter`-based app whose outlet observes its own `focusedChild` and re-grabs focus into its routed content on loss — a confirm dialog's button grabbing focus pre-attach caused the outlet's re-grab to be dropped, leaving nothing focused after the dialog closed. Device-confirmed on Roku hardware that the re-grab should succeed in this shape.
- Fix: guard the classification on `owner` and `focused` sharing the same tree root before treating an ancestor mismatch as a real steal. A legitimate cross-tree steal (both sides attached, genuinely unrelated) still drops correctly — verified via the existing device-measured `focus-steal-app`/`container-redirect-focus-app` regression suite, unchanged.
- Also fixes `Dialog.ts`'s `close` handler, which restored focus via a raw `sgRoot.setFocused()` pointer write instead of the full `setNodeFocus` commit path, bypassing the `focusedChild` chain rewrite entirely.

## Test plan
- [x] `npx vitest run` — full suite, 223 files / 2934 tests, all passing
- [x] `npx vitest run test/extensions/scenegraph test/cli/cli-scenegraph.test.js` — focused re-run after final polish
- [x] New regression test: `Focus.test.js` — "honors a re-grab when the competing focus lives in a still-detached subtree" (fails without the fix, confirmed by reverting the guard)
- [x] New `Dialog.test.js` covering the `close` handler fix
- [x] Existing device-measured focus-steal tests (`focus-steal-app`, `container-redirect-focus-app`, `Focus.test.js`) unchanged and passing
- [x] `npm run lint` / `npx prettier --check` clean
- [x] Manual end-to-end probe (open → close → refocus cycle) confirming the fix and that a dialog still legitimately retains focus while open

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011URFTMR6g4D7jtq1voUueb