### PR TITLE
fix(scenegraph): DynamicKeyGrid renders key icon/focusIcon per the KDF spec

### DIFF
--- a/src/extensions/scenegraph/nodes/DynamicKeyGrid.ts
+++ b/src/extensions/scenegraph/nodes/DynamicKeyGrid.ts
@@ -19,7 +19,7 @@ import { Font } from "./Font";
 import { sgRoot } from "../SGRoot";
 import { sgClock } from "../SGClock";
 import { jsValueOf } from "../factory/Serializer";
-import { computeLayout, KeyInset, keyboardSize, KeyLayout, RenderedKey, resolveKeyIcon } from "./kdf/KeyDefinition";
+import { computeLayout, KeyInset, keyboardSize, KeyLayout, RenderedKey } from "./kdf/KeyDefinition";
 
 /**
  * Default keyboard palette colors used when no RSGPalette is found in the scene graph (the gray
@@ -79,9 +79,10 @@ export class DynamicKeyGrid extends Group {
     private bmpBackground?: RoBitmap;
     private inset: KeyInset = { top: 0, right: 0, bottom: 0, left: 0 };
     private readonly keyFocusDelta: number;
+    // Bundled special-key icon assets, shared with the legacy Keyboard/MiniKeyboard/PinPad nodes
+    // and addressed from a KDF's `icon`/`focusIcon` via a `theme:` URI (see resolveIcon()).
     private readonly bmpIcons = new Map<string, RoBitmap>();
 
-    // The special-key icon assets shared with the legacy Keyboard/MiniKeyboard/PinPad nodes.
     private static readonly ICON_NAMES = [
         "shift",
         "space",
@@ -98,6 +99,48 @@ export class DynamicKeyGrid extends Group {
         "accent_on",
         "accent_off",
     ];
+
+    /**
+     * Maps Roku's own documented `theme:` bitmap identifiers for the Dynamic keyboards (as used
+     * by the reference KDF examples and real device KDFs, e.g. Roku's dynamic-voice-enabled-
+     * keyboards sample app) to this engine's bundled substitute icon (`ICON_NAMES`/`bmpIcons`).
+     * The engine doesn't ship Roku's actual system theme bitmaps, so both the base and "Focus"/
+     * "Off" variant of a given key resolve to the same bundled asset — built from each family's
+     * base name list rather than spelled out pairwise, so that invariant holds by construction.
+     */
+    private static readonly THEME_ICON_ALIASES: Record<string, string> = (() => {
+        const aliases: Record<string, string> = {};
+        const dkbBases: [string, string][] = [
+            ["Shift", "shift"],
+            ["Space", "space"],
+            ["Delete", "delete"],
+            ["Clear", "clear"],
+            ["Left", "moveCursorLeft"],
+            ["Right", "moveCursorRight"],
+            ["CapsModOff", "caps_off"],
+            ["CapsModOn", "caps_on"],
+            ["ABC123ModOff", "alphanum_off"],
+            ["ABC123ModOn", "alphanum_on"],
+            ["SymbolsModOff", "symbols_off"],
+            ["SymbolsModOn", "symbols_on"],
+            ["AccentsModOff", "accent_off"],
+            ["AccentsModOn", "accent_on"],
+        ];
+        for (const [base, name] of dkbBases) {
+            aliases[`DKB_${base}KeyBitmap`] = name;
+            aliases[`DKB_${base}KeyFocusBitmap`] = name;
+        }
+        const keyboardBases: [string, string][] = [
+            ["Space", "space"],
+            ["Delete", "delete"],
+            ["Clear", "clear"],
+        ];
+        for (const [base, name] of keyboardBases) {
+            aliases[`Keyboard${base}OnBitmap`] = name;
+            aliases[`Keyboard${base}OffBitmap`] = name;
+        }
+        return aliases;
+    })();
 
     private readonly hoverDelay = 800; // ms the focus must dwell on a key before its "hover" pop-up opens
 
@@ -529,8 +572,7 @@ export class DynamicKeyGrid extends Group {
 
         for (let i = 0; i < this.renderedKeys.length; i++) {
             const key = this.renderedKeys[i];
-            const hasContent = key.label.length > 0 || (key.icon ?? "").length > 0;
-            if (!hasContent) {
+            if (!key.hasContent) {
                 continue;
             }
             const disabled = !key.focusable || this.disabledSet.has(key.out);
@@ -557,7 +599,7 @@ export class DynamicKeyGrid extends Group {
                 this.drawImage(this.bmpFocus, focusRect, 0, opacity, draw2D, focusColor);
             }
             const color = disabled ? secondary : focused ? focusItem : primary;
-            this.renderKeyContent(key, keyRect, color, opacity, i, draw2D);
+            this.renderKeyContent(key, keyRect, color, opacity, i, focused, draw2D);
         }
 
         if (this.popup) {
@@ -570,37 +612,21 @@ export class DynamicKeyGrid extends Group {
     }
 
     /**
-     * Maps a key's strOut to a legacy icon asset name, honoring the current mode for
-     * the on/off toggle keys (caps/alphanum/symbols/accents), matching the legacy Keyboard.
+     * Resolves a key's `icon`/`focusIcon` URI to a bitmap. A `theme:<name>` URI names one of
+     * Roku's own built-in Dynamic Keyboard theme bitmaps (`THEME_ICON_ALIASES`), mapped to this
+     * node's bundled substitute asset (`bmpIcons`) since the engine doesn't ship Roku's actual
+     * theme graphics; any other URI (`pkg:/`, `common:/`, ...) is loaded generically, exactly
+     * like a custom KDF's own package image.
      */
-    private iconAssetFor(strOut: string): string | undefined {
-        const mode = this.mode;
-        const upper = mode.endsWith("Upper") || mode.endsWith("Shift");
-        const base = mode.startsWith("Symbols") ? "Symbols" : mode.startsWith("Accents") ? "Accents" : "ABC123";
-        switch (strOut.toLowerCase()) {
-            case "shift":
-                return "shift";
-            case "space":
-                return "space";
-            case "backspace":
-                return "delete";
-            case "clear":
-                return "clear";
-            case "left":
-                return "moveCursorLeft";
-            case "right":
-                return "moveCursorRight";
-            case "capslock":
-                return upper ? "caps_on" : "caps_off";
-            case "abc123":
-                return base === "ABC123" ? "alphanum_on" : "alphanum_off";
-            case "symbols":
-                return base === "Symbols" ? "symbols_on" : "symbols_off";
-            case "accents":
-                return base === "Accents" ? "accent_on" : "accent_off";
-            default:
-                return undefined;
+    private resolveIcon(uri?: string): RoBitmap | undefined {
+        if (!uri) {
+            return undefined;
         }
+        if (uri.startsWith("theme:")) {
+            const alias = DynamicKeyGrid.THEME_ICON_ALIASES[uri.slice("theme:".length)];
+            return alias ? this.bmpIcons.get(alias) : undefined;
+        }
+        return this.loadBitmap(uri);
     }
 
     private renderKeyContent(
@@ -609,32 +635,20 @@ export class DynamicKeyGrid extends Group {
         color: number,
         opacity: number,
         index: number,
+        focused: boolean,
         draw2D?: IfDraw2D
     ) {
-        // Icon keys: prefer the legacy bitmap asset (drawn at natural size), else a glyph.
-        if (key.strOut.length > 0 && key.label.length === 0) {
-            const iconName = this.iconAssetFor(key.strOut);
-            const bmp = iconName ? this.bmpIcons.get(iconName) : undefined;
-            if (bmp?.isValid()) {
-                const iconX = rect.x + Math.floor((rect.width - bmp.width) / 2);
-                const iconY = rect.y + Math.floor((rect.height - bmp.height) / 2);
-                this.drawImage(
-                    bmp,
-                    { x: iconX, y: iconY, width: bmp.width, height: bmp.height },
-                    0,
-                    opacity,
-                    draw2D,
-                    color
-                );
-                return;
-            }
-            const glyph = resolveKeyIcon(key.strOut)?.glyph ?? key.strOut;
-            this.drawText(glyph, this.font, color, opacity, rect, "center", "center", 0, draw2D, "", index);
-            return;
-        }
         if (key.label.length > 0) {
             this.drawText(key.label, this.font, color, opacity, rect, "center", "center", 0, draw2D, "", index);
+            return;
         }
+        const bmp = (focused && this.resolveIcon(key.focusIcon)) || this.resolveIcon(key.icon);
+        if (!bmp?.isValid()) {
+            return; // No label, no resolvable icon: draw nothing, matching the spec's blank key.
+        }
+        const iconX = rect.x + Math.floor((rect.width - bmp.width) / 2);
+        const iconY = rect.y + Math.floor((rect.height - bmp.height) / 2);
+        this.drawImage(bmp, { x: iconX, y: iconY, width: bmp.width, height: bmp.height }, 0, opacity, draw2D, color);
     }
 
     private renderPopup(

--- a/src/extensions/scenegraph/nodes/kdf/KeyDefinition.ts
+++ b/src/extensions/scenegraph/nodes/kdf/KeyDefinition.ts
@@ -17,9 +17,13 @@ export interface KeySuggestions {
 export interface KeyDef {
     keyWidthFHD?: number;
     keyWidthHD?: number;
+    /** Text drawn on the key (mutually exclusive with `icon`, per spec). */
     label?: string;
+    /** Bitmap URI drawn on the key when there is no `label`. */
     icon?: string;
+    /** Bitmap URI drawn instead of `icon` while the key is focused. */
     focusIcon?: string;
+    /** String emitted to keyFocused/keySelected; falls back to `label` when unset. */
     strOut?: string;
     autoRepeat?: number;
     disabled?: number;
@@ -64,7 +68,9 @@ export interface RenderedKey {
     width: number;
     height: number;
     label: string;
+    /** Bitmap URI to draw when the key has no label (mutually exclusive with `label`, per spec). */
     icon?: string;
+    /** Bitmap URI to draw instead of `icon` while the key is focused. */
     focusIcon?: string;
     /** The value emitted via keyFocused/keySelected: strOut when set, otherwise label. */
     out: string;
@@ -73,6 +79,8 @@ export interface RenderedKey {
     disabled: boolean;
     autoRepeat: boolean;
     suggestions?: KeySuggestions;
+    /** Whether the key has a label or an icon/focusIcon to draw (false for a blank spacer key). */
+    hasContent: boolean;
     /** Whether the key can receive focus (false for blank keys and disabled keys). */
     focusable: boolean;
 }
@@ -205,7 +213,8 @@ export function computeLayout(
                     const keyWidth = keyWidths[c];
                     const label = key.label ?? "";
                     const strOut = key.strOut ?? "";
-                    const hasContent = label.length > 0 || (key.icon ?? "").length > 0;
+                    const hasContent =
+                        label.length > 0 || (key.icon ?? "").length > 0 || (key.focusIcon ?? "").length > 0;
                     const disabled = (key.disabled ?? 0) !== 0;
                     rendered.push({
                         section: s,
@@ -223,6 +232,7 @@ export function computeLayout(
                         disabled,
                         autoRepeat: (key.autoRepeat ?? 0) !== 0,
                         suggestions: key.suggestions,
+                        hasContent,
                         focusable: hasContent && !disabled,
                     });
                     keyX += keyWidth;
@@ -233,43 +243,4 @@ export function computeLayout(
         sectionX += sectionWidth + gap;
     }
     return rendered;
-}
-
-/** Resolution-independent icon mapping for a special key, keyed by its strOut. */
-export interface SpecialKeyIcon {
-    /** Base name of an existing `common:/images/{res}/icon_<name>.png` asset, if any. */
-    iconName?: "clear" | "delete" | "space";
-    /** Short text glyph drawn when no bitmap asset is available. */
-    glyph: string;
-}
-
-/**
- * Maps a key's `strOut` to an icon asset and/or a text-glyph fallback. Only the
- * clear/space/delete icons ship in `common.zip`; everything else is a glyph.
- */
-export function resolveKeyIcon(strOut: string): SpecialKeyIcon | undefined {
-    switch (strOut.toLowerCase()) {
-        case "clear":
-            return { iconName: "clear", glyph: "clear" };
-        case "backspace":
-            return { iconName: "delete", glyph: "⌫" }; // ⌫
-        case "space":
-            return { iconName: "space", glyph: "␣" }; // ␣
-        case "shift":
-            return { glyph: "⇧" }; // ⇧
-        case "left":
-            return { glyph: "◄" }; // ◄
-        case "right":
-            return { glyph: "►" }; // ►
-        case "capslock":
-            return { glyph: "⇪" }; // ⇪
-        case "abc123":
-            return { glyph: "ABC" };
-        case "symbols":
-            return { glyph: "#+=" };
-        case "accents":
-            return { glyph: "àé" }; // àé
-        default:
-            return undefined;
-    }
 }

--- a/src/extensions/scenegraph/nodes/kdf/builtinKDFs.ts
+++ b/src/extensions/scenegraph/nodes/kdf/builtinKDFs.ts
@@ -2,9 +2,11 @@
  * Built-in Key Definition Files for the fixed-layout Dynamic keyboards.
  *
  * Transcribed from the Roku reference KDF examples
- * (`scenegraph/dynamic-voice-keyboard-nodes/key-definition-file.md`). The `icon`
- * fields are kept for fidelity, but the renderer resolves special-key visuals from
- * each key's `strOut` (see `resolveKeyIcon` in `KeyDefinition.ts`).
+ * (`scenegraph/dynamic-voice-keyboard-nodes/key-definition-file.md`), including its `theme:*`
+ * icon identifiers verbatim — the same ones real device KDFs use (e.g. Roku's own
+ * dynamic-voice-enabled-keyboards sample app). The engine maps each to a bundled substitute
+ * bitmap (`DynamicKeyGrid.THEME_ICON_ALIASES`/`resolveIcon()`) since it doesn't ship Roku's
+ * actual system theme graphics.
  */
 import { KeyLayout } from "./KeyDefinition";
 
@@ -68,6 +70,25 @@ export const dynamicMiniKeyboardKDF: KeyLayout = {
 const lblRow = (chars: string) => ({ keys: chars.split("").map((label) => ({ label })) });
 // Same, but from an explicit array (for rows containing quotes/backslashes).
 const rowOf = (labels: string[]) => ({ keys: labels.map((label) => ({ label })) });
+// A mode-toggle sidebar key (caps/abc123/symbols/accents), themed with Roku's DKB_*Mod{On,Off}
+// icon pair for the given on/off state.
+const modKey = (base: string, on: boolean, strOut: string) => {
+    const state = on ? "On" : "Off";
+    return {
+        icon: `theme:DKB_${base}Mod${state}KeyBitmap`,
+        focusIcon: `theme:DKB_${base}Mod${state}KeyFocusBitmap`,
+        strOut,
+    };
+};
+// The four mode-toggle sidebar rows (caps / abc123 / symbols / accents) for one mode-group grid:
+// `caps` is the caps-lock state and `active` names which of the three character sets is showing
+// (so its icon is "on" and the other two are "off").
+const sidebarRows = (caps: boolean, active: "ABC123" | "Symbols" | "Accents") => [
+    { keys: [modKey("Caps", caps, "capslock")] },
+    { keys: [modKey("ABC123", active === "ABC123", "abc123")] },
+    { keys: [modKey("Symbols", active === "Symbols", "symbols")] },
+    { keys: [modKey("Accents", active === "Accents", "accents")] },
+];
 
 /**
  * DynamicKeyboard — full WiFi-style keyboard matching the legacy Keyboard layout.
@@ -87,13 +108,29 @@ export const dynamicKeyboardKDF: KeyLayout = {
             grids: [
                 {
                     rows: [
-                        { keys: [{ icon: "theme:DKB_ShiftKeyBitmap", strOut: "shift" }] },
+                        {
+                            keys: [
+                                {
+                                    icon: "theme:DKB_ShiftKeyBitmap",
+                                    focusIcon: "theme:DKB_ShiftKeyFocusBitmap",
+                                    strOut: "shift",
+                                },
+                            ],
+                        },
                         { keys: [spaceKey] },
                         { keys: [deleteKey] },
                         {
                             keys: [
-                                { icon: "theme:DKB_LeftKeyBitmap", strOut: "left" },
-                                { icon: "theme:DKB_RightKeyBitmap", strOut: "right" },
+                                {
+                                    icon: "theme:DKB_LeftKeyBitmap",
+                                    focusIcon: "theme:DKB_LeftKeyFocusBitmap",
+                                    strOut: "left",
+                                },
+                                {
+                                    icon: "theme:DKB_RightKeyBitmap",
+                                    focusIcon: "theme:DKB_RightKeyFocusBitmap",
+                                    strOut: "right",
+                                },
                             ],
                         },
                     ],
@@ -184,29 +221,19 @@ export const dynamicKeyboardKDF: KeyLayout = {
                 },
             ],
         },
-        // Section 4: mode-toggle sidebar (caps / abc123 / symbols / accents).
+        // Section 4: mode-toggle sidebar (caps / abc123 / symbols / accents). Each grid's icons
+        // reflect that mode's on/off state directly (one grid per mode group, matching Roku's
+        // WiFi-keyboard reference KDF sample), so the renderer needs no mode-aware icon logic.
         {
             sectionWidthFHD: 181,
             sectionWidthHD: 120,
             grids: [
-                {
-                    modes: ["ABC123Lower", "ABC123Shift", "SymbolsLower", "AccentsLower"],
-                    rows: [
-                        { keys: [{ icon: "theme:DKB_CapsModOffKeyBitmap", strOut: "capslock" }] },
-                        { keys: [{ icon: "theme:DKB_ABC123ModKeyBitmap", strOut: "abc123" }] },
-                        { keys: [{ icon: "theme:DKB_SymbolsModKeyBitmap", strOut: "symbols" }] },
-                        { keys: [{ icon: "theme:DKB_AccentsModKeyBitmap", strOut: "accents" }] },
-                    ],
-                },
-                {
-                    modes: ["ABC123Upper", "SymbolsUpper", "AccentsUpper"],
-                    rows: [
-                        { keys: [{ icon: "theme:DKB_CapsModOnKeyBitmap", strOut: "capslock" }] },
-                        { keys: [{ icon: "theme:DKB_ABC123ModKeyBitmap", strOut: "abc123" }] },
-                        { keys: [{ icon: "theme:DKB_SymbolsModKeyBitmap", strOut: "symbols" }] },
-                        { keys: [{ icon: "theme:DKB_AccentsModKeyBitmap", strOut: "accents" }] },
-                    ],
-                },
+                { modes: ["ABC123Lower", "ABC123Shift"], rows: sidebarRows(false, "ABC123") },
+                { modes: "ABC123Upper", rows: sidebarRows(true, "ABC123") },
+                { modes: ["SymbolsLower", "SymbolsShift"], rows: sidebarRows(false, "Symbols") },
+                { modes: "SymbolsUpper", rows: sidebarRows(true, "Symbols") },
+                { modes: ["AccentsLower", "AccentsShift"], rows: sidebarRows(false, "Accents") },
+                { modes: "AccentsUpper", rows: sidebarRows(true, "Accents") },
             ],
         },
     ],

--- a/test/extensions/scenegraph/DynamicKeyboard.test.js
+++ b/test/extensions/scenegraph/DynamicKeyboard.test.js
@@ -500,22 +500,30 @@ describe("Dynamic voice keyboards", () => {
             });
         }
 
-        // Captures the URIs of every bitmap drawn during a render.
-        function drawnImageNames(node) {
+        // Builds a draw2D stub that records the URIs of every bitmap drawn through it.
+        function makeCaptureDraw2D() {
             const names = [];
             const record = (...args) => {
                 const bmp = args.find((a) => a && typeof a.getImageName === "function");
                 if (bmp) names.push(bmp.getImageName());
             };
-            const capture = {
-                doDrawRotatedText() {},
-                doDrawRotatedRect() {},
-                doDrawScaledObject: record,
-                doDrawRotatedBitmap: record,
-                drawNinePatch: record,
+            return {
+                names,
+                draw2D: {
+                    doDrawRotatedText() {},
+                    doDrawRotatedRect() {},
+                    doDrawScaledObject: record,
+                    doDrawRotatedBitmap: record,
+                    drawNinePatch: record,
+                },
             };
+        }
+
+        // Captures the URIs of every bitmap drawn while rendering `node` as the focused node.
+        function drawnImageNames(node) {
+            const { names, draw2D } = makeCaptureDraw2D();
             sgRoot.setFocused(node);
-            node.renderNode(fakeInterpreter, [0, 0], 0, 1, capture);
+            node.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D);
             return names;
         }
 
@@ -608,6 +616,144 @@ describe("Dynamic voice keyboards", () => {
         test("DynamicCustomKeyboard draws no keyboard background until a KDF is set", () => {
             const names = drawnImageNames(SGNodeFactory.createNode("DynamicCustomKeyboard"));
             expect(names.some((n) => n.includes("keyboard_"))).toBe(false);
+        });
+
+        describe("per-key icon/focusIcon (Key Definition File spec)", () => {
+            const KDF_URI = "pkg:/resources/keyboards/custom.json";
+
+            // A single-row, single-grid KDF holding exactly `keys`, sized to (w, h) at both
+            // resolutions — the minimal shape every test below needs.
+            function customKDF(keys, w = 100, h = 100) {
+                return JSON.stringify({
+                    keyboardWidthFHD: w,
+                    keyboardHeightFHD: h,
+                    keyboardWidthHD: w,
+                    keyboardHeightHD: h,
+                    sections: [{ grids: [{ rows: [{ keys }] }] }],
+                });
+            }
+
+            afterEach(() => {
+                BrsDevice.fileSystem.clearSourceOverlay();
+            });
+
+            // A labelless key with a real "icon" URI (not the "theme:" special-key convention)
+            // must draw that bitmap, per the DynamicCustomKeyboard spec's own worked example
+            // ({ "icon": "pkg:/images/Duplicate.png", "strOut": "DuplicateCharacter" }): the icon
+            // is the source of what's drawn, decoupled from strOut.
+            test("a custom KDF's icon URI is drawn, independent of strOut", () => {
+                BrsDevice.fileSystem.setSourceOverlay({
+                    [KDF_URI]: customKDF([{ icon: "common:/images/icon_options.png", strOut: "DuplicateCharacter" }]),
+                });
+                const kbd = SGNodeFactory.createNode("DynamicCustomKeyboard");
+                kbd.keyGrid.setValue("keyDefinitionUri", new BrsString(KDF_URI));
+                const names = drawnImageNames(kbd);
+                expect(names).toContain("common:/images/icon_options.png");
+            });
+
+            // Real device KDFs (including Roku's own dynamic-voice-enabled-keyboards sample app,
+            // e.g. its CustomAddressKDF.json) reference Roku's documented `theme:DKB_*Bitmap` and
+            // `theme:Keyboard*On/OffBitmap` identifiers directly. The engine doesn't ship Roku's
+            // actual system theme graphics, so these must resolve to the bundled substitute icons
+            // instead of silently drawing nothing.
+            test("Roku's documented theme: bitmap identifiers resolve to the bundled substitute icons", () => {
+                BrsDevice.fileSystem.setSourceOverlay({
+                    [KDF_URI]: customKDF(
+                        [
+                            {
+                                icon: "theme:DKB_SpaceKeyBitmap",
+                                focusIcon: "theme:DKB_SpaceKeyFocusBitmap",
+                                strOut: "Space",
+                            },
+                            {
+                                icon: "theme:KeyboardDeleteOnBitmap",
+                                focusIcon: "theme:KeyboardDeleteOffBitmap",
+                                strOut: "Delete",
+                            },
+                            { icon: "theme:UnknownFutureBitmap", strOut: "Unmapped" },
+                        ],
+                        300
+                    ),
+                });
+                const kbd = SGNodeFactory.createNode("DynamicCustomKeyboard");
+                kbd.keyGrid.setValue("keyDefinitionUri", new BrsString(KDF_URI));
+                const names = drawnImageNames(kbd);
+                expect(names.some((n) => n.includes("icon_space"))).toBe(true);
+                expect(names.some((n) => n.includes("icon_delete"))).toBe(true);
+                // An unrecognized theme identifier draws nothing (spec's blank-key behavior),
+                // rather than throwing.
+                expect(() => kbd.renderNode(fakeInterpreter, [0, 0], 0, 1, draw2D)).not.toThrow();
+            });
+
+            // Per the KDF spec's Row.keys description, a key is focusable as long as it has
+            // "either a label field or an icon/focusIcon field" — a key with only `focusIcon`
+            // (no `label`, no `icon`) must still be focusable and still draw something once
+            // focused.
+            test("a key with only focusIcon (no icon, no label) is still focusable and drawn", () => {
+                BrsDevice.fileSystem.setSourceOverlay({
+                    [KDF_URI]: customKDF([
+                        { focusIcon: "common:/images/icon_options_off.png", strOut: "OnlyFocusIcon" },
+                    ]),
+                });
+                const grid = SGNodeFactory.createNode("DynamicKeyGrid");
+                grid.setValue("keyDefinitionUri", new BrsString(KDF_URI));
+                expect(grid.getValueJS("keyFocused")).toBe("OnlyFocusIcon");
+                sgRoot.setFocused(grid);
+                const names = drawnImageNames(grid);
+                expect(names).toContain("common:/images/icon_options_off.png");
+            });
+
+            test("focusIcon is drawn only while the key has focus; icon is drawn otherwise", () => {
+                BrsDevice.fileSystem.setSourceOverlay({
+                    [KDF_URI]: customKDF([
+                        {
+                            icon: "common:/images/icon_options.png",
+                            focusIcon: "common:/images/icon_options_off.png",
+                            strOut: "Toggle",
+                        },
+                    ]),
+                });
+                const grid = SGNodeFactory.createNode("DynamicKeyGrid");
+                grid.setValue("keyDefinitionUri", new BrsString(KDF_URI));
+
+                // Not focused (the outer afterEach clears sgRoot's focus): icon only.
+                const unfocused = makeCaptureDraw2D();
+                grid.renderNode(fakeInterpreter, [0, 0], 0, 1, unfocused.draw2D);
+                expect(unfocused.names).toContain("common:/images/icon_options.png");
+                expect(unfocused.names).not.toContain("common:/images/icon_options_off.png");
+
+                // Focused: focusIcon takes over from icon.
+                sgRoot.setFocused(grid);
+                const focused = makeCaptureDraw2D();
+                grid.renderNode(fakeInterpreter, [0, 0], 0, 1, focused.draw2D);
+                expect(focused.names).toContain("common:/images/icon_options_off.png");
+                expect(focused.names).not.toContain("common:/images/icon_options.png");
+            });
+        });
+
+        describe("built-in keyboard mode-toggle icons", () => {
+            test("DynamicKeyboard draws the on/off icon matching the active mode", () => {
+                const kbd = SGNodeFactory.createNode("DynamicKeyboard");
+                sgRoot.setFocused(kbd);
+                let names = drawnImageNames(kbd);
+                expect(names.some((n) => n.includes("icon_caps_off"))).toBe(true);
+                expect(names.some((n) => n.includes("icon_alphanum_on"))).toBe(true);
+                expect(names.some((n) => n.includes("icon_caps_on"))).toBe(false);
+
+                kbd.keyGrid.setValue("jumpToKey", coords(3, 0, 0)); // capslock toggle (section 4)
+                kbd.handleKey("OK", true);
+                expect(kbd.keyGrid.getValueJS("mode")).toBe("ABC123Upper");
+                names = drawnImageNames(kbd);
+                expect(names.some((n) => n.includes("icon_caps_on"))).toBe(true);
+                expect(names.some((n) => n.includes("icon_caps_off"))).toBe(false);
+
+                kbd.keyGrid.setValue("jumpToKey", coords(3, 2, 0)); // symbols toggle
+                kbd.handleKey("OK", true);
+                expect(kbd.keyGrid.getValueJS("mode")).toBe("SymbolsUpper");
+                names = drawnImageNames(kbd);
+                expect(names.some((n) => n.includes("icon_symbols_on"))).toBe(true);
+                expect(names.some((n) => n.includes("icon_alphanum_on"))).toBe(false);
+            });
         });
 
         test("DynamicPinPad renders entered digits as underline slots", () => {


### PR DESCRIPTION
## Summary
- `DynamicKeyGrid` decided a key's icon by pattern-matching `strOut` (a hardcoded `iconAssetFor`/`resolveKeyIcon` switch) instead of reading the Key Definition File's own `icon`/`focusIcon` bitmap-URI fields, so any KDF-declared icon — a custom `pkg:/images/...png`, or Roku's documented `theme:DKB_*`/`theme:Keyboard*On/OffBitmap` identifiers used by real device KDFs (verified against Roku's own `dynamic-voice-enabled-keyboards` sample app) — was silently dropped.
- Rendering now decides label-vs-icon by field presence per spec, and resolves `icon`/`focusIcon` through a new `resolveIcon()`: a real URI loads generically via the existing `loadBitmap()`/`RoTextureManager` cache; a `theme:` URI maps to the engine's bundled substitute icon via a `THEME_ICON_ALIASES` table (the engine doesn't ship Roku's actual system theme graphics).
- The built-in keyboards' mode-toggle sidebar KDF is now 6 explicit per-mode grids (matching Roku's own reference KDF sample) instead of mode-inspecting code in the renderer.
- `hasContent`/`focusable` now also account for a `focusIcon`-only key (no `label`, no `icon`), computed once on `RenderedKey` instead of duplicated in two files.

## Test plan
- [x] `npx vitest run test/extensions/scenegraph/DynamicKeyboard.test.js` — 64 tests pass, including new coverage for a custom `pkg:/` icon, Roku's documented `theme:` identifiers, a `focusIcon`-only key, and `focusIcon` swapping on focus.
- [x] `npm test` — full suite (223 files / 2939 tests) passes.
- [x] `npm run lint` / `npm run prettier:write` clean.
- [x] Manually verified against the real `CustomAddressKDF.json` from Roku's `dynamic-voice-enabled-keyboards` sample app — space/delete/clear icons now render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011URFTMR6g4D7jtq1voUueb