### PR TITLE
feat(scenegraph): Add new `FloatArrayFieldInterpolator` node

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,7 +36,7 @@
 - **`setValue()` signature**: Does NOT create a field if it does not already exist (prevents accidental field creation on assignment)
 
 ### New SceneGraph Nodes (v2.0 – v2.1)
-- **Animation system**: `Animation`, `ParallelAnimation`, `SequentialAnimation`, `FloatFieldInterpolator`, `ColorFieldInterpolator`, `Vector2DFieldInterpolator`
+- **Animation system**: `Animation`, `ParallelAnimation`, `SequentialAnimation`, `FloatFieldInterpolator`, `FloatArrayFieldInterpolator`, `ColorFieldInterpolator`, `Vector2DFieldInterpolator`
 - **Panel nodes**: `PanelSet`, `Panel`, `ListPanel`, `GridPanel`, `OverhangPanelSetScene`, `Overhang`
 - **Standard dialogs**: `StandardKeyboardDialog`, `StandardProgressDialog`, `StdDlgContentArea`, `StdDlgProgressItem`, `StdDlgTitleArea`
 - **Input nodes**: `PinPad`, `VoiceTextEditBox`, `ScrollableText`, `ScrollingLabel`
@@ -178,7 +178,7 @@ All SceneGraph nodes inherit from **RoSGNode** (`src/extensions/scenegraph/compo
 
 4. **Animation Nodes**:
    - `Animation`, `ParallelAnimation`, `SequentialAnimation`: Animation container nodes
-   - `FloatFieldInterpolator`, `ColorFieldInterpolator`, `Vector2DFieldInterpolator`: Field interpolators
+   - `FloatFieldInterpolator`, `FloatArrayFieldInterpolator`, `ColorFieldInterpolator`, `Vector2DFieldInterpolator`: Field interpolators
 
 5. **Special Nodes**:
    - `ContentNode`: Data-only node (no rendering), holds metadata for lists/grids

--- a/src/extensions/scenegraph/factory/NodeFactory.ts
+++ b/src/extensions/scenegraph/factory/NodeFactory.ts
@@ -109,6 +109,7 @@ import {
     ParallelAnimation,
     SequentialAnimation,
     FloatFieldInterpolator,
+    FloatArrayFieldInterpolator,
     ColorFieldInterpolator,
     Vector2DFieldInterpolator,
 } from "../nodes";
@@ -342,6 +343,8 @@ export class SGNodeFactory {
                 return new SequentialAnimation([], name);
             case SGNodeType.FloatFieldInterpolator.toLowerCase():
                 return new FloatFieldInterpolator([], name);
+            case SGNodeType.FloatArrayFieldInterpolator.toLowerCase():
+                return new FloatArrayFieldInterpolator([], name);
             case SGNodeType.ColorFieldInterpolator.toLowerCase():
                 return new ColorFieldInterpolator([], name);
             case SGNodeType.Vector2DFieldInterpolator.toLowerCase():

--- a/src/extensions/scenegraph/nodes/Animation.ts
+++ b/src/extensions/scenegraph/nodes/Animation.ts
@@ -20,6 +20,9 @@ type TargetBinding = {
  */
 export class Animation extends AnimationBase {
     private readonly targetCache = new WeakMap<Interpolator, TargetBinding>();
+    // Tracks the last `fieldToInterp` value warned about per interpolator, so a still-invalid
+    // descriptor (checked every tick) doesn't reprint the same device warning every frame.
+    private readonly warnedDescriptors = new WeakMap<Interpolator, string>();
 
     private readonly animationFields: FieldModel[] = [
         { name: "duration", type: "float", value: "0" },
@@ -273,18 +276,21 @@ export class Animation extends AnimationBase {
             return cached;
         }
 
-        let targetNode: Node | undefined;
-        let fieldName = "";
-
-        if (normalized.includes(".")) {
-            const [nodeId, ...fieldParts] = normalized.split(".");
-            fieldName = fieldParts.join(".").trim();
-            targetNode = this.findTargetNode(nodeId.trim());
-        } else {
-            const parent = this.getNodeParent();
-            targetNode = parent instanceof Node ? parent : this;
-            fieldName = normalized;
+        if (!normalized.includes(".")) {
+            // Confirmed on a real Roku device: a bare field name (no "nodeId.") is NOT resolved
+            // against the interpolator's own enclosing node - the device rejects it outright.
+            this.targetCache.delete(child);
+            this.warnInvalidDescriptor(
+                child,
+                normalized,
+                `No node specified, expected a string of the form "nodeName.fieldName"`
+            );
+            return undefined;
         }
+
+        const [nodeId, ...fieldParts] = normalized.split(".");
+        const fieldName = fieldParts.join(".").trim();
+        const targetNode = this.findTargetNode(nodeId.trim());
 
         if (!targetNode || !fieldName) {
             this.targetCache.delete(child);
@@ -298,6 +304,21 @@ export class Animation extends AnimationBase {
         };
         this.targetCache.set(child, binding);
         return binding;
+    }
+
+    /**
+     * Reports a device-format `Failed to update interpolator field` warning for an invalid
+     * `fieldToInterp` descriptor, deduplicated per interpolator so a value re-checked every tick
+     * doesn't reprint the same warning every frame.
+     */
+    private warnInvalidDescriptor(child: Interpolator, descriptor: string, reason: string) {
+        if (this.warnedDescriptors.get(child) === descriptor) {
+            return;
+        }
+        this.warnedDescriptors.set(child, descriptor);
+        BrsDevice.stderr.write(
+            `warning,Failed to update interpolator field\r\nCould not update the interpolator field "${descriptor}"\r\n${reason}\r\n`
+        );
     }
 
     /**

--- a/src/extensions/scenegraph/nodes/FloatArrayFieldInterpolator.ts
+++ b/src/extensions/scenegraph/nodes/FloatArrayFieldInterpolator.ts
@@ -1,0 +1,51 @@
+import { AAMember, BrsType, Float, RoArray } from "brs-engine";
+import { Interpolator } from "./Interpolator";
+import { SGNodeType } from "../nodes";
+import { FieldModel } from "../SGTypes";
+import { jsValueOf } from "../factory/Serializer";
+
+/**
+ * Interpolates fields that hold arrays of floats, such as `Effect.borderRadius`. Each `keyValue` entry
+ * is itself an array of floats; interpolation is performed piecewise, blending each entry independently
+ * against its counterpart in the adjacent keyframe.
+ */
+export class FloatArrayFieldInterpolator extends Interpolator {
+    // Only key is inherited, adding keyValue
+    readonly interpolationFields: FieldModel[] = [{ name: "keyValue", type: "floatarray", value: "[]" }];
+
+    constructor(members: AAMember[] = [], name: string = SGNodeType.FloatArrayFieldInterpolator) {
+        super(members, name);
+        this.registerDefaultFields(this.interpolationFields);
+    }
+
+    /**
+     * Blends the two float arrays surrounding the current fraction, element by element. Keyframes with
+     * mismatched array lengths are an error condition on real hardware, so the update is skipped.
+     */
+    interpolate(fraction: number): BrsType | undefined {
+        const pair = this.resolveArrayKeyframePair(this.getValue("keyValue"), fraction);
+        if (!pair) {
+            return undefined;
+        }
+        if (pair instanceof RoArray) {
+            return pair;
+        }
+
+        const { start, end, localT } = pair;
+        const startValues = jsValueOf(start);
+        const endValues = jsValueOf(end);
+        if (
+            !Array.isArray(startValues) ||
+            !Array.isArray(endValues) ||
+            startValues.length === 0 ||
+            startValues.length !== endValues.length
+        ) {
+            return undefined;
+        }
+
+        const blended = startValues.map(
+            (value: number, i: number) => new Float(value + (endValues[i] - value) * localT)
+        );
+        return new RoArray(blended);
+    }
+}

--- a/src/extensions/scenegraph/nodes/Interpolator.ts
+++ b/src/extensions/scenegraph/nodes/Interpolator.ts
@@ -1,4 +1,4 @@
-import { AAMember, BrsType } from "brs-engine";
+import { AAMember, BrsType, RoArray } from "brs-engine";
 import { Node } from "./Node";
 import { SGNodeType } from "../nodes";
 import { FieldModel } from "../SGTypes";
@@ -75,6 +75,39 @@ export abstract class Interpolator extends Node {
             return { index: 0, localT: 0 };
         }
         return { index: lastIndex - 1, localT: 1 };
+    }
+
+    /**
+     * Resolves the pair of `RoArray` keyframes surrounding `fraction` from a `keyValue` field whose
+     * entries are themselves `RoArray`s (Vector2DFieldInterpolator's pairs, FloatArrayFieldInterpolator's
+     * float arrays). Returns the sole keyframe directly when there is only one (held constant for any
+     * fraction), or `undefined` when `keyValue` is empty/malformed.
+     */
+    protected resolveArrayKeyframePair(
+        keyValue: BrsType,
+        fraction: number
+    ): RoArray | { start: RoArray; end: RoArray; localT: number } | undefined {
+        if (!(keyValue instanceof RoArray)) {
+            return undefined;
+        }
+        // `elements` directly, not `getElements()`: the latter slices a throwaway copy, and this is a
+        // per-frame path.
+        const elements = keyValue.elements;
+        if (elements.length === 0) {
+            return undefined;
+        }
+        if (elements.length === 1 && elements[0] instanceof RoArray) {
+            return elements[0];
+        }
+
+        const { index, localT } = this.resolveSegment(fraction);
+        const clampedIndex = Math.min(index, elements.length - 2);
+        const start = elements[clampedIndex];
+        const end = elements[Math.min(clampedIndex + 1, elements.length - 1)];
+        if (!(start instanceof RoArray) || !(end instanceof RoArray)) {
+            return undefined;
+        }
+        return { start, end, localT };
     }
 
     /**

--- a/src/extensions/scenegraph/nodes/Vector2DFieldInterpolator.ts
+++ b/src/extensions/scenegraph/nodes/Vector2DFieldInterpolator.ts
@@ -22,39 +22,23 @@ export class Vector2DFieldInterpolator extends Interpolator {
      * consumes it copies (`Node.setValue`) and this runs every frame per animated target.
      */
     interpolate(fraction: number): BrsType | undefined {
-        const keyValues = this.getValue("keyValue");
-        if (!(keyValues instanceof RoArray)) {
+        const pair = this.resolveArrayKeyframePair(this.getValue("keyValue"), fraction);
+        if (!pair) {
             return undefined;
         }
-        // `elements` directly, not `getElements()`: the latter slices a throwaway copy, and this is a
-        // per-frame path.
-        const elements = keyValues.elements;
-        if (elements.length === 0) {
+        if (pair instanceof RoArray) {
+            return pair;
+        }
+
+        const { start, end, localT } = pair;
+        const startPoint = jsValueOf(start);
+        const endPoint = jsValueOf(end);
+        if (!Array.isArray(startPoint) || !Array.isArray(endPoint) || startPoint.length < 2 || endPoint.length < 2) {
             return undefined;
         }
-        if (elements.length === 1 && elements[0] instanceof RoArray) {
-            return elements[0];
-        }
 
-        const { index, localT } = this.resolveSegment(fraction);
-        const clampedIndex = Math.min(index, elements.length - 2);
-        const startVec = elements[clampedIndex];
-        const endVec = elements[Math.min(clampedIndex + 1, elements.length - 1)];
-
-        if (startVec instanceof RoArray && endVec instanceof RoArray) {
-            const startPoint = jsValueOf(startVec);
-            const endPoint = jsValueOf(endVec);
-            if (
-                Array.isArray(startPoint) &&
-                Array.isArray(endPoint) &&
-                startPoint.length >= 2 &&
-                endPoint.length >= 2
-            ) {
-                const currX = startPoint[0] + (endPoint[0] - startPoint[0]) * localT;
-                const currY = startPoint[1] + (endPoint[1] - startPoint[1]) * localT;
-                return new RoArray([new Float(currX), new Float(currY)]);
-            }
-        }
-        return undefined;
+        const currX = startPoint[0] + (endPoint[0] - startPoint[0]) * localT;
+        const currY = startPoint[1] + (endPoint[1] - startPoint[1]) * localT;
+        return new RoArray([new Float(currX), new Float(currY)]);
     }
 }

--- a/src/extensions/scenegraph/nodes/index.ts
+++ b/src/extensions/scenegraph/nodes/index.ts
@@ -90,6 +90,7 @@ export * from "./ParallelAnimation";
 export * from "./SequentialAnimation";
 export * from "./Interpolator";
 export * from "./FloatFieldInterpolator";
+export * from "./FloatArrayFieldInterpolator";
 export * from "./ColorFieldInterpolator";
 export * from "./Vector2DFieldInterpolator";
 
@@ -187,6 +188,7 @@ export enum SGNodeType {
     SequentialAnimation = "SequentialAnimation",
     ParallelAnimation = "ParallelAnimation",
     FloatFieldInterpolator = "FloatFieldInterpolator",
+    FloatArrayFieldInterpolator = "FloatArrayFieldInterpolator",
     Vector2DFieldInterpolator = "Vector2DFieldInterpolator",
     ColorFieldInterpolator = "ColorFieldInterpolator",
     BusySpinner = "BusySpinner",

--- a/test/extensions/scenegraph/Animation.test.js
+++ b/test/extensions/scenegraph/Animation.test.js
@@ -2,7 +2,7 @@ const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
 const core = require("../../../packages/node/bin/brs.node.js");
 
 const { SGNodeFactory } = scenegraph;
-const { BrsString, Float, RoArray } = core;
+const { BrsDevice, BrsString, Float, RoArray } = core;
 
 const floatArray = (nums) => new RoArray(nums.map((n) => new Float(n)));
 
@@ -15,6 +15,10 @@ const floatArray = (nums) => new RoArray(nums.map((n) => new Float(n)));
  * would animate the wrong node and the new image would never become visible.
  */
 describe("Animation target resolution", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
     test("interpolator targets the child, not a same-named (case-folded) component root", () => {
         // Container id "Background" mirrors the parent-assigned id; inner poster id "background".
         const container = SGNodeFactory.createNode("Rectangle");
@@ -88,5 +92,34 @@ describe("Animation target resolution", () => {
         expect(group.getValueJS("opacity")).toBe(1);
         animation.setValue("control", new BrsString("finish"));
         expect(group.getValueJS("opacity")).toBeCloseTo(0, 5);
+    });
+
+    test('a bare fieldToInterp (no "nodeId.") is rejected, matching a real device', () => {
+        // Device-confirmed: unlike a with-dot id that resolves to the interpolator's own enclosing
+        // node (the case above), a fieldToInterp with NO dot at all is never applied - the device
+        // reports "Failed to update interpolator field ... No node specified, expected a string of
+        // the form \"nodeName.fieldName\"" and leaves the target field untouched.
+        const errors = [];
+        vi.spyOn(BrsDevice.stderr, "write").mockImplementation((msg) => errors.push(msg));
+
+        const group = SGNodeFactory.createNode("Group");
+        group.setValue("opacity", new Float(1));
+
+        const animation = SGNodeFactory.createNode("Animation");
+        animation.setValue("duration", new Float(0.5));
+        const interp = SGNodeFactory.createNode("FloatFieldInterpolator");
+        interp.setValue("fieldToInterp", new BrsString("opacity")); // no "id." prefix
+        interp.setValue("key", floatArray([0.0, 1.0]));
+        interp.setValue("keyValue", floatArray([1.0, 0.0]));
+        animation.appendChildToParent(interp);
+        group.appendChildToParent(animation);
+
+        animation.setValue("control", new BrsString("finish"));
+
+        expect(group.getValueJS("opacity")).toBe(1); // untouched
+        const warnings = errors.filter((msg) => msg.includes("Failed to update interpolator field"));
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0]).toContain('Could not update the interpolator field "opacity"');
+        expect(warnings[0]).toContain('No node specified, expected a string of the form "nodeName.fieldName"');
     });
 });

--- a/test/extensions/scenegraph/FloatArrayInterpolator.test.js
+++ b/test/extensions/scenegraph/FloatArrayInterpolator.test.js
@@ -1,0 +1,74 @@
+const scenegraph = require("../../../packages/scenegraph/lib/brs-sg.node.js");
+const core = require("../../../packages/node/bin/brs.node.js");
+
+const { SGNodeFactory } = scenegraph;
+const { BrsString, Float, RoArray } = core;
+
+const floatArray = (nums) => new RoArray(nums.map((n) => new Float(n)));
+const nestedFloatArray = (rows) => new RoArray(rows.map(floatArray));
+
+/**
+ * FloatArrayFieldInterpolator (Roku OS 16) animates fields that hold arrays of floats, such as
+ * `Effect.borderRadius`. Each keyValue entry is itself an array of floats, interpolated piecewise
+ * against the corresponding entry in the adjacent keyframe.
+ */
+describe("FloatArrayFieldInterpolator", () => {
+    test("blends each array entry independently between two keyframes", () => {
+        // The Effect and the Animation driving it must both be part of the same visible tree for
+        // the interpolator's "id.field" lookup to resolve - confirmed on a real device, where a
+        // node only reachable via a scalar field reference (e.g. `poster.effect = effect`, never
+        // appended as a child anywhere) is NOT found ("Could not find node ... to update the
+        // interpolator field on"). A common parent Group is enough to make it resolvable.
+        const container = SGNodeFactory.createNode("Group");
+        const effect = SGNodeFactory.createNode("Effect");
+        effect.setValue("id", new BrsString("itemEffect"));
+        effect.setValue("borderRadius", floatArray([8, 8, 8, 32]));
+
+        const animation = SGNodeFactory.createNode("Animation");
+        animation.setValue("duration", new Float(0.4));
+        const interp = SGNodeFactory.createNode("FloatArrayFieldInterpolator");
+        interp.setValue("fieldToInterp", new BrsString("itemEffect.borderRadius"));
+        interp.setValue("key", floatArray([0.0, 1.0]));
+        interp.setValue(
+            "keyValue",
+            nestedFloatArray([
+                [8, 8, 8, 32],
+                [8, 8, 8, 8],
+            ])
+        );
+        animation.appendChildToParent(interp);
+        container.appendChildToParent(effect);
+        container.appendChildToParent(animation);
+
+        // Halfway through, each entry should be halfway between its start and end value.
+        interp.setValue("fraction", new Float(0.5));
+        expect(interp.interpolate(0.5).elements.map((el) => el.getValue())).toEqual([8, 8, 8, 20]);
+
+        animation.setValue("control", new BrsString("finish"));
+        const end = effect.getValueJS("borderRadius");
+        end.forEach((value, i) => expect(value).toBeCloseTo([8, 8, 8, 8][i], 5));
+    });
+
+    test("a single keyframe holds its value for any fraction", () => {
+        const interp = SGNodeFactory.createNode("FloatArrayFieldInterpolator");
+        interp.setValue("keyValue", nestedFloatArray([[1, 2, 3]]));
+
+        expect(interp.getValueJS("keyValue")).toEqual([[1, 2, 3]]);
+        const result = interp.interpolate(0.25);
+        expect(result.elements.map((el) => el.getValue())).toEqual([1, 2, 3]);
+    });
+
+    test("mismatched array lengths between keyframes are skipped, like a type mismatch", () => {
+        const interp = SGNodeFactory.createNode("FloatArrayFieldInterpolator");
+        interp.setValue("key", floatArray([0.0, 1.0]));
+        interp.setValue(
+            "keyValue",
+            nestedFloatArray([
+                [1, 2, 3],
+                [1, 2],
+            ])
+        );
+
+        expect(interp.interpolate(0.5)).toBeUndefined();
+    });
+});

--- a/test/simulator/probes/effect-demo/README.md
+++ b/test/simulator/probes/effect-demo/README.md
@@ -6,19 +6,23 @@ Beta section of `external/dev-doc/docs/DEVELOPER/release-notes/index.md` for the
 `src/extensions/scenegraph/nodes/Effect.ts` for how brs-engine implements it (Canvas2D, since the
 engine has no real GPU/shader pipeline).
 
+Panel 2 also demos the new **`FloatArrayFieldInterpolator`** node (same release), which animates a
+field holding an array of floats — such as `Effect.borderRadius` — by interpolating each entry
+independently. See `src/extensions/scenegraph/nodes/FloatArrayFieldInterpolator.ts`.
+
 Nine panels, each an independent `Effect` configuration:
 
-| # | Demonstrates |
-| --- | --- |
-| 1 | Uniform `borderRadius` on a `Rectangle` |
-| 2 | Per-corner `borderRadius` — proves the field's clockwise-from-top-right ordering |
-| 3 | `borderWidth`/`borderColor`/`borderPadding`, no rounding |
-| 4 | Rounded corners + border + padding together |
-| 5 | `gradientStyle="linear"` with `gradientAngle` |
-| 6 | `gradientStyle="radial"` |
-| 7 | A gradient applied to both content and border (`gradientFillBorder`) |
-| 8 | `borderRadius` clipping a `Poster`'s bitmap |
-| 9 | A `Poster` with rounded corners, a border, and a gradient overlay (`gradientFillContent`) |
+| #   | Demonstrates                                                                                                                                                                              |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Uniform `borderRadius` on a `Rectangle`                                                                                                                                                   |
+| 2   | Per-corner `borderRadius`, animated via `FloatArrayFieldInterpolator` — proves the field's clockwise-from-top-right ordering and that each of the 4 entries is interpolated independently |
+| 3   | `borderWidth`/`borderColor`/`borderPadding`, no rounding                                                                                                                                  |
+| 4   | Rounded corners + border + padding together                                                                                                                                               |
+| 5   | `gradientStyle="linear"` with `gradientAngle`                                                                                                                                             |
+| 6   | `gradientStyle="radial"`                                                                                                                                                                  |
+| 7   | A gradient applied to both content and border (`gradientFillBorder`)                                                                                                                      |
+| 8   | `borderRadius` clipping a `Poster`'s bitmap                                                                                                                                               |
+| 9   | A `Poster` with rounded corners, a border, and a gradient overlay (`gradientFillContent`)                                                                                                 |
 
 ## Run it
 

--- a/test/simulator/probes/effect-demo/components/EffectDemoScene.brs
+++ b/test/simulator/probes/effect-demo/components/EffectDemoScene.brs
@@ -3,6 +3,10 @@
 ' brs-engine renders this through Canvas2D rather than a real shader pipeline (see
 ' src/extensions/scenegraph/nodes/Effect.ts) but every field below behaves per the release notes:
 ' external/dev-doc/docs/DEVELOPER/release-notes/index.md ("Roku OS 16.0 Beta Release").
+'
+' Panel 2 also demos the new FloatArrayFieldInterpolator node (same release), which animates a
+' field holding an array of floats - such as Effect.borderRadius - by interpolating each entry
+' independently. See src/extensions/scenegraph/nodes/FloatArrayFieldInterpolator.ts.
 
 sub init()
     m.top.backgroundColor = "#12141aFF"
@@ -36,11 +40,14 @@ sub init()
     )
 
     ' borderRadius is [topRight, bottomRight, bottomLeft, topLeft] - clockwise from top-right -
-    ' so this rounds only the top-right and bottom-left corners.
+    ' so this rounds only the top-right and bottom-left corners. Animated via a
+    ' FloatArrayFieldInterpolator that swaps the rounded corners back and forth, proving each of
+    ' the 4 entries is interpolated independently rather than as a single blended scalar.
     BuildPanel(
         m.top, cols[1], rows[0], cellWidth, shapeWidth, shapeHeight, captionHeight,
-        "2. Per-corner radius", "rect", "#FDCB3AFF",
-        { borderRadius: [60, 0, 60, 0] }
+        "2. Per-corner radius (animated)", "rect", "#FDCB3AFF",
+        { borderRadius: [60, 0, 60, 0] },
+        [[60, 0, 60, 0], [0, 60, 0, 60], [60, 0, 60, 0]]
     )
 
     BuildPanel(
@@ -125,8 +132,12 @@ sub init()
 end sub
 
 ' Builds one caption + shape panel and applies an Effect node built from `fields` (an assocarray
-' of Effect field name -> value) onto the shape.
-sub BuildPanel(parent as object, colX as float, rowY as float, cellWidth as float, shapeWidth as float, shapeHeight as float, captionHeight as float, caption as string, kind as string, color as string, fields as object)
+' of Effect field name -> value) onto the shape. When `animKeyValues` is provided (an array of at
+' least two borderRadius-shaped float arrays), the Effect and a looping Animation/
+' FloatArrayFieldInterpolator pair are appended as children of `shape` (in addition to the
+' `shape.effect` assignment) so the interpolator's "id.borderRadius" target resolves, and animate
+' the Effect's borderRadius through those keyframes.
+sub BuildPanel(parent as object, colX as float, rowY as float, cellWidth as float, shapeWidth as float, shapeHeight as float, captionHeight as float, caption as string, kind as string, color as string, fields as object, animKeyValues = invalid as dynamic)
     MakeLabel(parent, colX, rowY, cellWidth, caption, "font:SmallBoldSystemFont", "#E6E6E6FF")
 
     shapeX = colX + (cellWidth - shapeWidth) / 2
@@ -155,6 +166,37 @@ sub BuildPanel(parent as object, colX as float, rowY as float, cellWidth as floa
             effect.setField(key, fields[key])
         end if
     end for
+
+    if animKeyValues <> invalid
+        ' fieldToInterp's "nodeName.fieldName" id lookup only finds nodes that are actually part of
+        ' the visible scene tree - being referenced by a scalar field (shape.effect, below) is not
+        ' enough, confirmed on a real device. So the Effect (and the Animation driving it) are also
+        ' appended as ordinary children of `shape`: neither draws anything on its own (Effect and
+        ' Animation have no render content), so this has no visual effect beyond making the Effect a
+        ' resolvable descendant.
+        effectId = "effect_" + Str(Int(colX)).Trim() + "_" + Str(Int(rowY)).Trim()
+        effect.id = effectId
+        shape.appendChild(effect)
+
+        animation = CreateObject("roSGNode", "Animation")
+        animation.duration = 2.0
+        animation.easeFunction = "inOutQuad"
+        animation.repeat = true
+
+        interp = CreateObject("roSGNode", "FloatArrayFieldInterpolator")
+        interp.fieldToInterp = effectId + ".borderRadius"
+        keys = []
+        for i = 0 to animKeyValues.count() - 1
+            keys.push(i / (animKeyValues.count() - 1))
+        end for
+        interp.key = keys
+        interp.keyValue = animKeyValues
+
+        animation.appendChild(interp)
+        shape.appendChild(animation)
+        animation.control = "start"
+    end if
+
     shape.effect = effect
 end sub
 


### PR DESCRIPTION
## Summary
- Adds the Roku OS 16.0 `FloatArrayFieldInterpolator` SceneGraph node, which animates fields holding arrays of floats (e.g. `Effect.borderRadius`), interpolating each entry piecewise and independently against the corresponding entry in the adjacent keyframe.
- Extracts the shared "resolve surrounding `RoArray` keyframe pair" logic into a new `Interpolator.resolveArrayKeyframePair()` base helper, reused by both `FloatArrayFieldInterpolator` and `Vector2DFieldInterpolator` to avoid duplicating that boilerplate a third time.
- Fixes `Animation`'s `fieldToInterp` target resolution to match real device behavior, based on errors reported while testing this feature on an actual Roku: a bare field name (no `"nodeId."` prefix) is now rejected with the device's own diagnostic (`Failed to update interpolator field ... No node specified, expected a string of the form "nodeName.fieldName"`) instead of silently resolving to the interpolator's enclosing node.
- Updates the `effect-demo` probe app to demonstrate the new node (animating `Effect.borderRadius` on panel 2), correcting the app to attach the `Effect` and its driving `Animation` as real children of the visible shape — a node reachable only via a scalar field reference (`shape.effect = effect`) is not resolvable by id for `fieldToInterp`, also based on a real-device error report.

## Test plan
- [x] `npm run build:cli` succeeds
- [x] `npm run lint` clean
- [x] `npx prettier --check` clean on all changed source/test files
- [x] `npx vitest run test/extensions/scenegraph` — all 93 test files / 1098 tests pass
- [x] Manually ran `test/simulator/probes/effect-demo` via the CLI (`--ascii`) — no warnings/errors across multiple animation cycles
- [ ] Re-verify on a real Roku device (OS 16.0 beta) that the latest `effect-demo` fix resolves the previously reported `Failed to update interpolator field` errors — not yet re-confirmed on hardware since the last round of fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBGL5HoJjAyCwbqpQQ9t4a