### PR TITLE
feat(scenegraph): Add ArrayGrid.focusFeedbackPoster field for customizing the focus indicator

### DIFF
--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -740,7 +740,7 @@ export class ArrayGrid extends Group {
         const frameRect = this.focusFrameRect(itemRect, bmp, index);
         // Dry run (no draw target, so every draw2D call inside is skipped) purely to resolve
         // frameRect's final width/height the same way a real draw would — see the ALIASING note above.
-        this.drawImage(bmp, frameRect, 0, opacity, undefined, undefined);
+        this.drawImage(bmp, frameRect, 0, opacity);
         // Read the field fresh rather than a cached property — see `setValue`'s `focusfeedbackposter`
         // branch for why.
         const poster = this.getValue("focusFeedbackPoster");

--- a/src/extensions/scenegraph/nodes/ArrayGrid.ts
+++ b/src/extensions/scenegraph/nodes/ArrayGrid.ts
@@ -17,8 +17,7 @@ import { Poster, SGNodeType } from ".";
 import { Group } from "./Group";
 import { Node } from "./Node";
 import { Field } from "./Field";
-import { createNode } from "../factory/NodeFactory";
-import { normalizeBlendColor } from "../SGUtil";
+import { createNode, SGNodeFactory } from "../factory/NodeFactory";
 import { brsValueOf, jsValueOf } from "../factory/Serializer";
 import { sgRoot } from "../SGRoot";
 import { ContentNode } from "./ContentNode";
@@ -64,6 +63,13 @@ export declare namespace ArrayGrid {
     };
 }
 
+/**
+ * Stand-in for `focusFeedbackPoster.renderNode`'s interpreter param when `sgRoot.interpreter` is not
+ * yet registered (a direct-render unit test that never calls `sgRoot.setInterpreter`). Safe because
+ * that param only ever reaches `renderChildren`, and this poster is never given scenegraph children.
+ */
+const noopInterpreter = {} as Interpreter;
+
 export class ArrayGrid extends Group {
     readonly defaultFields: FieldModel[] = [
         { name: "content", type: "node" },
@@ -83,6 +89,7 @@ export class ArrayGrid extends Group {
         { name: "focusFootprintBitmapUri", type: "string", value: "" },
         { name: "focusBitmapBlendColor", type: "color", value: "0xFFFFFFFF" },
         { name: "focusFootprintBlendColor", type: "color", value: "0xFFFFFFFF" },
+        { name: "focusFeedbackPoster", type: "node" }, // Introduced in OS 16.0
         { name: "wrapDividerBitmapUri", type: "string", value: "" },
         { name: "wrapDividerWidth", type: "float", value: "0" },
         { name: "wrapDividerHeight", type: "float", value: "36" },
@@ -191,6 +198,9 @@ export class ArrayGrid extends Group {
         this.setValueSilent("wrapDividerBitmapUri", new BrsString(this.dividerUri));
         this.setValueSilent("sectionDividerBitmapUri", new BrsString(this.dividerUri));
         this.setValueSilent("focusFootprintBitmapUri", new BrsString(this.footprintUri));
+        const focusFeedbackPoster = SGNodeFactory.createNode(SGNodeType.Poster) as Poster;
+        focusFeedbackPoster.setNodeParent(this);
+        this.setValueSilent("focusFeedbackPoster", focusFeedbackPoster);
         this.applyVertFocusStyle();
         this.applyHorizFocusStyle();
         this.lastPressHandled = "";
@@ -208,6 +218,15 @@ export class ArrayGrid extends Group {
             return;
         } else if (["jumptoitem", "animatetoitem"].includes(fieldName) && isNumberComp(value)) {
             this.setFocusedItem(jsValueOf(value));
+        } else if (fieldName === "focusfeedbackposter") {
+            // Must stay a Poster (matches BusySpinner's `poster` field). No private cache is kept for
+            // it — `renderFocus` re-reads the field every draw, because `Node.cloneNode` aliases a
+            // node-valued field onto the SAME node while still re-running this constructor, which
+            // would desync a cache from the field the moment a grid is cloned.
+            if (!(value instanceof Poster)) {
+                return;
+            }
+            value.setNodeParent(this);
         } else if (fieldName === "vertfocusanimationstyle" && isBrsString(value)) {
             const style = resolveFocusStyle(value.toString());
             if (style) {
@@ -705,7 +724,10 @@ export class ArrayGrid extends Group {
      *
      * TEMPLATE METHOD — override `focusFrameRect`, never this. Everything here is shared contract: the
      * uri and blend field the focus state selects, the validity guard, the `hasNinePatch` write that
-     * `rectMargins()` reads, and the `drawImage` call.
+     * `rectMargins()` reads, and the draw itself — via `focusFeedbackPoster` (Roku OS 16.0), the Poster
+     * node this grid uses to draw its focus indicator, so an app-assigned `effect` on it (rounded/
+     * asymmetric corners matching a custom item shape) is honored through `Poster.renderNodeContent`'s
+     * own `applyNodeEffect` call.
      */
     protected renderFocus(itemRect: Rect, opacity: number, nodeFocus: boolean, draw2D?: IfDraw2D, index = -1) {
         const bmpUri = nodeFocus ? "focusBitmapUri" : "focusFootprintBitmapUri";
@@ -715,8 +737,21 @@ export class ArrayGrid extends Group {
             return;
         }
         this.hasNinePatch = bmp.ninePatch;
-        const blendColor = normalizeBlendColor(this.getValueJS(blendField));
-        this.drawImage(bmp, this.focusFrameRect(itemRect, bmp, index), 0, opacity, draw2D, blendColor);
+        const frameRect = this.focusFrameRect(itemRect, bmp, index);
+        // Dry run (no draw target, so every draw2D call inside is skipped) purely to resolve
+        // frameRect's final width/height the same way a real draw would — see the ALIASING note above.
+        this.drawImage(bmp, frameRect, 0, opacity, undefined, undefined);
+        // Read the field fresh rather than a cached property — see `setValue`'s `focusfeedbackposter`
+        // branch for why.
+        const poster = this.getValue("focusFeedbackPoster");
+        if (!(poster instanceof Poster)) {
+            return;
+        }
+        this.copyField(poster, "uri", bmpUri);
+        this.copyField(poster, "blendColor", blendField);
+        poster.setValue("width", new Float(frameRect.width), false);
+        poster.setValue("height", new Float(frameRect.height), false);
+        poster.renderNode(sgRoot.interpreter ?? noopInterpreter, [frameRect.x, frameRect.y], 0, opacity, draw2D);
     }
 
     /**

--- a/test/extensions/scenegraph/GridFocusFeedbackEffect.test.js
+++ b/test/extensions/scenegraph/GridFocusFeedbackEffect.test.js
@@ -1,0 +1,104 @@
+const fs = require("fs");
+const path = require("path");
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory, Poster, sgRoot } = scenegraph;
+const { BrsDevice, BrsString, Float, Int32, IfDraw2D, RoArray, RoAssociativeArray, RoBitmap } = core;
+
+/** Mounts the common: volume (fonts, 9-patch/plain images) that Poster loads its bitmaps from. */
+function mountCommonVolume() {
+    const commonZip = fs.readFileSync(path.join(__dirname, "../../../packages/scenegraph/assets/common.zip"));
+    BrsDevice.fileSystem.setup(commonZip.buffer, new ArrayBuffer(1024 * 1024), new ArrayBuffer(1024 * 1024));
+}
+
+function scratchBitmap(size = 40) {
+    const fields = [
+        { name: new BrsString("width"), value: new Int32(size) },
+        { name: new BrsString("height"), value: new Int32(size) },
+    ];
+    return new RoBitmap(new RoAssociativeArray(fields));
+}
+
+/**
+ * Roku OS 16.0: the Poster ArrayGrid draws its focus indicator with is now a public
+ * `focusFeedbackPoster` field, so an app can apply an Effect (rounded/asymmetric corners) to it —
+ * see the release notes example under `external/dev-doc/docs/DEVELOPER/release-notes/index.md`.
+ */
+describe("ArrayGrid.focusFeedbackPoster (Roku OS 16.0)", () => {
+    beforeAll(mountCommonVolume);
+
+    afterEach(() => {
+        sgRoot.setFocused();
+    });
+
+    test("defaults to a real Poster instance, not invalid, matching a device using it internally already", () => {
+        const grid = SGNodeFactory.createNode("MarkupGrid");
+        expect(grid.getValue("focusFeedbackPoster")).toBeInstanceOf(Poster);
+    });
+
+    test("an Effect assigned to focusFeedbackPoster rounds the drawn focus indicator's corners", () => {
+        const grid = SGNodeFactory.createNode("MarkupGrid");
+        // A plain (non-9-patch) bitmap: drawNinePatch bypasses none of the rounded clip, but a plain
+        // scaled draw exercises the same `applyNodeEffect` path Poster/Rectangle already use.
+        grid.setValue("focusBitmapUri", new BrsString("common:/images/icon_options.png"));
+        const effect = SGNodeFactory.createNode("Effect");
+        effect.setValue("borderRadius", new RoArray([new Float(18)]));
+        grid.getValue("focusFeedbackPoster").setValue("effect", effect);
+
+        const target = scratchBitmap(40);
+        const draw2D = new IfDraw2D(target);
+        grid.renderFocus({ x: 0, y: 0, width: 40, height: 40 }, 1, true, draw2D);
+
+        const corner = Array.from(target.getContext().getImageData(0, 0, 1, 1).data);
+        const center = Array.from(target.getContext().getImageData(20, 20, 1, 1).data);
+        expect(corner[3]).toBe(0); // clipped transparent by the rounded corner
+        expect(center[3]).toBeGreaterThan(0); // untouched away from the corner
+    });
+
+    test("swapping in an app-assigned Poster is what renderFocus draws", () => {
+        const grid = SGNodeFactory.createNode("MarkupGrid");
+        grid.setValue("focusBitmapUri", new BrsString("common:/images/icon_options.png"));
+
+        const customPoster = SGNodeFactory.createNode("Poster");
+        grid.setValue("focusFeedbackPoster", customPoster);
+        expect(grid.getValue("focusFeedbackPoster")).toBe(customPoster);
+
+        const effect = SGNodeFactory.createNode("Effect");
+        effect.setValue("borderRadius", new RoArray([new Float(18)]));
+        customPoster.setValue("effect", effect);
+
+        const target = scratchBitmap(40);
+        const draw2D = new IfDraw2D(target);
+        grid.renderFocus({ x: 0, y: 0, width: 40, height: 40 }, 1, true, draw2D);
+
+        const corner = Array.from(target.getContext().getImageData(0, 0, 1, 1).data);
+        expect(corner[3]).toBe(0);
+        expect(customPoster.getValueJS("loadStatus")).toBe("ready");
+    });
+
+    /**
+     * Regression: `renderFocus` used to draw through a private `this.focusFeedbackPoster` cache set
+     * only in the constructor. `Node.cloneNode` copies a node-valued field by ALIASING the same node
+     * (device-confirmed: only children are deep-copied) while still running the clone's own
+     * constructor, which used to create a fresh, unrelated default Poster and cache it privately —
+     * leaving the clone's private cache and its (aliased) field pointing at two different Posters.
+     */
+    test("Clone() renders with the field's (aliased) Poster, not a fresh default from its own constructor", () => {
+        const grid = SGNodeFactory.createNode("MarkupGrid");
+        grid.setValue("focusBitmapUri", new BrsString("common:/images/icon_options.png"));
+        const effect = SGNodeFactory.createNode("Effect");
+        effect.setValue("borderRadius", new RoArray([new Float(18)]));
+        grid.getValue("focusFeedbackPoster").setValue("effect", effect);
+
+        const clone = grid.cloneNode(false);
+        expect(clone.getValue("focusFeedbackPoster")).toBe(grid.getValue("focusFeedbackPoster"));
+
+        const target = scratchBitmap(40);
+        const draw2D = new IfDraw2D(target);
+        clone.renderFocus({ x: 0, y: 0, width: 40, height: 40 }, 1, true, draw2D);
+
+        const corner = Array.from(target.getContext().getImageData(0, 0, 1, 1).data);
+        expect(corner[3]).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary
- Roku OS 16.0 exposes the `Poster` node that `ArrayGrid`-derived grids (RowList, MarkupGrid, PosterGrid, etc.) use internally to draw their focus indicator, as a public `focusFeedbackPoster` field — letting apps apply the same `Effect`-based treatment (rounded/asymmetric corners) they can already apply to content items, matching the release notes example.
- The field is pre-populated with a real `Poster` node in the constructor (not left invalid like `content`) and is **re-read from the field on every draw** rather than cached in a private property — `Node.cloneNode` aliases a node-valued field onto the same node while still re-running the constructor, which would otherwise desync a private cache from the field the moment a grid is cloned.
- `setValue` guards the field to only accept a `Poster` (mirroring `BusySpinner.poster`) and lets an app swap in its own instance.
- Preserves the pre-existing non-9-patch "aliasing" sizing behavior on `focusFrameRect` via a no-op dry-run `drawImage` call before handing geometry to the poster.

## Test plan
- [x] `npm run lint`
- [x] `npm run build:sg` → `npm run build:node` → `npm run build:sg` (respecting the `common.zip` build-order dependency documented in CLAUDE.md)
- [x] `npx vitest run test/extensions/scenegraph` — 92 files / 1094 tests passing
- [x] `npx vitest run test/cli/cli-scenegraph.test.js` — 61 real end-to-end app tests passing
- [x] Added `test/extensions/scenegraph/GridFocusFeedbackEffect.test.js` with real pixel-level assertions: default Poster instance, an assigned `Effect` actually rounds the drawn focus indicator's corners, app-assigned Poster swap is honored, and a `Clone()` regression test for the field/cache desync described above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELwyUMGPjmGJoj6d8bAovV